### PR TITLE
Add asset decimals field

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ let fee = 10; // the number of microAlgos per byte to pay as a transaction fee
 let defaultFrozen = false; // whether user accounts will need to be unfrozen before transacting
 let genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="; // hash of the genesis block of the network to be used
 let totalIssuance = 100; // total number of this asset in circulation
-let decimalPlaces = 0; // hint that the units of this asset are whole-integer amounts
+let decimals = 0; // hint that the units of this asset are whole-integer amounts
 let reserve = addr; // specified address is considered the asset reserve (it has no special privileges, this is only informational)
 let freeze = addr; // specified address can freeze or unfreeze user asset holdings
 let clawback = addr; // specified address can revoke user asset holdings and send them to other addresses
@@ -339,7 +339,7 @@ let assetMetadataHash = "16efaa3924a6fd9d3a4824799a4ac65d"; // optional hash com
 
 // signing and sending "txn" allows "addr" to create an asset
 let txn = algosdk.makeAssetCreateTxn(addr, fee, firstRound, lastRound, note,
-    genesisHash, genesisID, totalIssuance, decimalPlaces, defaultFrozen, manager, reserve, freeze, clawback,
+    genesisHash, genesisID, totalIssuance, decimals, defaultFrozen, manager, reserve, freeze, clawback,
     unitName, assetName, assetURL, assetMetadataHash);
 ```
 

--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ let fee = 10; // the number of microAlgos per byte to pay as a transaction fee
 let defaultFrozen = false; // whether user accounts will need to be unfrozen before transacting
 let genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="; // hash of the genesis block of the network to be used
 let totalIssuance = 100; // total number of this asset in circulation
+let decimalPlaces = 0; // hint that the units of this asset are whole-integer amounts
 let reserve = addr; // specified address is considered the asset reserve (it has no special privileges, this is only informational)
 let freeze = addr; // specified address can freeze or unfreeze user asset holdings
 let clawback = addr; // specified address can revoke user asset holdings and send them to other addresses
@@ -338,7 +339,7 @@ let assetMetadataHash = "16efaa3924a6fd9d3a4824799a4ac65d"; // optional hash com
 
 // signing and sending "txn" allows "addr" to create an asset
 let txn = algosdk.makeAssetCreateTxn(addr, fee, firstRound, lastRound, note,
-    genesisHash, genesisID, totalIssuance, defaultFrozen, manager, reserve, freeze, clawback,
+    genesisHash, genesisID, totalIssuance, decimalPlaces, defaultFrozen, manager, reserve, freeze, clawback,
     unitName, assetName, assetURL, assetMetadataHash);
 ```
 

