### PR TITLE
Delete `afrz` in transaction if false

### DIFF
--- a/src/transaction.js
+++ b/src/transaction.js
@@ -237,6 +237,7 @@ class Transaction {
             if (!txn.amt) delete txn.amt;
             if (!txn.fee) delete txn.fee;
             if (!txn.gen) delete txn.gen;
+            if (!txn.afrz) delete txn.afrz;
             if (txn.grp === undefined) delete txn.grp;
 
             return txn;
@@ -303,7 +304,9 @@ class Transaction {
             txn.to = address.decode(address.encode(new Uint8Array(txnForEnc.arcv)));
         }
         else if (txnForEnc.type === "afrz") {
-            txn.freezeState = txnForEnc.afrz;
+            if (txnForEnc.afrz !== undefined) {
+                txn.freezeState = txnForEnc.afrz;
+            }
             if (txnForEnc.faid !== undefined) {
                 txn.assetIndex = txnForEnc.faid;
             }

--- a/tests/7.AlgoSDK.js
+++ b/tests/7.AlgoSDK.js
@@ -330,7 +330,6 @@ describe('Algosdk (AKA end to end)', function () {
             };
             sk = algosdk.mnemonicToSecretKey(sk);
             let js_dec = algosdk.signTransaction(o, sk.sk);
-            console.log(Buffer.from(js_dec.blob).toString('base64'));
             assert.deepStrictEqual(Buffer.from(js_dec.blob), Buffer.from(golden, "base64"));
         });
 


### PR DESCRIPTION
The freeze state (in `Transaction`) is `omitifempty`. So, it needs to be deleted if false.

Testing: ran `it('should be able to use helper to make an asset freeze transaction'` with `freezeState=false`. It fails before this change, and passes after.
Also removed a noticed unnecessary `console.log`.