### PR TITLE
Added additional header capability to algod client and it's methods

### DIFF
--- a/src/client/algod.js
+++ b/src/client/algod.js
@@ -1,24 +1,14 @@
 const client = require('./client');
 
-// token can either be the X-Algo-API-Token string value or is a JS Object to allow setting multiple headers in the request
-// ex. 
-// const token = {
-//    'X-API-Key': 'SOME VALUE',
-//   'X-Algo-API-Token': 'ANOTHER VALUE'
-// };
-// const algodclient = new algosdk.Algod(token, baseServer, port);
-
-
-function Algod(token = '', baseServer = "http://r2.algorand.network", port = 4180) {
-
+function Algod(token = '', baseServer = "http://r2.algorand.network", port = 4180, headers = {}) {
     // workaround to allow backwards compatibility for multiple headers
-    let requestHeaders = token;
-    if (typeof (requestHeaders) == 'string') {
-        requestHeaders = {'X-Algo-API-Token': requestHeaders};
+    let tokenHeader = token;
+    if (typeof (tokenHeader) == 'string') {
+        tokenHeader = {"X-Algo-API-Token": tokenHeader};
     }
 
     // Get client
-    let c = new client.HTTPClient(requestHeaders, baseServer, port);
+    let c = new client.HTTPClient(tokenHeader, baseServer, port, headers);
 
     /**
      * Takes an object and convert its note field to Buffer, if exist.
@@ -34,19 +24,21 @@ function Algod(token = '', baseServer = "http://r2.algorand.network", port = 418
 
     /**
      * status retrieves the StatusResponse from the running node
+     * @param headers, optional
      * @returns {Promise<*>}
      */
-    this.status = async function () {
-        let res = await c.get("/v1/status");
+    this.status = async function (headers={}) {
+        let res = await c.get("/v1/status", {}, headers);
         return res.body;
     };
 
     /**
      * healthCheck returns an empty object iff the node is running
+     * @param headers, optional
      * @returns {Promise<*>}
      */
-    this.healthCheck = async function () {
-        let res = await c.get("/health");
+    this.healthCheck = async function (headers={}) {
+        let res = await c.get("/health", {}, headers);
         return res.body;
     };
 
@@ -54,11 +46,12 @@ function Algod(token = '', baseServer = "http://r2.algorand.network", port = 418
      * statusAfterBlock waits for round roundNumber to occur then returns the StatusResponse for this round.
      * This call blocks
      * @param roundNumber
+     * @param headers, optional
      * @returns {Promise<*>}
      */
-    this.statusAfterBlock = async function (roundNumber) {
+    this.statusAfterBlock = async function (roundNumber, headers={}) {
         if (!Number.isInteger(roundNumber)) throw Error("roundNumber should be an integer");
-        let res = await c.get("/v1/status/wait-for-block-after/" + roundNumber);
+        let res = await c.get("/v1/status/wait-for-block-after/" + roundNumber, {}, headers);
         return res.body;
     };
 
@@ -66,11 +59,12 @@ function Algod(token = '', baseServer = "http://r2.algorand.network", port = 418
      * pendingTransactions asks algod for a snapshot of current pending txns on the node, bounded by maxTxns.
      * If maxTxns = 0, fetches as many transactions as possible.
      * @param maxTxns number
+     * @param headers, optional
      * @returns {Promise<*>}
      */
-    this.pendingTransactions = async function (maxTxns) {
+    this.pendingTransactions = async function (maxTxns, headers={}) {
         if (!Number.isInteger(maxTxns)) throw Error("maxTxns should be an integer");
-        let res = await c.get("/v1/transactions/pending", { 'max': maxTxns });
+        let res = await c.get("/v1/transactions/pending", { 'max': maxTxns }, headers);
         if (res.statusCode === 200 && res.body.truncatedTxns.transactions !== undefined) {
             for (let i = 0; i < res.body.truncatedTxns.transactions.length; i++) {
                 res.body.truncatedTxns.transactions[i] = noteb64ToNote(res.body.truncatedTxns.transactions[i]);
@@ -81,19 +75,21 @@ function Algod(token = '', baseServer = "http://r2.algorand.network", port = 418
 
     /**
      * versions retrieves the VersionResponse from the running node
+     * @param headers, optional
      * @returns {Promise<*>}
      */
-    this.versions = async function () {
-        let res = await c.get("/versions");
+    this.versions = async function (headers={}) {
+        let res = await c.get("/versions", {}, headers);
         return res.body;
     };
 
     /**
      * LedgerSupply gets the supply details for the specified node's Ledger
+     * @param headers, optional
      * @returns {Promise<*>}
      */
-    this.ledgerSupply = async function () {
-        let res = await c.get("/v1/ledger/supply");
+    this.ledgerSupply = async function (headers={}) {
+        let res = await c.get("/v1/ledger/supply", {}, headers);
         return res.body;
     };
 
@@ -103,9 +99,10 @@ function Algod(token = '', baseServer = "http://r2.algorand.network", port = 418
      * @param first number, optional
      * @param last number, optional
      * @param maxTxns number, optional
+     * @param headers, optional
      * @returns {Promise<*>}
      */
-    this.transactionByAddress = async function (addr, first=null, last=null, maxTxns=null) {
+    this.transactionByAddress = async function (addr, first=null, last=null, maxTxns=null, headers={}) {
 
         if (( first !== null ) && (!Number.isInteger(first) )){
             throw Error("first round should be an integer")
@@ -113,7 +110,7 @@ function Algod(token = '', baseServer = "http://r2.algorand.network", port = 418
         if (( last !== null ) && (!Number.isInteger(last) )){
             throw Error("last round should be an integer")
         }
-        let res = await c.get("/v1/account/" + addr + "/transactions", { 'firstRound': first, 'lastRound': last, 'max': maxTxns });
+        let res = await c.get("/v1/account/" + addr + "/transactions", { 'firstRound': first, 'lastRound': last, 'max': maxTxns }, headers);
         if (res.statusCode === 200 && res.body.transactions !== undefined) {
             for (let i = 0; i < res.body.transactions.length; i++) {
                 res.body.transactions[i] = noteb64ToNote(res.body.transactions[i]);
@@ -129,10 +126,11 @@ function Algod(token = '', baseServer = "http://r2.algorand.network", port = 418
      * @param fromDate string
      * @param toDate string
      * @param maxTxns number, optional
+     * @param headers, optional
      * @returns {Promise<*>}
      */
-    this.transactionByAddressAndDate = async function (addr, fromDate, toDate, maxTxns=null) {
-        let res = await c.get("/v1/account/" + addr + "/transactions", { 'fromDate': fromDate, 'toDate': toDate, 'max': maxTxns });
+    this.transactionByAddressAndDate = async function (addr, fromDate, toDate, maxTxns=null, headers={}) {
+        let res = await c.get("/v1/account/" + addr + "/transactions", { 'fromDate': fromDate, 'toDate': toDate, 'max': maxTxns }, headers);
         if (res.statusCode === 200 && res.body.transactions !== undefined) {
             for (let i = 0; i < res.body.transactions.length; i++) {
                 res.body.transactions[i] = noteb64ToNote(res.body.transactions[i]);
@@ -145,10 +143,11 @@ function Algod(token = '', baseServer = "http://r2.algorand.network", port = 418
      * transactionById returns the a transaction information of a specific txid [txId]
      * Note - This method is allowed only when Indexer is enabled.
      * @param txid
+     * @param headers, optional
      * @returns {Promise<*>}
      */
-    this.transactionById = async function (txid) {
-        let res = await c.get("/v1/transaction/" + txid);
+    this.transactionById = async function (txid, headers={}) {
+        let res = await c.get("/v1/transaction/" + txid, {}, headers);
         if (res.statusCode === 200) {
             res.body = noteb64ToNote(res.body);
         }
@@ -159,10 +158,11 @@ function Algod(token = '', baseServer = "http://r2.algorand.network", port = 418
      * transactionInformation returns the transaction information of a specific txid and an address
      * @param addr
      * @param txid
+     * @param headers, optional
      * @returns {Promise<*>}
      */
-    this.transactionInformation = async function (addr, txid) {
-        let res = await c.get("/v1/account/" + addr + "/transaction/" + txid);
+    this.transactionInformation = async function (addr, txid, headers={}) {
+        let res = await c.get("/v1/account/" + addr + "/transaction/" + txid, {}, headers);
         if (res.statusCode === 200) {
             res.body = noteb64ToNote(res.body);
         }
@@ -172,10 +172,11 @@ function Algod(token = '', baseServer = "http://r2.algorand.network", port = 418
     /**
      * pendingTransactionInformation returns the transaction information for a specific txid of a pending transaction
      * @param txid
+     * @param headers, optional
      * @returns {Promise<*>}
      */
-    this.pendingTransactionInformation = async function (txid) {
-        let res = await c.get("/v1/transactions/pending/" + txid);
+    this.pendingTransactionInformation = async function (txid, headers={}) {
+        let res = await c.get("/v1/transactions/pending/" + txid, {}, headers);
         if (res.statusCode === 200) {
             res.body = noteb64ToNote(res.body);
         }
@@ -185,10 +186,11 @@ function Algod(token = '', baseServer = "http://r2.algorand.network", port = 418
     /**
      * accountInformation returns the passed account's information
      * @param addr string
+     * @param headers, optional
      * @returns {Promise<*>}
      */
-    this.accountInformation = async function (addr) {
-        let res = await c.get("/v1/account/" + addr);
+    this.accountInformation = async function (addr, headers={}) {
+        let res = await c.get("/v1/account/" + addr, {}, headers);
         return res.body;
     };
 
@@ -205,51 +207,56 @@ function Algod(token = '', baseServer = "http://r2.algorand.network", port = 418
 
     /**
      * suggestedFee gets the recommended transaction fee from the node
+     * @param headers, optional
      * @returns {Promise<*>}
      */
-    this.suggestedFee = async function () {
-        let res = await c.get("/v1/transactions/fee");
+    this.suggestedFee = async function (headers={}) {
+        let res = await c.get("/v1/transactions/fee", {}, headers);
         return res.body;
     };
 
     /**
      * sendRawTransaction gets an encoded SignedTxn and broadcasts it to the network
      * @param txn Uin8Array
+     * @param headers, optional
      * @returns {Promise<*>}
      */
-    this.sendRawTransaction = async function (txn) {
-        let res = await c.post("/v1/transactions", Buffer.from(txn));
+    this.sendRawTransaction = async function (txn, headers={}) {
+        let res = await c.post("/v1/transactions", Buffer.from(txn), headers);
         return res.body;
     };
 
     /**
      * sendRawTransactions gets a list of encoded SignedTxns and broadcasts it to the network
      * @param txn Array of Uin8Array
+     * @param headers, optional
      * @returns {Promise<*>}
      */
-    this.sendRawTransactions = async function (txns) {
+    this.sendRawTransactions = async function (txns, headers={}) {
         const merged = Array.prototype.concat(...txns.map(arr => Array.from(arr)));
-        let res = await c.post("/v1/transactions", Buffer.from(merged));
+        let res = await c.post("/v1/transactions", Buffer.from(merged), headers);
         return res.body;
     };
 
     /**
      * getTransactionParams returns to common needed parameters for a new transaction
+     * @param headers, optional
      * @returns {Promise<*>}
      */
-    this.getTransactionParams = async function () {
-        let res = await c.get("/v1/transactions/params");
+    this.getTransactionParams = async function (headers={}) {
+        let res = await c.get("/v1/transactions/params", {}, headers);
         return res.body;
     };
 
     /**
      * block gets the block info for the given round This call blocks
      * @param roundNumber
+     * @param headers, optional
      * @returns {Promise<*>}
      */
-    this.block = async function (roundNumber) {
+    this.block = async function (roundNumber, headers={}) {
         if (!Number.isInteger(roundNumber)) throw Error("roundNumber should be an integer");
-        let res = await c.get("/v1/block/" + roundNumber);
+        let res = await c.get("/v1/block/" + roundNumber, {}, headers);
         if (res.statusCode === 200 && res.body.txns.transactions !== undefined) {
             for (let i = 0; i < res.body.txns.transactions.length; i++) {
                 res.body.txns.transactions[i] = noteb64ToNote(res.body.txns.transactions[i]);

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -14,17 +14,21 @@ function removeEmpty(obj) {
     return obj;
 }
 
-function HTTPClient(requestHeaders, baseServer, port) {
+function HTTPClient(token, baseServer, port, headers={}) {
     // Do not need colon if port is empty
     if (port !== '') {
         baseServer += ":" + port.toString();
     }
     this.address = baseServer;
+    this.token = token;
+    this.clientHeaders = headers;
 
-    this.get = async function (path, query) {
+    this.get = async function (path, query, requestHeaders={}) {
         try {
             return await request
                 .get(this.address + path)
+                .set(this.token)
+                .set(this.clientHeaders)
                 .set(requestHeaders)
                 .set('Accept', 'application/json')
                 .query(removeEmpty(query));
@@ -33,10 +37,12 @@ function HTTPClient(requestHeaders, baseServer, port) {
         }
     };
 
-    this.post = async function (path, data) {
+    this.post = async function (path, data, requestHeaders={}) {
         try {
             return await request
                 .post(this.address + path)
+                .set(this.token)
+                .set(this.clientHeaders)
                 .set(requestHeaders)
                 .send(data);
         } catch (e) {
@@ -44,10 +50,12 @@ function HTTPClient(requestHeaders, baseServer, port) {
         }
     };
 
-    this.delete = async function (path, data) {
+    this.delete = async function (path, data, requestHeaders={}) {
         try {
             return await request
                 .delete(this.address + path)
+                .set(this.token)
+                .set(this.clientHeaders)
                 .set(requestHeaders)
                 .send(data);
         } catch (e) {

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -21,14 +21,14 @@ function HTTPClient(token, baseServer, port, headers={}) {
     }
     this.address = baseServer;
     this.token = token;
-    this.clientHeaders = headers;
+    this.defaultHeaders = headers;
 
     this.get = async function (path, query, requestHeaders={}) {
         try {
             return await request
                 .get(this.address + path)
                 .set(this.token)
-                .set(this.clientHeaders)
+                .set(this.defaultHeaders)
                 .set(requestHeaders)
                 .set('Accept', 'application/json')
                 .query(removeEmpty(query));
@@ -42,7 +42,7 @@ function HTTPClient(token, baseServer, port, headers={}) {
             return await request
                 .post(this.address + path)
                 .set(this.token)
-                .set(this.clientHeaders)
+                .set(this.defaultHeaders)
                 .set(requestHeaders)
                 .send(data);
         } catch (e) {
@@ -55,7 +55,7 @@ function HTTPClient(token, baseServer, port, headers={}) {
             return await request
                 .delete(this.address + path)
                 .set(this.token)
-                .set(this.clientHeaders)
+                .set(this.defaultHeaders)
                 .set(requestHeaders)
                 .send(data);
         } catch (e) {


### PR DESCRIPTION
Adds support for multiple different headers on the algod client and in all of the internal methods.
Backwards compatible for existing code, both normal Algod string tokens and previous modification that allowed dict tokens.