### PR TITLE
Ensure thrown errors from algod.js have error.message defined.

### DIFF
--- a/src/client/algod.js
+++ b/src/client/algod.js
@@ -21,8 +21,12 @@ function Algod(token, baseServer = "http://r2.algorand.network", port = 4180) {
      * @returns {Promise<*>}
      */
     this.status = async function () {
-        let res = await c.get("/v1/status");
-        return res.body;
+        try {
+            let res = await c.get("/v1/status");
+            return res.body;
+        } catch (e) {
+            throw Error(e.response.error.message)
+        }
     };
 
     /**
@@ -30,8 +34,12 @@ function Algod(token, baseServer = "http://r2.algorand.network", port = 4180) {
      * @returns {Promise<*>}
      */
     this.healthCheck = async function () {
-        let res = await c.get("/health");
-        return res.body;
+        try {
+            let res = await c.get("/health");
+            return res.body;
+        } catch (e) {
+            throw Error(e.response.error.message)
+        }
     };
 
     /**
@@ -42,8 +50,12 @@ function Algod(token, baseServer = "http://r2.algorand.network", port = 4180) {
      */
     this.statusAfterBlock = async function (roundNumber) {
         if (!Number.isInteger(roundNumber)) throw Error("roundNumber should be an integer");
-        let res = await c.get("/v1/status/wait-for-block-after/" + roundNumber);
-        return res.body;
+        try {
+            let res = await c.get("/v1/status/wait-for-block-after/" + roundNumber);
+            return res.body;
+        } catch (e) {
+            throw Error(e.response.error.message)
+        }
     };
 
     /**
@@ -54,13 +66,17 @@ function Algod(token, baseServer = "http://r2.algorand.network", port = 4180) {
      */
     this.pendingTransactions = async function (maxTxns) {
         if (!Number.isInteger(maxTxns)) throw Error("maxTxns should be an integer");
-        let res = await c.get("/v1/transactions/pending", {'max': maxTxns});
-        if (res.statusCode === 200) {
-            for (var i = 0; i < res.body.truncatedTxns.transactions.length; i++) {
-                res.body.truncatedTxns.transactions[i] = noteb64ToNote(res.body.truncatedTxns.transactions[i]);
+        try {
+            let res = await c.get("/v1/transactions/pending", {'max': maxTxns});
+            if (res.statusCode === 200) {
+                for (var i = 0; i < res.body.truncatedTxns.transactions.length; i++) {
+                    res.body.truncatedTxns.transactions[i] = noteb64ToNote(res.body.truncatedTxns.transactions[i]);
+                }
             }
+            return res.body;
+        } catch (e) {
+            throw Error(e.response.error.message)
         }
-        return res.body;
     };
 
     /**
@@ -68,8 +84,12 @@ function Algod(token, baseServer = "http://r2.algorand.network", port = 4180) {
      * @returns {Promise<*>}
      */
     this.versions = async function () {
-        let res = await c.get("/versions");
-        return res.body;
+        try {
+            let res = await c.get("/versions");
+            return res.body;
+        } catch (e) {
+            throw Error(e.response.error.message)
+        }
     };
 
     /**
@@ -77,8 +97,12 @@ function Algod(token, baseServer = "http://r2.algorand.network", port = 4180) {
      * @returns {Promise<*>}
      */
     this.ledgerSupply = async function () {
-        let res = await c.get("/v1/ledger/supply");
-        return res.body;
+        try {
+            let res = await c.get("/v1/ledger/supply");
+            return res.body;
+        } catch (e) {
+            throw Error(e.response.error.message)
+        }
     };
 
     /**
@@ -90,13 +114,17 @@ function Algod(token, baseServer = "http://r2.algorand.network", port = 4180) {
      */
     this.transactionByAddress = async function (addr, first, last) {
         if (!Number.isInteger(first) || !Number.isInteger(last)) throw Error("first and last rounds should be integers");
-        let res = await c.get("/v1/account/" + addr + "/transactions", {'firstRound': first, 'lastRound': last});
-        if (res.statusCode === 200) {
-          for(var i = 0; i < res.body.transactions.length; i++) {
-            res.body.transactions[i] = noteb64ToNote(res.body.transactions[i]);
-          }
+        try {
+            let res = await c.get("/v1/account/" + addr + "/transactions", {'firstRound': first, 'lastRound': last});
+            if (res.statusCode === 200) {
+              for(var i = 0; i < res.body.transactions.length; i++) {
+                res.body.transactions[i] = noteb64ToNote(res.body.transactions[i]);
+              }
+            }
+            return res.body;
+        } catch (e) {
+            throw Error(e.response.error.message)
         }
-        return res.body;
     };
 
     /**
@@ -105,8 +133,12 @@ function Algod(token, baseServer = "http://r2.algorand.network", port = 4180) {
      * @returns {Promise<*>}
      */
     this.accountInformation = async function (addr) {
-        let res = await c.get("/v1/account/" + addr);
-        return res.body;
+        try {
+            let res = await c.get("/v1/account/" + addr);
+            return res.body;
+        } catch (e) {
+            throw Error(e.response.error.message)
+        }
     };
 
     /**
@@ -116,11 +148,15 @@ function Algod(token, baseServer = "http://r2.algorand.network", port = 4180) {
      * @returns {Promise<*>}
      */
     this.transactionInformation = async function (addr, txid) {
-        let res = await c.get("/v1/account/" + addr + "/transaction/" + txid);
-        if (res.statusCode === 200) {
-           res.body = noteb64ToNote(res.body);
+        try {
+            let res = await c.get("/v1/account/" + addr + "/transaction/" + txid);
+            if (res.statusCode === 200) {
+               res.body = noteb64ToNote(res.body);
+            }
+            return res.body;
+        } catch (e) {
+            throw Error(e.response.error.message)
         }
-        return res.body;
     };
 
     /**
@@ -128,8 +164,12 @@ function Algod(token, baseServer = "http://r2.algorand.network", port = 4180) {
      * @returns {Promise<*>}
      */
     this.suggestedFee = async function () {
-        let res = await c.get("/v1/transactions/fee");
-        return res.body;
+        try {
+            let res = await c.get("/v1/transactions/fee");
+            return res.body;
+        } catch (e) {
+            throw Error(e.response.error.message)
+        }
     };
 
     /**
@@ -138,8 +178,12 @@ function Algod(token, baseServer = "http://r2.algorand.network", port = 4180) {
      * @returns {Promise<*>}
      */
     this.sendRawTransaction = async function (txn) {
-        let res = await c.post("/v1/transactions", Buffer.from(txn));
-        return res.body;
+        try {
+            let res = await c.post("/v1/transactions", Buffer.from(txn));
+            return res.body;
+        } catch (e) {
+            throw Error(e.error.message)
+        }
     };
 
     /**
@@ -147,8 +191,12 @@ function Algod(token, baseServer = "http://r2.algorand.network", port = 4180) {
      * @returns {Promise<*>}
      */
     this.getTransactionParams = async function () {
-        let res = await c.get("/v1/transactions/params");
-        return res.body;
+        try {
+            let res = await c.get("/v1/transactions/params");
+            return res.body;
+        } catch (e) {
+            throw Error(e.response.error.message)
+        }
     };
 
     /**
@@ -158,13 +206,17 @@ function Algod(token, baseServer = "http://r2.algorand.network", port = 4180) {
      */
     this.block = async function (roundNumber) {
         if (!Number.isInteger(roundNumber)) throw Error("roundNumber should be an integer");
-        let res = await c.get("/v1/block/" + roundNumber);
-        if (res.statusCode === 200 && res.txns.transactions !== undefined) {
-          for(var i = 0; i < res.body.txns.transactions.length; i++) {
-            res.body.txns.transactions[i] = noteb64ToNote(res.body.txns.transactions[i]);
-          }
+        try {
+            let res = await c.get("/v1/block/" + roundNumber);
+            if (res.statusCode === 200 && res.txns.transactions !== undefined) {
+              for(var i = 0; i < res.body.txns.transactions.length; i++) {
+                res.body.txns.transactions[i] = noteb64ToNote(res.body.txns.transactions[i]);
+              }
+            }
+            return res.body;
+        } catch (e) {
+            throw Error(e.response.error.message)
         }
-        return res.body;
     };
 
 }

--- a/src/client/algod.js
+++ b/src/client/algod.js
@@ -25,7 +25,8 @@ function Algod(token, baseServer = "http://r2.algorand.network", port = 4180) {
             let res = await c.get("/v1/status");
             return res.body;
         } catch (e) {
-            throw Error(e.response.error.message)
+            e.message = e.response.error.message;
+            throw e;
         }
     };
 
@@ -38,7 +39,8 @@ function Algod(token, baseServer = "http://r2.algorand.network", port = 4180) {
             let res = await c.get("/health");
             return res.body;
         } catch (e) {
-            throw Error(e.response.error.message)
+            e.message = e.response.error.message;
+            throw e;
         }
     };
 
@@ -54,7 +56,8 @@ function Algod(token, baseServer = "http://r2.algorand.network", port = 4180) {
             let res = await c.get("/v1/status/wait-for-block-after/" + roundNumber);
             return res.body;
         } catch (e) {
-            throw Error(e.response.error.message)
+            e.message = e.response.error.message;
+            throw e;
         }
     };
 
@@ -75,7 +78,8 @@ function Algod(token, baseServer = "http://r2.algorand.network", port = 4180) {
             }
             return res.body;
         } catch (e) {
-            throw Error(e.response.error.message)
+            e.message = e.response.error.message;
+            throw e;
         }
     };
 
