### PR TITLE
Add wrappers to main.js - functions for making various types of txn - and usage in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,5 +307,141 @@ let algodclient = new algosdk.Algod(atoken, aserver, aport);
 algodclient.sendRawTransaction(rawSignedTxn);
 ```
 
+#### Assets
+
+Asset creation:
+```javascript
+let addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4";
+let fee = 10;
+let defaultFrozen = false;
+let genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=";
+let totalIssuance = 100;
+let reserve = addr;
+let freeze = addr;
+let clawback = addr;
+let manager = addr;
+let unitName = "tst";
+let assetName = "testcoin";
+let genesisID = "";
+let firstRound = 322575;
+let lastRound = 322575;
+let note = undefined;
+
+// signing and sending "txn" will allow you to create an asset
+let txn = algosdk.makeAssetCreateTxn(addr, fee, firstRound, lastRound, note,
+    genesisHash, genesisID, totalIssuance, defaultFrozen, manager, reserve, freeze, clawback, unitName, assetName);
+```
+
+
+Asset reconfiguration:
+```javascript
+let addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4";
+let fee = 10;
+let assetIndex = 1234;
+let genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=";
+let creator = addr;
+let manager = addr;
+let reserve = addr;
+let freeze = addr;
+let clawback = addr;
+let genesisID = "";
+let firstRound = 322575;
+let lastRound = 322575;
+let note = undefined;
+
+// signing and sending "txn" will allow the asset manager to change:
+// asset manager, reserve, asset freeze manager, asset revocation manager 
+let txn = algosdk.makeAssetConfigTxn(addr, fee, firstRound, lastRound, note, genesisHash, genesisID,
+    creator, assetIndex, manager, reserve, freeze, clawback);
+```
+
+Asset destruction:
+```javascript
+let addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4";
+let fee = 10;
+let assetIndex = 1234;
+let genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=";
+let creator = addr;
+let genesisID = "";
+let firstRound = 322575;
+let lastRound = 322575;
+let note = undefined;
+
+// if all outstanding assets are held by the asset creator,
+// the asset creator can sign and issue "txn" to remove the asset from the ledger. 
+let txn = algosdk.makeAssetDestroyTxn(addr, fee, firstRound, lastRound, note, genesisHash, genesisID,
+    creator, assetIndex);
+```
+
+Begin accepting an asset:
+```javascript
+let addr = "47YPQTIGQEO7T4Y4RWDYWEKV6RTR2UNBQXBABEEGM72ESWDQNCQ52OPASU";
+let fee = 10;
+let sender = addr;
+let recipient = sender;
+let revocationTarget = undefined;
+let closeRemainderTo = undefined;
+let assetIndex = 1234;
+let amount = 0;
+let genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=";
+let creator = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4";
+let genesisID = "";
+let firstRound = 322575;
+let lastRound = 322575;
+let note = undefined;
+
+// signing and sending "txn" allows sender to begin accepting asset specified by creator and index
+let txn = algosdk.makeAssetTransferTxn(sender, recipient, closeRemainderTo, revocationTarget,
+    fee, amount, firstRound, lastRound, note, genesisHash, genesisID,
+    creator, assetIndex);
+```
+
+Transfer an asset:
+```javascript
+let addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4";
+let fee = 10;
+let sender = addr;
+let recipient = "47YPQTIGQEO7T4Y4RWDYWEKV6RTR2UNBQXBABEEGM72ESWDQNCQ52OPASU";
+let revocationTarget = undefined;
+let closeRemainderTo = undefined; // supply an address to close remaining balance after transfer to supplied address
+let assetIndex = 1234;
+let amount = 10;
+let genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=";
+let creator = addr;
+let genesisID = "";
+let firstRound = 322575;
+let lastRound = 322575;
+let note = undefined;
+
+// signing and sending "txn" will send "amount" assets from "sender" to "recipient"
+let txn = algosdk.makeAssetTransferTxn(sender, recipient, closeRemainderTo, revocationTarget,
+    fee, amount, firstRound, lastRound, note, genesisHash, genesisID,
+    creator, assetIndex);
+```
+
+Revoke an asset:
+```javascript
+let addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4";
+let fee = 10;
+let sender = addr;
+let recipient = addr;
+let revocationTarget = "47YPQTIGQEO7T4Y4RWDYWEKV6RTR2UNBQXBABEEGM72ESWDQNCQ52OPASU";
+let closeRemainderTo = undefined; 
+let assetIndex = 1234;
+let amount = 10;
+let genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=";
+let creator = addr;
+let genesisID = "";
+let firstRound = 322575;
+let lastRound = 322575;
+let note = undefined;
+
+// signing and sending "txn" will send "amount" assets from "revocationTarget" to "recipient",
+// if and only if sender == clawback manager for this asset
+let txn = algosdk.makeAssetTransferTxn(sender, recipient, closeRemainderTo, revocationTarget,
+    fee, amount, firstRound, lastRound, note, genesisHash, genesisID,
+    creator, assetIndex);
+```
+
 ## License
 js-algorand-sdk is licensed under a MIT license. See the [LICENSE](https://github.com/algorand/js-algorand-sdk/blob/master/LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -309,31 +309,43 @@ algodclient.sendRawTransaction(rawSignedTxn);
 
 #### Assets
 
-Asset creation:
-```javascript
-let addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4";
-let fee = 10;
-let defaultFrozen = false;
-let genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=";
-let totalIssuance = 100;
-let reserve = addr;
-let freeze = addr;
-let clawback = addr;
-let manager = addr;
-let unitName = "tst";
-let assetName = "testcoin";
-let genesisID = "";
-let firstRound = 322575;
-let lastRound = 322575;
-let note = undefined;
+The Algorand protocol allows users to create and trade named assets on layer one. Creating and managing these assets
+is done through the issuing of asset transactions. This section details how to make asset transactions, and what they do.
 
