### PR TITLE
Extra functions in algosdk

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -335,6 +335,33 @@ function signLogicSigTransaction(txn, lsig) {
     };
 }
 
+/**
+ * signLogicSigTransactionObject takes transaction.Transaction and a LogicSig object and returns a logicsig
+ * transaction which is a blob representing a transaction and logicsig object.
+ * @param {Object} txn transaction.Transaction
+ * @param {LogicSig} lsig logicsig object
+ * @returns {Object} Object containing txID and blob representing signed transaction.
+ */
+function signLogicSigTransactionObject(txn, lsig) {
+    let lstx = {
+        lsig: lsig.get_obj_for_encoding(),
+        txn: txn.get_obj_for_encoding()
+    };
+
+    return {
+        "txID": txn.txID().toString(),
+        "blob": encoding.encode(lstx)
+    };
+}
+
+/**
+ * logicSigFromByte accepts encoded logic sig bytes and attempts to call logicsig.fromByte on it,
+ * returning the result
+ */
+function logicSigFromByte(encoded) {
+    return logicsig.LogicSig.fromByte(encoded);
+}
+
 
 /**
  * makePaymentTxn takes payment arguments and returns a Transaction object
@@ -624,6 +651,8 @@ module.exports = {
     assignGroupID,
     makeLogicSig,
     signLogicSigTransaction,
+    signLogicSigTransactionObject,
+    logicSigFromByte,
     makePaymentTxn,
     makeKeyRegistrationTxn,
     makeAssetCreateTxn,

--- a/src/main.js
+++ b/src/main.js
@@ -312,7 +312,7 @@ function makeLogicSig(program, args) {
 /**
  * signLogicSigTransaction takes  a raw transaction and a LogicSig object and returns a logicsig
  * transaction which is a blob representing a transaction and logicsig object.
- * @param {Object} txn transaction object
+ * @param {Dict} txn transaction constructors dictionary
  * @param {LogicSig} lsig logicsig object
  * @returns {Object} Object containing txID and blob representing signed transaction.
  * @throws error on failure

--- a/src/main.js
+++ b/src/main.js
@@ -312,7 +312,7 @@ function makeLogicSig(program, args) {
 /**
  * signLogicSigTransaction takes  a raw transaction and a LogicSig object and returns a logicsig
  * transaction which is a blob representing a transaction and logicsig object.
- * @param {Dict} txn transaction constructors dictionary
+ * @param {Object} dictionary containing constructor arguments for a transaction
  * @param {LogicSig} lsig logicsig object
  * @returns {Object} Object containing txID and blob representing signed transaction.
  * @throws error on failure
@@ -321,18 +321,8 @@ function signLogicSigTransaction(txn, lsig) {
     if (!lsig.verify(address.decode(txn.from).publicKey)) {
         throw new Error("invalid signature");
     }
-
     let algoTxn = new txnBuilder.Transaction(txn);
-
-    let lstx = {
-        lsig: lsig.get_obj_for_encoding(),
-        txn: algoTxn.get_obj_for_encoding()
-    };
-
-    return {
-        "txID": algoTxn.txID().toString(),
-        "blob": encoding.encode(lstx)
-    };
+    return signLogicSigTransactionObject(algoTxn, lsig);
 }
 
 /**


### PR DESCRIPTION
## Summary
Add new functions in `algosdk` that expose internal functions developers need, or that accept slightly different arguments:
- `logicSigFromByte` takes encoded bytes to produce a logicsig
- `signLogicSigTransactionObject` is as `signLogicSigTransaction`, but it expects already-constructed `Transaction` rather than a dict of constructor arguments. This allows the use of groupID in combination with logicsigs.

### See also
Resolves #100 `signLogicSigTransactionObject`
Resolves #101 `logicSigFromByte`
Closes #109 out