@@ -88,7 +92,8 @@ function Algod(token, baseServer = "http://r2.algorand.network", port = 4180) {
             let res = await c.get("/versions");
             return res.body;
         } catch (e) {
-            throw Error(e.response.error.message)
+            e.message = e.response.error.message;
+            throw e;
         }
     };
 
@@ -101,7 +106,8 @@ function Algod(token, baseServer = "http://r2.algorand.network", port = 4180) {
             let res = await c.get("/v1/ledger/supply");
             return res.body;
         } catch (e) {
-            throw Error(e.response.error.message)
+            e.message = e.response.error.message;
+            throw e;
         }
     };
 
@@ -123,7 +129,8 @@ function Algod(token, baseServer = "http://r2.algorand.network", port = 4180) {
             }
             return res.body;
         } catch (e) {
-            throw Error(e.response.error.message)
+            e.message = e.response.error.message;
+            throw e;
         }
     };
 
@@ -137,7 +144,8 @@ function Algod(token, baseServer = "http://r2.algorand.network", port = 4180) {
             let res = await c.get("/v1/account/" + addr);
             return res.body;
         } catch (e) {
-            throw Error(e.response.error.message)
+            e.message = e.response.error.message;
+            throw e;
         }
     };
 
@@ -155,7 +163,8 @@ function Algod(token, baseServer = "http://r2.algorand.network", port = 4180) {
             }
             return res.body;
         } catch (e) {
-            throw Error(e.response.error.message)
+            e.message = e.response.error.message;
+            throw e;
         }
     };
 