-// signing and sending "txn" will allow you to create an asset
+Asset creation: This allows a user to issue a new asset. The user can define the number of assets in circulation,
+whether there is an account that can revoke assets, whether there is an account that can freeze user accounts, 
+whether there is an account that can be considered the asset reserve, and whether there is an account that can change
+the other accounts. The creating user can also do things like specify a name for the asset.
+                                                                        
+```javascript
+let addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4"; // the account issuing the transaction; the asset creator
+let fee = 10; // the number of microAlgos per byte to pay as a transaction fee
+let defaultFrozen = false; // whether user accounts will need to be unfrozen before transacting
+let genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="; // hash of the genesis block of the network to be used
+let totalIssuance = 100; // total number of this asset in circulation
+let reserve = addr; // specified address is considered the asset reserve (it has no special privileges, this is only informational)
+let freeze = addr; // specified address can freeze or unfreeze user asset holdings
+let clawback = addr; // specified address can revoke user asset holdings and send them to other addresses
+let manager = addr; // specified address can change reserve, freeze, clawback, and manager
+let unitName = "tst"; // used to display asset units to user
+let assetName = "testcoin"; // "friendly name" of asset
+let genesisID = ""; // like genesisHash this is used to specify network to be used
+let firstRound = 322575; // first Algorand round on which this transaction is valid
+let lastRound = 322575; // last Algorand round on which this transaction is valid
+let note = undefined; // arbitrary data to be stored in the transaction; here, none is stored
+
+// signing and sending "txn" allows "addr" to create an asset
 let txn = algosdk.makeAssetCreateTxn(addr, fee, firstRound, lastRound, note,
     genesisHash, genesisID, totalIssuance, defaultFrozen, manager, reserve, freeze, clawback, unitName, assetName);
 ```
 
 
-Asset reconfiguration:
+Asset reconfiguration: This allows the address specified as `manager` to change any of the special addresses for the asset,
+such as the reserve address. To keep an address the same, it must be re-specified in each new configuration transaction.
+Supplying an empty address is the same as turning the associated feature off for this asset. Once a special address
+is set to the empty address, it can never change again. For example, if an asset configuration transaction specifying
+`clawback=""` were issued, the associated asset could never be revoked from asset holders, and `clawback=""` would be
+true for all time.                                                                                                                     
 ```javascript
 let addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4";
 let fee = 10;
@@ -350,12 +362,13 @@ let lastRound = 322575;
 let note = undefined;
 
 // signing and sending "txn" will allow the asset manager to change:
-// asset manager, reserve, asset freeze manager, asset revocation manager 
+// asset manager, asset reserve, asset freeze manager, asset revocation manager 
 let txn = algosdk.makeAssetConfigTxn(addr, fee, firstRound, lastRound, note, genesisHash, genesisID,
     creator, assetIndex, manager, reserve, freeze, clawback);
 ```
 
-Asset destruction:
+Asset destruction: This allows the creator to remove the asset from the ledger, if all outstanding assets are held
+by the creator.
 ```javascript
 let addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4";
 let fee = 10;
@@ -373,7 +386,9 @@ let txn = algosdk.makeAssetDestroyTxn(addr, fee, firstRound, lastRound, note, ge
     creator, assetIndex);
 ```
 
-Begin accepting an asset:
+Begin accepting an asset: Before a user can begin transacting with an asset, the user must first issue an asset acceptance transaction.
+This is a special case of the asset transfer transaction, where the user sends 0 assets to themself. After issuing this transaction,
+the user can begin transacting with the asset. Each new accepted asset increases the user's minimum balance.                                                                                                                               
 ```javascript
 let addr = "47YPQTIGQEO7T4Y4RWDYWEKV6RTR2UNBQXBABEEGM72ESWDQNCQ52OPASU";
 let fee = 10;
@@ -396,7 +411,9 @@ let txn = algosdk.makeAssetTransferTxn(sender, recipient, closeRemainderTo, revo
     creator, assetIndex);
 ```
 
-Transfer an asset:
+Transfer an asset: This allows users to transact with assets, after they have issued asset acceptance transactions. The
+optional `closeRemainderTo` argument can be used to stop transacting with a particular asset. Note: A frozen account can always close
+out to the asset creator.                                                                                                             
 ```javascript
 let addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4";
 let fee = 10;
@@ -419,7 +436,8 @@ let txn = algosdk.makeAssetTransferTxn(sender, recipient, closeRemainderTo, revo
     creator, assetIndex);
 ```
 