--- a/src/logicTemplates/htlc.js
+++ b/src/logicTemplates/htlc.js
@@ -9,7 +9,7 @@ class HTLC {
      *
      * More formally -
      * Algos can be transferred under only two circumstances:
-     * 1. To receiver if hash_function(arg_0) = hash_value
+     * 1. To owner if hash_function(arg_0) = hash_value
      * 2. To owner if txn.FirstValid > expiry_round
      * ...
      *

--- a/src/logicTemplates/htlc.js
+++ b/src/logicTemplates/htlc.js
@@ -10,7 +10,7 @@ class HTLC {
      * More formally -
      * Algos can be transferred under only two circumstances:
      * 1. To owner if hash_function(arg_0) = hash_value
-     * 2. To owner if txn.FirstValid > expiry_round
+     * 2. To receiver if txn.FirstValid > expiry_round
      * ...
      *
      *Parameters

--- a/src/logicTemplates/htlc.js
+++ b/src/logicTemplates/htlc.js
@@ -9,8 +9,8 @@ class HTLC {
      *
      * More formally -
      * Algos can be transferred under only two circumstances:
-     * 1. To owner if hash_function(arg_0) = hash_value
-     * 2. To receiver if txn.FirstValid > expiry_round
+     * 1. To receiver if hash_function(arg_0) = hash_value
+     * 2. To owner if txn.FirstValid > expiry_round
      * ...
      *
      *Parameters

--- a/src/main.js
+++ b/src/main.js
@@ -416,6 +416,7 @@ function makeKeyRegistrationTxn(from, fee, firstRound, lastRound, note, genesisH
  * @param genesisHash - string specifies hash genesis block of network in use
  * @param genesisID - string specifies genesis ID of network in use
  * @param total - integer total supply of the asset
+ * @param decimals - integer number of decimals for asset unit calculation
  * @param defaultFrozen - boolean whether asset accounts should default to being frozen
  * @param manager - string representation of Algorand address in charge of reserve, freeze, clawback, destruction, etc
  * @param reserve - string representation of Algorand address representing asset reserve
@@ -428,8 +429,8 @@ function makeKeyRegistrationTxn(from, fee, firstRound, lastRound, note, genesisH
  * @returns {Transaction}
  */
 function makeAssetCreateTxn(from, fee, firstRound, lastRound, note, genesisHash, genesisID,
-                            total, defaultFrozen, manager, reserve, freeze, clawback,
-                            unitName, assetName, assetURL, assetMetadataHash) {
+                            total, decimals, defaultFrozen, manager, reserve, freeze,
+                            clawback, unitName, assetName, assetURL, assetMetadataHash) {
     let o = {
         "from": from,
         "fee": fee,
@@ -438,6 +439,7 @@ function makeAssetCreateTxn(from, fee, firstRound, lastRound, note, genesisHash,
         "note": note,
         "genesisHash": genesisHash,
         "assetTotal": total,
+        "assetDecimals": decimals,
         "assetDefaultFrozen": defaultFrozen,
         "assetUnitName": unitName,
         "assetName": assetName,

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -8,6 +8,7 @@ const ALGORAND_TRANSACTION_LENGTH = 52;
 const ALGORAND_MIN_TX_FEE = 1000; // version v5
 const ALGORAND_TRANSACTION_LEASE_LENGTH = 32;
 const ALGORAND_MAX_TX_GROUP_SIZE = 16;
+const ALGORAND_MAX_ASSET_DECIMALS = 19;
 
 /**
  * Transaction enables construction of Algorand transactions
@@ -39,7 +40,7 @@ class Transaction {
         if (!Number.isSafeInteger(firstRound) || firstRound < 0) throw Error("firstRound must be a positive number");
         if (!Number.isSafeInteger(lastRound) || lastRound < 0) throw Error("lastRound must be a positive number");
         if (assetTotal !== undefined && (!Number.isSafeInteger(assetTotal) || assetTotal < 0)) throw Error("Total asset issuance must be a positive number and smaller than 2^53-1");
-        if (assetDecimals !== undefined && (!Number.isSafeInteger(assetDecimals) || assetDecimals < 0)) throw Error("assetDecimals must be a positive number and smaller than 2^53-1");
+        if (assetDecimals !== undefined && (!Number.isSafeInteger(assetDecimals) || assetDecimals < 0 || assetDecimals > ALGORAND_MAX_ASSET_DECIMALS)) throw Error("assetDecimals must be a positive number and smaller than " + ALGORAND_MAX_ASSET_DECIMALS.toString());
         if (assetIndex !== undefined && (!Number.isSafeInteger(assetIndex) || assetIndex < 0)) throw Error("Asset index must be a positive number and smaller than 2^53-1");
 
         if (note !== undefined) {

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -15,7 +15,7 @@ const ALGORAND_MAX_TX_GROUP_SIZE = 16;
 class Transaction {
     constructor({from, to, fee, amount, firstRound, lastRound, note, genesisID, genesisHash, lease,
                  closeRemainderTo, voteKey, selectionKey, voteFirst, voteLast, voteKeyDilution, 
-                 assetIndex, assetTotal, assetDefaultFrozen, assetManager, assetReserve,
+                 assetIndex, assetTotal, assetDecimals, assetDefaultFrozen, assetManager, assetReserve,
                  assetFreeze, assetClawback, assetUnitName, assetName, assetURL, assetMetadataHash,
                  freezeAccount, freezeState, assetRevocationTarget, type="pay", flatFee=false}) {
         this.name = "Transaction";
@@ -39,6 +39,7 @@ class Transaction {
         if (!Number.isSafeInteger(firstRound) || firstRound < 0) throw Error("firstRound must be a positive number");
         if (!Number.isSafeInteger(lastRound) || lastRound < 0) throw Error("lastRound must be a positive number");
         if (assetTotal !== undefined && (!Number.isSafeInteger(assetTotal) || assetTotal < 0)) throw Error("Total asset issuance must be a positive number and smaller than 2^53-1");
+        if (assetDecimals !== undefined && (!Number.isSafeInteger(assetDecimals) || assetDecimals < 0)) throw Error("assetDecimals must be a positive number and smaller than 2^53-1");
         if (assetIndex !== undefined && (!Number.isSafeInteger(assetIndex) || assetIndex < 0)) throw Error("Asset index must be a positive number and smaller than 2^53-1");
 
         if (note !== undefined) {
@@ -64,7 +65,7 @@ class Transaction {
         Object.assign(this, {
             from, to, fee, amount, firstRound, lastRound, note, genesisID, genesisHash, lease,
             closeRemainderTo, voteKey, selectionKey, voteFirst, voteLast, voteKeyDilution,
-            assetIndex, assetTotal, assetDefaultFrozen, assetManager, assetReserve,
+            assetIndex, assetTotal, assetDecimals, assetDefaultFrozen, assetManager, assetReserve,
             assetFreeze, assetClawback, assetUnitName, assetName, assetURL, assetMetadataHash,
             freezeAccount, freezeState, assetRevocationTarget, type
         });
@@ -156,6 +157,7 @@ class Transaction {
                 "apar": {
                     "t": this.assetTotal,
                     "df": this.assetDefaultFrozen,
+                    "dc": this.assetDecimals,
                 }
             };
             if (this.assetManager !== undefined) txn.apar.m = Buffer.from(this.assetManager.publicKey);
@@ -185,11 +187,13 @@ class Transaction {
                 (!txn.apar.f) &&
                 (!txn.apar.c) &&
                 (!txn.apar.au) &&
-                (!txn.apar.am)){
+                (!txn.apar.am) &&
+                (!txn.apar.dc)){
                     delete txn.apar
             }
             else {
                 if (!txn.apar.t) delete txn.apar.t;
+                if (!txn.apar.dc) delete txn.apar.dc;
                 if (!txn.apar.un) delete txn.apar.un;
                 if (!txn.apar.an) delete txn.apar.an;
                 if (!txn.apar.df) delete txn.apar.df;
@@ -299,6 +303,7 @@ class Transaction {
             if (txnForEnc.apar !== undefined){
                 txn.assetTotal = txnForEnc.apar.t;
                 txn.assetDefaultFrozen = txnForEnc.apar.df;
+                if (txnForEnc.apar.dc !== undefined) txn.assetDecimals = txnForEnc.apar.dc;
                 if (txnForEnc.apar.m !== undefined) txn.assetManager = address.decode(address.encode(new Uint8Array(txnForEnc.apar.m)));
                 if (txnForEnc.apar.r !== undefined) txn.assetReserve = address.decode(address.encode(new Uint8Array(txnForEnc.apar.r)));
                 if (txnForEnc.apar.f !== undefined) txn.assetFreeze = address.decode(address.encode(new Uint8Array(txnForEnc.apar.f)));

--- a/tests/5.Transaction.js
+++ b/tests/5.Transaction.js
@@ -404,6 +404,7 @@ describe('Sign', function () {
             let defaultFrozen = false;
             let genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=";
             let total = 100;
+            let decimals = 0;
             let reserve = addr;
             let freeze = addr;
             let clawback = addr;
@@ -423,6 +424,7 @@ describe('Sign', function () {
                 "note": note,
                 "genesisHash": genesisHash,
                 "assetTotal": total,
+                "assetDecimals": decimals,
                 "assetDefaultFrozen": defaultFrozen,
                 "assetUnitName": unitName,
                 "assetName": assetName,
@@ -437,7 +439,7 @@ describe('Sign', function () {
             };
             let expectedTxn = new transaction.Transaction(o);
             let actualTxn = algosdk.makeAssetCreateTxn(addr, fee, firstRound, lastRound, note, genesisHash, genesisID,
-                total, defaultFrozen, addr, reserve, freeze, clawback, unitName, assetName, assetURL, assetMetadataHash);
+                total, decimals, defaultFrozen, addr, reserve, freeze, clawback, unitName, assetName, assetURL, assetMetadataHash);
             assert.deepStrictEqual(expectedTxn, actualTxn);
         });
 

--- a/tests/7.AlgoSDK.js
+++ b/tests/7.AlgoSDK.js
@@ -359,8 +359,34 @@ describe('Algosdk (AKA end to end)', function () {
                 "type": "acfg"
             };
             sk = algosdk.mnemonicToSecretKey(sk);
-            let algoTxn = new transaction.Transaction(createTxn);
+            let js_dec_create = algosdk.signTransaction(createTxn, sk.sk);
+            assert.deepStrictEqual(Buffer.from(js_dec_create.blob), Buffer.from(golden, "base64"));
+        });
 
+        it('should return a blob that matches the go code for asset create with decimals', function() {
+            let address = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4";
+            let golden = "gqNzaWfEQCj5xLqNozR5ahB+LNBlTG+d0gl0vWBrGdAXj1ibsCkvAwOsXs5KHZK1YdLgkdJecQiWm4oiZ+pm5Yg0m3KFqgqjdHhuh6RhcGFyiqJhbcQgZkFDUE80blJnTzU1ajFuZEFLM1c2U2djNEFQa2N5RmiiYW6odGVzdGNvaW6iYXWnd2Vic2l0ZaFjxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aJkYwGhZsQgCfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f2hbcQgCfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f2hcsQgCfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f2hdGSidW6jdHN0o2ZlZc0P3KJmds4ABOwPomdoxCBIY7UYpLPITsgQ8i1PEIHLD3HwWaesIN7GL39w5Qk6IqJsds4ABO/3o3NuZMQgCfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f2kdHlwZaRhY2Zn";
+            let sk = "awful drop leaf tennis indoor begin mandate discover uncle seven only coil atom any hospital uncover make any climb actor armed measure need above hundred";
+            let createTxn = {
+                "from": address,
+                "fee": 10,
+                "firstRound": 322575,
+                "lastRound": 323575,
+                "genesisHash": "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=",
+                "assetTotal": 100,
+                "assetDecimals": 1,
+                "assetDefaultFrozen": false,
+                "assetManager": address,
+                "assetReserve": address,
+                "assetFreeze": address,
+                "assetClawback": address,
+                "assetUnitName": "tst",
+                "assetName": "testcoin",
+                "assetURL": "website",
+                "assetMetadataHash": "fACPO4nRgO55j1ndAK3W6Sgc4APkcyFh",
+                "type": "acfg"
+            };
+            sk = algosdk.mnemonicToSecretKey(sk);
             let js_dec_create = algosdk.signTransaction(createTxn, sk.sk);
             assert.deepStrictEqual(Buffer.from(js_dec_create.blob), Buffer.from(golden, "base64"));
         });


### PR DESCRIPTION
Add a decimals/precision field to asset creation.

### Testing
Automatic unit testing. `algorand-sdk-testing` will fail due to signature mismatch, see pull 30 in "See also" section.

### See also
https://github.com/algorand/algorand-sdk-testing/pull/30
https://github.com/algorand/js-algorand-sdk/issues/96
algorand/go-algorand#601