### PR TITLE
Declaring note if undefined.

### DIFF
--- a/src/transaction.js
+++ b/src/transaction.js
@@ -26,6 +26,9 @@ class Transaction {
         if (note !== undefined) {
             if (note.constructor !== Uint8Array) throw Error("note must be a Uint8Array.");
         }
+        else {
+          note = new Uint8Array([0]);
+        }
 
         Object.assign(this, {
             from, to, fee, amount, firstRound, lastRound, note, genesisID

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -27,7 +27,7 @@ class Transaction {
             if (note.constructor !== Uint8Array) throw Error("note must be a Uint8Array.");
         }
         else {
-          note = new Uint8Array([0]);
+          note = new Uint8Array(0);
         }
 
         Object.assign(this, {


### PR DESCRIPTION
Comparing the behaviour between SDK's, the field **note** seems to be optional though I wasn't able to let it undefined without the SDK throwing an error.
Assigning this as default will comply with the expected behaviour.

Error before this fix:
```bash
> algosdk.signTransaction(tx_object,sk.sk)
TypeError [ERR_INVALID_ARG_TYPE]: The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received type undefined
    at Function.from (buffer.js:207:11)
    at Transaction.get_obj_for_encoding (/home/fscucchiero/repos/algorand-api-backend/node_modules/algosdk/src/transaction.js:43:28)
    at Transaction.toByte (/home/fscucchiero/repos/algorand-api-backend/node_modules/algosdk/src/transaction.js:72:37)
    at Transaction.bytesToSign (/home/fscucchiero/repos/algorand-api-backend/node_modules/algosdk/src/transaction.js:67:31)
    at Transaction.signTxn (/home/fscucchiero/repos/algorand-api-backend/node_modules/algosdk/src/transaction.js:76:33)
    at Transaction.estimateSize (/home/fscucchiero/repos/algorand-api-backend/node_modules/algosdk/src/transaction.js:62:21)
    at new Transaction (/home/fscucchiero/repos/algorand-api-backend/node_modules/algosdk/src/transaction.js:34:26)
    at Object.signTransaction (/home/fscucchiero/repos/algorand-api-backend/node_modules/algosdk/src/main.js:93:19)
```