### PR TITLE
KMDClient properly provides a dict to first arg of HTTPClient

### DIFF
--- a/src/client/kmd.js
+++ b/src/client/kmd.js
@@ -2,7 +2,7 @@ const client = require('./client');
 
 function Kmd(token, baseServer = "http://127.0.0.1", port = 7833) {
     // Get client
-    let c = new client.HTTPClient('X-KMD-API-Token', token, baseServer, port);
+    let c = new client.HTTPClient({'X-KMD-API-Token':token}, baseServer, port);
 
     /**
      * version returns a VersionResponse containing a list of kmd API versions supported by this running kmd instance.


### PR DESCRIPTION
Previously, KMD passed four args to `client.HTTPClient`. However, `client.HTTPClient` expects three args, the first of which is a dict. This PR fixes the `Kmd` so it constructs its HTTP Client properly.

This change is necessary for the GOAL2-501 "sign a transaction using kmd in the javascript SDK" ticket, but additional work is needed to complete that. 