### PR TITLE
Add Asset Transfer ("axfer") transactions 

### DIFF
--- a/src/transaction.js
+++ b/src/transaction.js
@@ -313,6 +313,7 @@ class Transaction {
                 txn.index = txnForEnc.faid.i;
                 if (txnForEnc.faid.c !== undefined) txn.creator = address.decode(address.encode(new Uint8Array(txnForEnc.faid.c)));
             }
+            txn.freezeAccount = address.decode(address.encode(new Uint8Array(txnForEnc.fadd)));
         }
         return txn;
     }

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -292,7 +292,7 @@ class Transaction {
         }
         else if (txnForEnc.type === "axfer") {
             // asset transfer, acceptance, revocation, mint, or burn
-            if (txnForEnc.xaid !== undefined){
+            if (txnForEnc.xaid !== undefined) {
                 txn.index = txnForEnc.xaid.i
                 if (txnForEnc.xaid.c !== undefined) txn.creator = address.decode(address.encode(new Uint8Array(txnForEnc.xaid.c)));
             }
@@ -304,6 +304,7 @@ class Transaction {
                 txn.assetRevocationTarget = address.decode(address.encode(new Uint8Array(txnForEnc.asnd)));
             }
             txn.to = address.decode(address.encode(new Uint8Array(txnForEnc.arcv)));
+        }
         else if (txnForEnc.type === "afrz") {
             txn.freezeState = txnForEnc.afrz;
             if (txnForEnc.faid !== undefined) {

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -14,7 +14,8 @@ class Transaction {
     constructor({from, to, fee, amount, firstRound, lastRound, note, genesisID, genesisHash, 
                  closeRemainderTo, voteKey, selectionKey, voteFirst, voteLast, voteKeyDilution, 
                  creator, index, assetTotal, assetDefaultFrozen, assetManager, assetReserve, 
-                 assetFreeze, assetClawback, assetUnitName, assetName, freezeAccount, freezeState, assetRevocationTarget, type="pay", flatFee=false}) {
+                 assetFreeze, assetClawback, assetUnitName, assetName, freezeAccount, freezeState,
+                 assetRevocationTarget, type="pay", flatFee=false}) {
         this.name = "Transaction";
         this.tag = Buffer.from("TX");
 
@@ -56,8 +57,8 @@ class Transaction {
             from, to, fee, amount, firstRound, lastRound, note, genesisHash, genesisID, 
             closeRemainderTo, voteKey, selectionKey, voteFirst, voteLast, voteKeyDilution, 
             creator, index, assetTotal, assetDefaultFrozen, assetManager, assetReserve, 
-            assetFreeze, assetClawback, assetUnitName, assetName, freezeAccount,
-            freezeState, assetRevocationTarget, type
+            assetFreeze, assetClawback, assetUnitName, assetName, freezeAccount, freezeState,
+            assetRevocationTarget, type
         });
 
         // Modify Fee
@@ -217,6 +218,7 @@ class Transaction {
             if (txn.grp === undefined) delete txn.grp;
             if (!txn.aclose) delete txn.aclose;
             if (!txn.asnd) delete txn.asnd;
+            return txn;
         }
         else if (this.type == "afrz") {
             // asset freeze or unfreeze

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -270,7 +270,7 @@ class Transaction {
                 txn.index = txnForEnc.xaid.i
                 if (txnForEnc.xaid.c !== undefined) txn.creator = address.decode(address.encode(new Uint8Array(txnForEnc.xaid.c)));
             }
-            if (txnForEnc.amount !== undefined) txn.amount = txnForEnc.aamt;
+            if (txnForEnc.aamt !== undefined) txn.amount = txnForEnc.aamt;
             if (txnForEnc.aclose !== undefined) {
                 txn.closeRemainderTo = address.decode(address.encode(new Uint8Array(txnForEnc.aclose)));
             }

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -209,12 +209,14 @@ class Transaction {
             if (this.assetRevocationTarget !== undefined) txn.asnd = Buffer.from(this.assetRevocationTarget.publicKey);
             // allowed zero values
             if (!txn.note.length) delete txn.note;
-            if (!txn.amt) delete txn.amt;
+            if (!txn.aamt) delete txn.aamt;
             if (!txn.fee) delete txn.fee;
             if (!txn.gen) delete txn.gen;
             if (txn.grp === undefined) delete txn.grp;
             if (!txn.aclose) delete txn.aclose;
             if (!txn.asnd) delete txn.asnd;
+
+            return txn;
         }
     }
 
@@ -262,7 +264,7 @@ class Transaction {
                 if (txnForEnc.apar.an !== undefined) txn.assetName = txnForEnc.apar.an;
             }
         }
-        else if (txnForenc.type === "axfer") {
+        else if (txnForEnc.type === "axfer") {
             // asset transfer, acceptance, revocation, mint, or burn
             if (txnForEnc.xaid !== undefined){
                 txn.index = txnForEnc.xaid.i

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -217,6 +217,7 @@ class Transaction {
             if (txn.grp === undefined) delete txn.grp;
             if (!txn.aclose) delete txn.aclose;
             if (!txn.asnd) delete txn.asnd;
+        }
         else if (this.type == "afrz") {
             // asset freeze or unfreeze
             let txn = {

--- a/tests/5.Transaction.js
+++ b/tests/5.Transaction.js
@@ -210,14 +210,27 @@ describe('Sign', function () {
 
         it('should correctly serialize and deserialize an asset transfer transaction from msgpack representation', function() {
             address = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"
-            let o = {};
+            let o = {
+                "type": "axfer",
+                "from": address,
+                "to": address,
+                "amount": 100,
+                "fee": 10,
+                "firstRound": 322575,
+                "lastRound": 323575,
+                "genesisHash": "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=",
+                "creator": address,
+                "index": 1234,
+                "assetRevocationTarget": address,
+                "closeRemainderTo": address
+            };
             let expectedTxn = new transaction.Transaction(o);
             let encRep = expectedTxn.get_obj_for_encoding();
             const encTxn = encoding.encode(encRep);
             const decEncRep = encoding.decode(encTxn);
             let decTxn = transaction.Transaction.from_obj_for_encoding(decEncRep);
             const reencRep = decTxn.get_obj_for_encoding();
-            assert.deepStrictEqual(0, 1); // TODO ejr fail always for now
+            assert.deepStrictEqual(reencRep, encRep); // TODO ejr fail always for now
         });
 
         it('reserializes correctly no genesis ID', function() {

--- a/tests/5.Transaction.js
+++ b/tests/5.Transaction.js
@@ -208,6 +208,18 @@ describe('Sign', function () {
             assert.deepStrictEqual(reencRep, encRep);
         });
 
+        it('should correctly serialize and deserialize an asset transfer transaction from msgpack representation', function() {
+            address = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"
+            let o = {};
+            let expectedTxn = new transaction.Transaction(o);
+            let encRep = expectedTxn.get_obj_for_encoding();
+            const encTxn = encoding.encode(encRep);
+            const decEncRep = encoding.decode(encTxn);
+            let decTxn = transaction.Transaction.from_obj_for_encoding(decEncRep);
+            const reencRep = decTxn.get_obj_for_encoding();
+            assert.deepStrictEqual(0, 1); // TODO ejr fail always for now
+        });
+
         it('reserializes correctly no genesis ID', function() {
             let o = {
                 "from": "XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU",

--- a/tests/5.Transaction.js
+++ b/tests/5.Transaction.js
@@ -230,7 +230,7 @@ describe('Sign', function () {
             const decEncRep = encoding.decode(encTxn);
             let decTxn = transaction.Transaction.from_obj_for_encoding(decEncRep);
             const reencRep = decTxn.get_obj_for_encoding();
-            assert.deepStrictEqual(reencRep, encRep); // TODO ejr fail always for now
+            assert.deepStrictEqual(reencRep, encRep);
         });
 
         it('reserializes correctly no genesis ID', function() {

--- a/tests/7.AlgoSDK.js
+++ b/tests/7.AlgoSDK.js
@@ -303,4 +303,36 @@ describe('Algosdk (AKA end to end)', function () {
             assert.equal(result.length, 0);
         });
     });
+
+    describe('asset transfer', function () {
+        it('should return a blob that matches the go code', function () {
+
+            let addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4";
+
+            let o = {
+                "type": "axfer",
+                "from": addr,
+                "to": addr,
+                "amount": 1,
+                "fee": 10,
+                "firstRound": 322575,
+                "lastRound": 323576,
+                "genesisHash": "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=",
+                "creator": addr,
+                "index": 1,
+                "closeRemainderTo": addr
+            };
+
+            let mnem = "awful drop leaf tennis indoor begin mandate discover uncle seven only coil atom any hospital uncover make any climb actor armed measure need above hundred";
+            let seed = passphrase.seedFromMnemonic(mnem);
+            let keys = nacl.keyPairFromSeed(seed);
+            let sk = keys.secretKey;
+            let js_dec = algosdk.signTransaction(o, sk);
+
+            let golden = Buffer.from("gqNzaWfEQGkk9CtvOKnn4nU59xmPGoZvYv+6TCu5B95PgwQ/YytwE9dr199ehEqAnSS0C2SaO4YhEBAk+JVOiwZiRq/w1gijdHhuiqRhYW10AaZhY2xvc2XEIAn70nYsCPhsWua/bdenqQHeZnXXUOB+jFx2mGR9tuH9pGFyY3bEIAn70nYsCPhsWua/bdenqQHeZnXXUOB+jFx2mGR9tuH9o2ZlZc0MRKJmds4ABOwPomdoxCBIY7UYpLPITsgQ8i1PEIHLD3HwWaesIN7GL39w5Qk6IqJsds4ABO/4o3NuZMQgCfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f2kdHlwZaVheGZlcqR4YWlkgqFjxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFpAQ==", "base64");
+            assert.deepStrictEqual(Buffer.from(js_dec.blob), golden);
+
+        });
+    });
+
 });


### PR DESCRIPTION
## Summary
This PR proposes to add asset transfer support to the javascript SDK, enabling: asset acceptance, asset transferral, asset clawback, asset mint, and asset burn.

### Testing
Added a serialize/deserialize test to `Transaction.js`