-Revoke an asset:
+Revoke an asset: This allows an asset's revocation manager to transfer assets on behalf of another user. It will only work when 
+issued by the asset's revocation manager.
 ```javascript
 let addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4";
 let fee = 10;

--- a/src/main.js
+++ b/src/main.js
@@ -487,7 +487,7 @@ function makeAssetConfigTxn(from, fee, firstRound, lastRound, note, genesisHash,
 }
 
 /** makeAssetDestroyTxn will allow the asset's manager to remove this asset from the ledger, so long
- * as all outstanding assets are held by the manager.
+ * as all outstanding assets are held by the creator.
  *
  * @param from - string representation of Algorand address
  * @param fee - integer fee per byte. for a flat fee, overwrite the fee property on the returned object

--- a/src/main.js
+++ b/src/main.js
@@ -368,6 +368,7 @@ function makePaymentTxn(from, to, fee, amount, firstRound, lastRound, note, gene
 /**
  * makeKeyRegistrationTxn takes key registration arguments and returns a transaction.Transaction object for
  * that key registration operation
+ *
  * @param from - string representation of Algorand address
  * @param fee - integer fee per byte. for a flat fee, overwrite the fee property on the returned object
  * @param firstRound - integer first protocol round on which this txn is valid
@@ -402,6 +403,195 @@ function makeKeyRegistrationTxn(from, fee, firstRound, lastRound, note, genesisH
     return new txnBuilder.Transaction(o);
 }
 
+/** makeAssetCreateTxn takes asset creation arguments and returns a transaction.Transaciton object
+ * for creating that asset
+ *
+ * @param from - string representation of Algorand address
+ * @param fee - integer fee per byte. for a flat fee, overwrite the fee property on the returned object
+ * @param firstRound - integer first protocol round on which this txn is valid
+ * @param lastRound - integer last protocol round on which this txn is valid
+ * @param note - uint8array of arbitrary data
+ * @param genesisHash - string
+ * @param genesisID - string
+ * @param total - integer total supply of the asset
+ * @param defaultFrozen - boolean whether asset accounts should default to being frozen
+ * @param manager - string representation of Algorand address in charge of reserve, freeze, clawback, destruction, etc
+ * @param reserve - string representation of Algorand address representing asset reserve
+ * @param freeze - string representation of Algorand address with power to freeze/unfreeze asset holdings
+ * @param clawback - string representation of Algorand address with power to revoke asset holdings
+ * @param unitName - string units name for this asset
+ * @param assetName - string name for this asset
+ * @returns {Transaction}
+ */
+function makeAssetCreateTxn(from, fee, firstRound, lastRound, note, genesisHash, genesisID,
+                            total, defaultFrozen, manager, reserve, freeze, clawback, unitName, assetName) {
+    let o = {
+        "from": from,
+        "fee": fee,
+        "firstRound": firstRound,
+        "lastRound": lastRound,
+        "note": note,
+        "genesisHash": genesisHash,
+        "t": total,
+        "df": defaultFrozen,
+        "un": unitName,
+        "an": assetName,
+        "assetManager": manager,
+        "assetReserve": reserve,
+        "assetFreeze": freeze,
+        "assetClawback": clawback,
+        "genesisID": genesisID,
+        "type": "acfg"
+    };
+    return new txnBuilder.Transaction(o);
+}
+
+/** makeAssetConfigTxn can be issued by the asset manager to change the manager, reserve, freeze, or clawback
+ * you must respecify existing addresses to keep them the same; leaving a field blank is the same as turning
+ * that feature off for this asset
+ *
+ * @param from - string representation of Algorand address
+ * @param fee - integer fee per byte. for a flat fee, overwrite the fee property on the returned object
+ * @param firstRound - integer first protocol round on which this txn is valid
+ * @param lastRound - integer last protocol round on which this txn is valid
+ * @param note - uint8array of arbitrary data
+ * @param genesisHash - string
+ * @param genesisID - string
+ * @param creator - string representation of Algorand address of creator
+ * @param assetIndex - int asset index
+ * @param manager - string representation of new asset manager Algorand address
+ * @param reserve - string representation of new reserve Algorand address
+ * @param freeze - string representation of new freeze manager Algorand address
+ * @param clawback - string representaiton of new revocation manager Algorand address
+ * @returns {Transaction}
+ */
+function makeAssetConfigTxn(from, fee, firstRound, lastRound, note, genesisHash, genesisID,
+                            creator, assetIndex, manager, reserve, freeze, clawback) {
+    let o = {
+        "from": from,
+        "fee": fee,
+        "firstRound": firstRound,
+        "lastRound": lastRound,
+        "genesisHash": genesisHash,
+        "genesisID": genesisID,
+        "creator": creator,
+        "index": assetIndex,
+        "assetManager": manager,
+        "assetReserve": reserve,
+        "assetFreeze": freeze,
+        "assetClawback": clawback,
+        "type": "acfg",
+        "note": note
+    };
+    return new txnBuilder.Transaction(o);
+}
+
+/** makeAssetDestroyTxn will allow the asset's manager to remove this asset from the ledger, so long
+ * as all outstanding assets are held by the manager.
+ *
+ * @param from - string representation of Algorand address
+ * @param fee - integer fee per byte. for a flat fee, overwrite the fee property on the returned object
+ * @param firstRound - integer first protocol round on which this txn is valid
+ * @param lastRound - integer last protocol round on which this txn is valid
+ * @param note - uint8array of arbitrary data
+ * @param genesisHash - string
+ * @param genesisID - string
+ * @param creator - string representation of Algorand address of creator
+ * @param assetIndex - int asset index
+ * @returns {Transaction}
+ */
+function makeAssetDestroyTxn(from, fee, firstRound, lastRound, note, genesisHash, genesisID,
+                             creator, assetIndex) {
+    let o = {
+        "from": from,
+        "fee": fee,
+        "firstRound": firstRound,
+        "lastRound": lastRound,
+        "genesisHash": genesisHash,
+        "genesisID": genesisID,
+        "creator": creator,
+        "index": assetIndex,
+        "type": "acfg",
+        "note": note
+    };
+    return new txnBuilder.Transaction(o);
+}
+
+/** makeAssetFreezeTxn will allow the asset's freeze manager to freeze or un-freeze an account
+ *
+ * @param from - string representation of Algorand address
+ * @param fee - integer fee per byte. for a flat fee, overwrite the fee property on the returned object
+ * @param firstRound - integer first protocol round on which this txn is valid
+ * @param lastRound - integer last protocol round on which this txn is valid
+ * @param note - uint8array of arbitrary data
+ * @param genesisHash - string
+ * @param genesisID - string
+ * @param creator - string representation of Algorand address of creator
+ * @param assetIndex - int asset index
+ * @param freezeTarget - string representation of Algorand address being frozen or unfrozen
+ * @param freezeState - true if freezeTarget should be frozen, false if freezeTarget should be allowed to transact
+ * @returns {Transaction}
+ */
+function makeAssetFreezeTxn(from, fee, firstRound, lastRound, note, genesisHash, genesisID,
+                            creator, assetIndex, freezeTarget, freezeState) {
+    let o = {
+        "from": from,
+        "fee": fee,
+        "firstRound": firstRound,
+        "lastRound": lastRound,
+        "genesisHash": genesisHash,
+        "type": "afrz",
+        "freezeAccount": freezeTarget,
+        "index": assetIndex,
+        "creator" : creator,
+        "freezeState" : freezeState,
+        "note": note
+    };
+    return new txnBuilder.Transaction(o);
+}
+
+/** makeAssetTransferTxn allows for the creation of an asset transfer transaction.
+ * Special case: to begin accepting assets, set amount=0 and from=to.
+ *
+ * @param from - string representation of Algorand address
+ * @param to - string representation of Algorand address of asset recipient
+ * @param closeRemainderTo - optional - string representation of Algorand address - if provided,
+ * send all remaining assets after transfer to the closeRemainderTo address and close "from"'s asset holdings
+ * @param revocationTarget - optional - string representaiton of Algorand address - if provided,
+ * and if "from" is the asset's revocation manager, then deduct from revocationTarget rather than "from"
+ * @param fee - integer fee per byte. for a flat fee, overwrite the fee property on the returned object
+ * @param amount - integer amount of assets to send
+ * @param firstRound - integer first protocol round on which this txn is valid
+ * @param lastRound - integer last protocol round on which this txn is valid
+ * @param note - uint8array of arbitrary data
+ * @param genesisHash - string
+ * @param genesisID - string
+ * @param creator - string representation of Algorand address of creator
+ * @param assetIndex - int asset index
+ * @returns {Transaction}
+ */
+function makeAssetTransferTxn(from, to, closeRemainderTo, revocationTarget,
+                              fee, amount, firstRound, lastRound, note, genesisHash, genesisID,
+                              creator, assetIndex) {
+    let o = {
+        "type": "axfer",
+        "from": from,
+        "to": to,
+        "amount": amount,
+        "fee": fee,
+        "firstRound": firstRound,
+        "lastRound": lastRound,
+        "genesisHash": genesisHash,
+        "genesisID": genesisID,
+        "creator": creator,
+        "index": assetIndex,
+        "note": note,
+        "assetRevocationTarget": revocationTarget,
+        "closeRemainderTo": closeRemainderTo
+    };
+    return new txnBuilder.Transaction(o);
+}
+
 module.exports = {
     isValidAddress,
     generateAccount,
@@ -431,4 +621,9 @@ module.exports = {
     signLogicSigTransaction,
     makePaymentTxn,
     makeKeyRegistrationTxn,
+    makeAssetCreateTxn,
+    makeAssetConfigTxn,
+    makeAssetDestroyTxn,
+    makeAssetFreezeTxn,
+    makeAssetTransferTxn,
 };

--- a/src/main.js
+++ b/src/main.js
@@ -337,16 +337,16 @@ function signLogicSigTransaction(txn, lsig) {
 
 
 /**
- * makePaymentTxn takes payment arguments and returns a transaction.Transaction object representing that payment txn
- * @param from - string representation of Algorand address
- * @param to - string representation of Algorand address
- * @param fee - integer fee per byte. for a flat fee, overwrite the fee property on the returned object
- * @param amount - integer amount to send
+ * makePaymentTxn takes payment arguments and returns a Transaction object
+ * @param from - string representation of Algorand address of sender
+ * @param to - string representation of Algorand address of recipient
+ * @param fee - integer fee per byte, in microAlgos. for a flat fee, overwrite the fee property on the returned object
+ * @param amount - integer amount to send, in microAlgos
  * @param firstRound - integer first protocol round on which this txn is valid
  * @param lastRound - integer last protocol round on which this txn is valid
- * @param note - uint8array of arbitrary data
- * @param genesisHash - string
- * @param genesisID - string
+ * @param note - uint8array of arbitrary data for sender to store
+ * @param genesisHash - string specifies hash genesis block of network in use
+ * @param genesisID - string specifies genesis ID of network in use
  * @returns {Transaction}
  */
 function makePaymentTxn(from, to, fee, amount, firstRound, lastRound, note, genesisHash, genesisID) {
@@ -366,18 +366,18 @@ function makePaymentTxn(from, to, fee, amount, firstRound, lastRound, note, gene
 }
 
 /**
- * makeKeyRegistrationTxn takes key registration arguments and returns a transaction.Transaction object for
+ * makeKeyRegistrationTxn takes key registration arguments and returns a Transaction object for
  * that key registration operation
  *
- * @param from - string representation of Algorand address
- * @param fee - integer fee per byte. for a flat fee, overwrite the fee property on the returned object
+ * @param from - string representation of Algorand address of sender
+ * @param fee - integer fee per byte, in microAlgos. for a flat fee, overwrite the fee property on the returned object
  * @param firstRound - integer first protocol round on which this txn is valid
  * @param lastRound - integer last protocol round on which this txn is valid
- * @param note - uint8array of arbitrary data
- * @param genesisHash - string
- * @param genesisID - string
- * @param voteKey - string
- * @param selectionKey - string
+ * @param note - uint8array of arbitrary data for sender to store
+ * @param genesisHash - string specifies hash genesis block of network in use
+ * @param genesisID - string specifies genesis ID of network in use
+ * @param voteKey - string representation of voting key. for key deregistration, leave undefined
+ * @param selectionKey - string representation of selection key. for key deregistration, leave undefined 
  * @param voteFirst - first round on which voteKey is valid
  * @param voteLast - last round on which voteKey is valid
  * @param voteKeyDilution - integer
@@ -403,16 +403,16 @@ function makeKeyRegistrationTxn(from, fee, firstRound, lastRound, note, genesisH
     return new txnBuilder.Transaction(o);
 }
 
-/** makeAssetCreateTxn takes asset creation arguments and returns a transaction.Transaciton object
+/** makeAssetCreateTxn takes asset creation arguments and returns a Transaction object
  * for creating that asset
  *
- * @param from - string representation of Algorand address
- * @param fee - integer fee per byte. for a flat fee, overwrite the fee property on the returned object
+ * @param from - string representation of Algorand address of sender
+ * @param fee - integer fee per byte, in microAlgos. for a flat fee, overwrite the fee property on the returned object
  * @param firstRound - integer first protocol round on which this txn is valid
  * @param lastRound - integer last protocol round on which this txn is valid
- * @param note - uint8array of arbitrary data
- * @param genesisHash - string
- * @param genesisID - string
+ * @param note - uint8array of arbitrary data for sender to store
+ * @param genesisHash - string specifies hash genesis block of network in use
+ * @param genesisID - string specifies genesis ID of network in use
  * @param total - integer total supply of the asset
  * @param defaultFrozen - boolean whether asset accounts should default to being frozen
  * @param manager - string representation of Algorand address in charge of reserve, freeze, clawback, destruction, etc
@@ -450,19 +450,19 @@ function makeAssetCreateTxn(from, fee, firstRound, lastRound, note, genesisHash,
  * you must respecify existing addresses to keep them the same; leaving a field blank is the same as turning
  * that feature off for this asset
  *
- * @param from - string representation of Algorand address
- * @param fee - integer fee per byte. for a flat fee, overwrite the fee property on the returned object
+ * @param from - string representation of Algorand address of sender
+ * @param fee - integer fee per byte, in microAlgos. for a flat fee, overwrite the fee property on the returned object
  * @param firstRound - integer first protocol round on which this txn is valid
  * @param lastRound - integer last protocol round on which this txn is valid
- * @param note - uint8array of arbitrary data
- * @param genesisHash - string
- * @param genesisID - string
+ * @param note - uint8array of arbitrary data for sender to store
+ * @param genesisHash - string specifies hash genesis block of network in use
+ * @param genesisID - string specifies genesis ID of network in use
  * @param creator - string representation of Algorand address of creator
  * @param assetIndex - int asset index
  * @param manager - string representation of new asset manager Algorand address
  * @param reserve - string representation of new reserve Algorand address
  * @param freeze - string representation of new freeze manager Algorand address
- * @param clawback - string representaiton of new revocation manager Algorand address
+ * @param clawback - string representation of new revocation manager Algorand address
  * @returns {Transaction}
  */
 function makeAssetConfigTxn(from, fee, firstRound, lastRound, note, genesisHash, genesisID,
@@ -489,13 +489,13 @@ function makeAssetConfigTxn(from, fee, firstRound, lastRound, note, genesisHash,
 /** makeAssetDestroyTxn will allow the asset's manager to remove this asset from the ledger, so long
  * as all outstanding assets are held by the creator.
  *
- * @param from - string representation of Algorand address
- * @param fee - integer fee per byte. for a flat fee, overwrite the fee property on the returned object
+ * @param from - string representation of Algorand address of sender
+ * @param fee - integer fee per byte, in microAlgos. for a flat fee, overwrite the fee property on the returned object
  * @param firstRound - integer first protocol round on which this txn is valid
  * @param lastRound - integer last protocol round on which this txn is valid
- * @param note - uint8array of arbitrary data
- * @param genesisHash - string
- * @param genesisID - string
+ * @param note - uint8array of arbitrary data for sender to store
+ * @param genesisHash - string specifies hash genesis block of network in use
+ * @param genesisID - string specifies genesis ID of network in use
  * @param creator - string representation of Algorand address of creator
  * @param assetIndex - int asset index
  * @returns {Transaction}
@@ -517,15 +517,16 @@ function makeAssetDestroyTxn(from, fee, firstRound, lastRound, note, genesisHash
     return new txnBuilder.Transaction(o);
 }
 
-/** makeAssetFreezeTxn will allow the asset's freeze manager to freeze or un-freeze an account
+/** makeAssetFreezeTxn will allow the asset's freeze manager to freeze or un-freeze an account,
+ * blocking or allowing asset transfers to and from the targeted account.
  *
- * @param from - string representation of Algorand address
- * @param fee - integer fee per byte. for a flat fee, overwrite the fee property on the returned object
+ * @param from - string representation of Algorand address of sender
+ * @param fee - integer fee per byte, in microAlgos. for a flat fee, overwrite the fee property on the returned object
  * @param firstRound - integer first protocol round on which this txn is valid
  * @param lastRound - integer last protocol round on which this txn is valid
- * @param note - uint8array of arbitrary data
- * @param genesisHash - string
- * @param genesisID - string
+ * @param note - uint8array of arbitrary data for sender to store
+ * @param genesisHash - string specifies hash genesis block of network in use
+ * @param genesisID - string specifies genesis ID of network in use
  * @param creator - string representation of Algorand address of creator
  * @param assetIndex - int asset index
  * @param freezeTarget - string representation of Algorand address being frozen or unfrozen
@@ -553,19 +554,19 @@ function makeAssetFreezeTxn(from, fee, firstRound, lastRound, note, genesisHash,
 /** makeAssetTransferTxn allows for the creation of an asset transfer transaction.
  * Special case: to begin accepting assets, set amount=0 and from=to.
  *
- * @param from - string representation of Algorand address
+ * @param from - string representation of Algorand address of sender
  * @param to - string representation of Algorand address of asset recipient
  * @param closeRemainderTo - optional - string representation of Algorand address - if provided,
- * send all remaining assets after transfer to the closeRemainderTo address and close "from"'s asset holdings
- * @param revocationTarget - optional - string representaiton of Algorand address - if provided,
- * and if "from" is the asset's revocation manager, then deduct from revocationTarget rather than "from"
- * @param fee - integer fee per byte. for a flat fee, overwrite the fee property on the returned object
+ * send all remaining assets after transfer to the "closeRemainderTo" address and close "from"'s asset holdings
+ * @param revocationTarget - optional - string representation of Algorand address - if provided,
+ * and if "from" is the asset's revocation manager, then deduct from "revocationTarget" rather than "from"
+ * @param fee - integer fee per byte, in microAlgos. for a flat fee, overwrite the fee property on the returned object
  * @param amount - integer amount of assets to send
  * @param firstRound - integer first protocol round on which this txn is valid
  * @param lastRound - integer last protocol round on which this txn is valid
- * @param note - uint8array of arbitrary data
- * @param genesisHash - string
- * @param genesisID - string
+ * @param note - uint8array of arbitrary data for sender to store
+ * @param genesisHash - string specifies hash genesis block of network in use
+ * @param genesisID - string specifies genesis ID of network in use
  * @param creator - string representation of Algorand address of creator
  * @param assetIndex - int asset index
  * @returns {Transaction}

--- a/src/main.js
+++ b/src/main.js
@@ -335,6 +335,73 @@ function signLogicSigTransaction(txn, lsig) {
     };
 }
 
+
+/**
+ * makePaymentTxn takes payment arguments and returns a transaction.Transaction object representing that payment txn
+ * @param from - string representation of Algorand address
+ * @param to - string representation of Algorand address
+ * @param fee - integer fee per byte. for a flat fee, overwrite the fee property on the returned object
+ * @param amount - integer amount to send
+ * @param firstRound - integer first protocol round on which this txn is valid
+ * @param lastRound - integer last protocol round on which this txn is valid
+ * @param note - uint8array of arbitrary data
+ * @param genesisHash - string
+ * @param genesisID - string
+ * @returns {Transaction}
+ */
+function makePaymentTxn(from, to, fee, amount, firstRound, lastRound, note, genesisHash, genesisID) {
+    let o = {
+        "from": from,
+        "to": to,
+        "fee": fee,
+        "amount": amount,
+        "firstRound": firstRound,
+        "lastRound": lastRound,
+        "note": note,
+        "genesisHash": genesisHash,
+        "genesisID": genesisID,
+        "type": "pay"
+    };
+    return new txnBuilder.Transaction(o);
+}
+
+/**
+ * makeKeyRegistrationTxn takes key registration arguments and returns a transaction.Transaction object for
+ * that key registration operation
+ * @param from - string representation of Algorand address
+ * @param fee - integer fee per byte. for a flat fee, overwrite the fee property on the returned object
+ * @param firstRound - integer first protocol round on which this txn is valid
+ * @param lastRound - integer last protocol round on which this txn is valid
+ * @param note - uint8array of arbitrary data
+ * @param genesisHash - string
+ * @param genesisID - string
+ * @param voteKey - string
+ * @param selectionKey - string
+ * @param voteFirst - first round on which voteKey is valid
+ * @param voteLast - last round on which voteKey is valid
+ * @param voteKeyDilution - integer
+ * @returns {Transaction}
+ */
+function makeKeyRegistrationTxn(from, fee, firstRound, lastRound, note, genesisHash, genesisID,
+                                voteKey, selectionKey, voteFirst, voteLast, voteKeyDilution) {
+    let o = {
+        "from": from,
+        "fee": fee,
+        "firstRound": firstRound,
+        "lastRound": lastRound,
+        "note": note,
+        "genesisHash": genesisHash,
+        "voteKey": voteKey,
+        "selectionKey": selectionKey,
+        "voteFirst": voteFirst,
+        "voteLast": voteLast,
+        "voteKeyDilution": voteKeyDilution,
+        "genesisID": genesisID,
+        "type": "keyreg"
+    };
+    return new txnBuilder.Transaction(o);
+}
+
 module.exports = {
     isValidAddress,
     generateAccount,
@@ -362,4 +429,6 @@ module.exports = {
     assignGroupID,
     makeLogicSig,
     signLogicSigTransaction,
+    makePaymentTxn,
+    makeKeyRegistrationTxn,
 };

--- a/tests/5.Transaction.js
+++ b/tests/5.Transaction.js
@@ -1,7 +1,9 @@
+
 let assert = require('assert');
 
 let transaction = require("../src/transaction");
 let encoding = require("../src/encoding/encoding");
+let algosdk = require("../src/main");
 
 describe('Sign', function () {
     it('should not complain on a missing note', function () {
@@ -357,7 +359,7 @@ describe('Sign', function () {
                 "genesisID": genesisID
             };
             let expectedTxn = new transaction.Transaction(o);
-            let actualTxn = makePaymentTxn(from, to, fee, amount, firstRound, lastRound, note, genesisHash, genesisID);
+            let actualTxn = algosdk.makePaymentTxn(from, to, fee, amount, firstRound, lastRound, note, genesisHash, genesisID);
             assert.deepStrictEqual(expectedTxn, actualTxn);
         });
 
@@ -390,7 +392,7 @@ describe('Sign', function () {
                 "type": "keyreg"
             };
             let expectedTxn = new transaction.Transaction(o);
-            let actualTxn = makeKeyRegistrationTxn(from, fee, firstRound, lastRound, note, genesisHash, genesisID,
+            let actualTxn = algosdk.makeKeyRegistrationTxn(from, fee, firstRound, lastRound, note, genesisHash, genesisID,
                 voteKey, selectionKey, voteFirst, voteLast, voteKeyDilution);
             assert.deepStrictEqual(expectedTxn, actualTxn);
         });

--- a/tests/5.Transaction.js
+++ b/tests/5.Transaction.js
@@ -394,5 +394,177 @@ describe('Sign', function () {
                 voteKey, selectionKey, voteFirst, voteLast, voteKeyDilution);
             assert.deepStrictEqual(expectedTxn, actualTxn);
         });
+
+        it('should be able to use helper to make an asset create transaction', function() {
+            let addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4";
+            let fee = 10;
+            let defaultFrozen = false;
+            let genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=";
+            let total = 100;
+            let reserve = addr;
+            let freeze = addr;
+            let clawback = addr;
+            let unitName = "tst";
+            let assetName = "testcoin";
+            let genesisID = "";
+            let firstRound = 322575;
+            let lastRound = 322575;
+            let note = new Uint8Array([123, 12, 200]);
+            let o = {
+                "from": addr,
+                "fee": fee,
+                "firstRound": firstRound,
+                "lastRound": lastRound,
+                "note": note,
+                "genesisHash": genesisHash,
+                "t": total,
+                "df": defaultFrozen,
+                "un": unitName,
+                "an": assetName,
+                "assetManager": addr,
+                "assetReserve": reserve,
+                "assetFreeze": freeze,
+                "assetClawback": clawback,
+                "genesisID": genesisID,
+                "type": "acfg"
+            };
+            let expectedTxn = new transaction.Transaction(o);
+            let actualTxn = makeAssetCreateTxn(addr, fee, firstRound, lastRound, note, genesisHash, genesisID,
+                total, defaultFrozen, addr, reserve, freeze, clawback, unitName, assetName);
+            assert.deepStrictEqual(expectedTxn, actualTxn);
+        });
+
+        it('should be able to use helper to make an asset config transaction', function() {
+            let addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4";
+            let fee = 10;
+            let assetIndex = 1234;
+            let genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=";
+            let creator = addr;
+            let manager = addr;
+            let reserve = addr;
+            let freeze = addr;
+            let clawback = addr;
+            let genesisID = "";
+            let firstRound = 322575;
+            let lastRound = 322575;
+            let note = new Uint8Array([123, 12, 200]);
+            let o = {
+                "from": addr,
+                "fee": fee,
+                "firstRound": firstRound,
+                "lastRound": lastRound,
+                "genesisHash": genesisHash,
+                "genesisID": genesisID,
+                "creator": creator,
+                "index": assetIndex,
+                "assetManager": manager,
+                "assetReserve": reserve,
+                "assetFreeze": freeze,
+                "assetClawback": clawback,
+                "type": "acfg",
+                "note": note
+            };
+            let expectedTxn = new transaction.Transaction(o);
+            let actualTxn = makeAssetConfigTxn(addr, fee, firstRound, lastRound, note, genesisHash, genesisID,
+                creator, assetIndex, manager, reserve, freeze, clawback);
+            assert.deepStrictEqual(expectedTxn, actualTxn);
+        });
+
+        it('should be able to use helper to make an asset destroy transaction', function() {
+            let addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4";
+            let fee = 10;
+            let assetIndex = 1234;
+            let genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=";
+            let creator = addr;
+            let genesisID = "";
+            let firstRound = 322575;
+            let lastRound = 322575;
+            let note = new Uint8Array([123, 12, 200]);
+            let o = {
+                "from": addr,
+                "fee": fee,
+                "firstRound": firstRound,
+                "lastRound": lastRound,
+                "genesisHash": genesisHash,
+                "genesisID": genesisID,
+                "creator": creator,
+                "index": assetIndex,
+                "type": "acfg",
+                "note": note
+            };
+            let expectedTxn = new transaction.Transaction(o);
+            let actualTxn = makeAssetDestroyTxn(addr, fee, firstRound, lastRound, note, genesisHash, genesisID,
+                creator, assetIndex);
+            assert.deepStrictEqual(expectedTxn, actualTxn);
+        });
+
+        it('should be able to use helper to make an asset transfer transaction', function() {
+            let addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4";
+            let fee = 10;
+            let sender = addr;
+            let recipient = addr;
+            let revocationTarget = addr;
+            let closeRemainderTo = addr;
+            let assetIndex = 1234;
+            let amount = 100;
+            let genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=";
+            let creator = addr;
+            let genesisID = "";
+            let firstRound = 322575;
+            let lastRound = 322575;
+            let note = new Uint8Array([123, 12, 200]);
+            let o = o = {
+                "type": "axfer",
+                "from": sender,
+                "to": recipient,
+                "amount": amount,
+                "fee": fee,
+                "firstRound": firstRound,
+                "lastRound": lastRound,
+                "genesisHash": genesisHash,
+                "genesisID": genesisID,
+                "creator": creator,
+                "index": assetIndex,
+                "note": note,
+                "assetRevocationTarget": revocationTarget,
+                "closeRemainderTo": closeRemainderTo
+            };
+            let expectedTxn = new transaction.Transaction(o);
+            let actualTxn = makeAssetTransferTxn(sender, recipient, closeRemainderTo, revocationTarget,
+                fee, firstRound, lastRound, note, genesisHash, genesisID,
+                creator, assetIndex);
+            assert.deepStrictEqual(expectedTxn, actualTxn);
+        });
+
+        it('should be able to use helper to make an asset freeze transaction', function() {
+            let addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4";
+            let fee = 10;
+            let assetIndex = 1234;
+            let genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=";
+            let creator = addr;
+            let freezeTarget = addr;
+            let genesisID = "";
+            let firstRound = 322575;
+            let lastRound = 322575;
+            let freezeState = true;
+            let note = new Uint8Array([123, 12, 200]);
+            let o = {
+                "from": addr,
+                "fee": fee,
+                "firstRound": firstRound,
+                "lastRound": lastRound,
+                "genesisHash": genesisHash,
+                "type": "afrz",
+                "freezeAccount": freezeTarget,
+                "index": assetIndex,
+                "creator" : creator,
+                "freezeState" : freezeState,
+                "note": note
+            };
+            let expectedTxn = new transaction.Transaction(o);
+            let actualTxn = makeAssetFreezeTxn(addr, fee, firstRound, lastRound, note, genesisHash, genesisID,
+                creator, assetIndex, freezeTarget, freezeState);
+            assert.deepStrictEqual(expectedTxn, actualTxn);
+        });
     });
 });

--- a/tests/5.Transaction.js
+++ b/tests/5.Transaction.js
@@ -431,7 +431,7 @@ describe('Sign', function () {
                 "type": "acfg"
             };
             let expectedTxn = new transaction.Transaction(o);
-            let actualTxn = makeAssetCreateTxn(addr, fee, firstRound, lastRound, note, genesisHash, genesisID,
+            let actualTxn = algosdk.makeAssetCreateTxn(addr, fee, firstRound, lastRound, note, genesisHash, genesisID,
                 total, defaultFrozen, addr, reserve, freeze, clawback, unitName, assetName);
             assert.deepStrictEqual(expectedTxn, actualTxn);
         });
@@ -467,7 +467,7 @@ describe('Sign', function () {
                 "note": note
             };
             let expectedTxn = new transaction.Transaction(o);
-            let actualTxn = makeAssetConfigTxn(addr, fee, firstRound, lastRound, note, genesisHash, genesisID,
+            let actualTxn = algosdk.makeAssetConfigTxn(addr, fee, firstRound, lastRound, note, genesisHash, genesisID,
                 creator, assetIndex, manager, reserve, freeze, clawback);
             assert.deepStrictEqual(expectedTxn, actualTxn);
         });
@@ -495,7 +495,7 @@ describe('Sign', function () {
                 "note": note
             };
             let expectedTxn = new transaction.Transaction(o);
-            let actualTxn = makeAssetDestroyTxn(addr, fee, firstRound, lastRound, note, genesisHash, genesisID,
+            let actualTxn = algosdk.makeAssetDestroyTxn(addr, fee, firstRound, lastRound, note, genesisHash, genesisID,
                 creator, assetIndex);
             assert.deepStrictEqual(expectedTxn, actualTxn);
         });
@@ -515,7 +515,7 @@ describe('Sign', function () {
             let firstRound = 322575;
             let lastRound = 322575;
             let note = new Uint8Array([123, 12, 200]);
-            let o = o = {
+            let o = {
                 "type": "axfer",
                 "from": sender,
                 "to": recipient,
@@ -532,8 +532,8 @@ describe('Sign', function () {
                 "closeRemainderTo": closeRemainderTo
             };
             let expectedTxn = new transaction.Transaction(o);
-            let actualTxn = makeAssetTransferTxn(sender, recipient, closeRemainderTo, revocationTarget,
-                fee, firstRound, lastRound, note, genesisHash, genesisID,
+            let actualTxn = algosdk.makeAssetTransferTxn(sender, recipient, closeRemainderTo, revocationTarget,
+                fee, amount, firstRound, lastRound, note, genesisHash, genesisID,
                 creator, assetIndex);
             assert.deepStrictEqual(expectedTxn, actualTxn);
         });
@@ -564,7 +564,7 @@ describe('Sign', function () {
                 "note": note
             };
             let expectedTxn = new transaction.Transaction(o);
-            let actualTxn = makeAssetFreezeTxn(addr, fee, firstRound, lastRound, note, genesisHash, genesisID,
+            let actualTxn = algosdk.makeAssetFreezeTxn(addr, fee, firstRound, lastRound, note, genesisHash, genesisID,
                 creator, assetIndex, freezeTarget, freezeState);
             assert.deepStrictEqual(expectedTxn, actualTxn);
         });

--- a/tests/5.Transaction.js
+++ b/tests/5.Transaction.js
@@ -333,4 +333,66 @@ describe('Sign', function () {
 
         });
     });
+
+    describe('transaction making functions', function () {
+        it('should be able to use helper to make a payment transaction', function() {
+            let from = "XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU";
+            let to = "UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM";
+            let fee = 10;
+            let amount = 847;
+            let firstRound = 51;
+            let lastRound = 61;
+            let note = new Uint8Array([123, 12, 200]);
+            let genesisHash = "JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=";
+            let genesisID = "";
+            let o = {
+                "from": from,
+                "to": to,
+                "fee": fee,
+                "amount": amount,
+                "firstRound": firstRound,
+                "lastRound": lastRound,
+                "note": note,
+                "genesisHash": genesisHash,
+                "genesisID": genesisID
+            };
+            let expectedTxn = new transaction.Transaction(o);
+            let actualTxn = makePaymentTxn(from, to, fee, amount, firstRound, lastRound, note, genesisHash, genesisID);
+            assert.deepStrictEqual(expectedTxn, actualTxn);
+        });
+
+        it('should be able to use helper to make a keyreg transaction', function() {
+            let from = "XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU";
+            let fee = 10;
+            let firstRound = 51;
+            let lastRound = 61;
+            let note = new Uint8Array([123, 12, 200]);
+            let genesisHash = "JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=";
+            let genesisID = "";
+            let voteKey = "5/D4TQaBHfnzHI2HixFV9GcdUaGFwgCQhmf0SVhwaKE=";
+            let selectionKey = "oImqaSLjuZj63/bNSAjd+eAh5JROOJ6j1cY4eGaJGX4=";
+            let voteKeyDilution = 1234;
+            let voteFirst = 123;
+            let voteLast = 456;
+            let o = {
+                "from": from,
+                "fee": fee,
+                "firstRound": firstRound,
+                "lastRound": lastRound,
+                "note": note,
+                "genesisHash": genesisHash,
+                "voteKey": voteKey,
+                "selectionKey": selectionKey,
+                "voteFirst": voteFirst,
+                "voteLast": voteLast,
+                "voteKeyDilution": voteKeyDilution,
+                "genesisID": genesisID,
+                "type": "keyreg"
+            };
+            let expectedTxn = new transaction.Transaction(o);
+            let actualTxn = makeKeyRegistrationTxn(from, fee, firstRound, lastRound, note, genesisHash, genesisID,
+                voteKey, selectionKey, voteFirst, voteLast, voteKeyDilution);
+            assert.deepStrictEqual(expectedTxn, actualTxn);
+        });
+    });
 });


### PR DESCRIPTION
## Summary
Previous asset PRs added support for assets to class `Transaction`, but a user would have to read the code and tests to see how assets work. This PR proposes to add `make[Foo]Txn` helpers and similar to make transaction creation easier. It also proposes to update the `README.md` with usage.

## See also
https://github.com/algorand/js-algorand-sdk/issues/69