@@ -168,7 +177,8 @@ function Algod(token, baseServer = "http://r2.algorand.network", port = 4180) {
             let res = await c.get("/v1/transactions/fee");
             return res.body;
         } catch (e) {
-            throw Error(e.response.error.message)
+            e.message = e.response.error.message;
+            throw e;
         }
     };
 
@@ -182,7 +192,8 @@ function Algod(token, baseServer = "http://r2.algorand.network", port = 4180) {
             let res = await c.post("/v1/transactions", Buffer.from(txn));
             return res.body;
         } catch (e) {
-            throw Error(e.error.message)
+            e.message = e.error.message;
+            throw e;
         }
     };
 
@@ -195,7 +206,8 @@ function Algod(token, baseServer = "http://r2.algorand.network", port = 4180) {
             let res = await c.get("/v1/transactions/params");
             return res.body;
         } catch (e) {
-            throw Error(e.response.error.message)
+            e.message = e.response.error.message;
+            throw e;
         }
     };
 
@@ -215,7 +227,8 @@ function Algod(token, baseServer = "http://r2.algorand.network", port = 4180) {
             }
             return res.body;
         } catch (e) {
-            throw Error(e.response.error.message)
+            e.message = e.response.error.message;
+            throw e;
         }
     };
 


### PR DESCRIPTION
## Summary
Problem statement from @JasonWeathersby :
> When using the JS SDK the returned error message is not set:
> 
> let tx = (await algodclient.transactionInformation( "NJY27OQ2ZXK6OWBN44LE4K43TA2AV3DPILPYTHAJAMKIVZDWTEJKZJKO4A", "EXQVLGRRARXG5KG5EBZVVJD3GK2GI5S4PET33OKN36S42KD65ZRQ" ));
> 
> Wrap with try catch and print out err.message. It will be undefined. err prints though.

This PR proposes to wrap algod.js calls in a try/catch. When catching an error, a new error is re-thrown using the extracted error message, so that `err.message` is defined, as expected.

### Testing
Used minimal example provided by Jason to test if `err.message` was defined. Also hand-tested other functions such as `sendRawTransaction`, which needed different re-throw logic. 