### PR TITLE
Transaction accepts params object

### DIFF
--- a/src/client/algod.js
+++ b/src/client/algod.js
@@ -249,6 +249,23 @@ function Algod(token = '', baseServer = "http://r2.algorand.network", port = 418
     };
 
     /**
+     * suggestParams returns to common needed parameters for a new transaction, in a format the transaction builder expects
+     * @param headers, optional
+     * @returns {Object}
+     */
+    this.suggestParams = async function (headers={}) {
+        let result = await this.getTransactionParams(headers);
+        return {
+            "flatFee": false,
+            "fee": result.fee,
+            "firstRound": result.lastRound,
+            "lastRound": result.lastRound + 1000,
+            "genesisID": result.genesisID,
+            "genesisHash": result.genesishashb64,
+        };
+    };
+
+    /**
      * block gets the block info for the given round This call blocks
      * @param roundNumber
      * @param headers, optional

--- a/src/main.js
+++ b/src/main.js
@@ -621,7 +621,7 @@ function makeAssetConfigTxnWithParams(from, note, assetIndex,
     }
     let o = {
         "from": from,
-        "params":, params,
+        "params": params,
         "assetIndex": assetIndex,
         "assetManager": manager,
         "assetReserve": reserve,

--- a/src/main.js
+++ b/src/main.js
@@ -365,20 +365,45 @@ function logicSigFromByte(encoded) {
  * @param note - uint8array of arbitrary data for sender to store
  * @param genesisHash - string specifies hash genesis block of network in use
  * @param genesisID - string specifies genesis ID of network in use
+ * @Deprecated in version 2.0 this will change to use the "WithParams" signature.
  * @returns {Transaction}
  */
 function makePaymentTxn(from, to, fee, amount, closeRemainderTo, firstRound, lastRound, note, genesisHash, genesisID) {
+    let params = {
+        "genesisHash": genesisHash,
+        "genesisID": genesisID,
+        "firstRound": firstRound,
+        "lastRound": lastRound,
+        "fee": fee
+    };
+    return makePaymentTxnWithParams(from, to, amount, closeRemainderTo, note, params);
+}
+
+/**
+ * makePaymentTxnWithParams takes payment arguments and returns a Transaction object
+ * @param from - string representation of Algorand address of sender
+ * @param to - string representation of Algorand address of recipient
+ * @param amount - integer amount to send, in microAlgos
+ * @param closeRemainderTo - optionally close out remaining account balance to this account, represented as string rep of Algorand address
+ * @param note - uint8array of arbitrary data for sender to store
+ * @param params - a dict holding common-to-all-txns args:
+ * fee - integer fee per byte, in microAlgos. for a flat fee, set flatFee to true
+ * flatFee - bool optionally set this to true to specify fee as microalgos-per-txn
+ * firstRound - integer first protocol round on which this txn is valid
+ * lastRound - integer last protocol round on which this txn is valid
+ * genesisHash - string specifies hash genesis block of network in use
+ * genesisID - string specifies genesis ID of network in use
+ * @Deprecated in version 2.0 this will change to use the "WithParams" signature.
+ * @returns {Transaction}
+ */
+function makePaymentTxnWithParams(from, to, amount, closeRemainderTo, note, params) {
     let o = {
         "from": from,
         "to": to,
-        "fee": fee,
         "amount": amount,
         "closeRemainderTo": closeRemainderTo,
-        "firstRound": firstRound,
-        "lastRound": lastRound,
         "note": note,
-        "genesisHash": genesisHash,
-        "genesisID": genesisID,
+        "params": params,
         "type": "pay"
     };
     return new txnBuilder.Transaction(o);
@@ -396,27 +421,56 @@ function makePaymentTxn(from, to, fee, amount, closeRemainderTo, firstRound, las
  * @param genesisHash - string specifies hash genesis block of network in use
  * @param genesisID - string specifies genesis ID of network in use
  * @param voteKey - string representation of voting key. for key deregistration, leave undefined
- * @param selectionKey - string representation of selection key. for key deregistration, leave undefined 
+ * @param selectionKey - string representation of selection key. for key deregistration, leave undefined
  * @param voteFirst - first round on which voteKey is valid
  * @param voteLast - last round on which voteKey is valid
  * @param voteKeyDilution - integer
+ * @Deprecated in version 2.0 this will change to use the "WithParams" signature.
  * @returns {Transaction}
  */
 function makeKeyRegistrationTxn(from, fee, firstRound, lastRound, note, genesisHash, genesisID,
                                 voteKey, selectionKey, voteFirst, voteLast, voteKeyDilution) {
-    let o = {
-        "from": from,
-        "fee": fee,
+    let params = {
+        "genesisHash": genesisHash,
+        "genesisID": genesisID,
         "firstRound": firstRound,
         "lastRound": lastRound,
+        "fee": fee
+    };
+    return makeKeyRegistrationTxnWithParams(from, note, voteKey, selectionKey, voteFirst, voteLast, voteKeyDilution, params);
+}
+
+/**
+ * makeKeyRegistrationTxnWithParams takes key registration arguments and returns a Transaction object for
+ * that key registration operation
+ *
+ * @param from - string representation of Algorand address of sender
+ * @param note - uint8array of arbitrary data for sender to store
+ * @param voteKey - string representation of voting key. for key deregistration, leave undefined
+ * @param selectionKey - string representation of selection key. for key deregistration, leave undefined
+ * @param voteFirst - first round on which voteKey is valid
+ * @param voteLast - last round on which voteKey is valid
+ * @param voteKeyDilution - integer
+ * @param params - a dict holding common-to-all-txns args:
+ * fee - integer fee per byte, in microAlgos. for a flat fee, set flatFee to true
+ * flatFee - bool optionally set this to true to specify fee as microalgos-per-txn
+ * firstRound - integer first protocol round on which this txn is valid
+ * lastRound - integer last protocol round on which this txn is valid
+ * genesisHash - string specifies hash genesis block of network in use
+ * genesisID - string specifies genesis ID of network in use
+ * @Deprecated in version 2.0 this will change to use the "WithParams" signature.
+ * @returns {Transaction}
+ */
+function makeKeyRegistrationTxnWithParams(from, note, voteKey, selectionKey, voteFirst, voteLast, voteKeyDilution, params) {
+    let o = {
+        "from": from,
         "note": note,
-        "genesisHash": genesisHash,
         "voteKey": voteKey,
         "selectionKey": selectionKey,
         "voteFirst": voteFirst,
         "voteLast": voteLast,
         "voteKeyDilution": voteKeyDilution,
-        "genesisID": genesisID,
+        "params": params,
         "type": "keyreg"
     };
     return new txnBuilder.Transaction(o);
@@ -443,18 +497,54 @@ function makeKeyRegistrationTxn(from, fee, firstRound, lastRound, note, genesisH
  * @param assetName - string name for this asset
  * @param assetURL - string URL relating to this asset
  * @param assetMetadataHash - string representation of some sort of hash commitment with respect to the asset
+ * @Deprecated in version 2.0 this will change to use the "WithParams" signature.
  * @returns {Transaction}
  */
 function makeAssetCreateTxn(from, fee, firstRound, lastRound, note, genesisHash, genesisID,
                             total, decimals, defaultFrozen, manager, reserve, freeze,
                             clawback, unitName, assetName, assetURL, assetMetadataHash) {
-    let o = {
-        "from": from,
-        "fee": fee,
+    let params = {
+        "genesisHash": genesisHash,
+        "genesisID": genesisID,
         "firstRound": firstRound,
         "lastRound": lastRound,
+        "fee": fee
+    };
+    return makeAssetCreateTxnWithParams(from, note, total, decimals, defaultFrozen, manager, reserve, freeze, clawback,
+        unitName, assetName, assetURL, assetMetadataHash, params);
+}
+
+/** makeAssetCreateTxnWithParams takes asset creation arguments and returns a Transaction object
+ * for creating that asset
+ *
+ * @param from - string representation of Algorand address of sender
+ * @param note - uint8array of arbitrary data for sender to store
+ * @param total - integer total supply of the asset
+ * @param decimals - integer number of decimals for asset unit calculation
+ * @param defaultFrozen - boolean whether asset accounts should default to being frozen
+ * @param manager - string representation of Algorand address in charge of reserve, freeze, clawback, destruction, etc
+ * @param reserve - string representation of Algorand address representing asset reserve
+ * @param freeze - string representation of Algorand address with power to freeze/unfreeze asset holdings
+ * @param clawback - string representation of Algorand address with power to revoke asset holdings
+ * @param unitName - string units name for this asset
+ * @param assetName - string name for this asset
+ * @param assetURL - string URL relating to this asset
+ * @param assetMetadataHash - string representation of some sort of hash commitment with respect to the asset
+ * @param params - a dict holding common-to-all-txns args:
+ * fee - integer fee per byte, in microAlgos. for a flat fee, set flatFee to true
+ * flatFee - bool optionally set this to true to specify fee as microalgos-per-txn
+ * firstRound - integer first protocol round on which this txn is valid
+ * lastRound - integer last protocol round on which this txn is valid
+ * genesisHash - string specifies hash genesis block of network in use
+ * genesisID - string specifies genesis ID of network in use
+ * @returns {Transaction}
+ */
+function makeAssetCreateTxnWithParams(from, note, total, decimals, defaultFrozen, manager, reserve, freeze,
+                            clawback, unitName, assetName, assetURL, assetMetadataHash, params) {
+    let o = {
+        "from": from,
         "note": note,
-        "genesisHash": genesisHash,
+        "params": params,
         "assetTotal": total,
         "assetDecimals": decimals,
         "assetDefaultFrozen": defaultFrozen,
@@ -466,7 +556,6 @@ function makeAssetCreateTxn(from, fee, firstRound, lastRound, note, genesisHash,
         "assetReserve": reserve,
         "assetFreeze": freeze,
         "assetClawback": clawback,
-        "genesisID": genesisID,
         "type": "acfg"
     };
     return new txnBuilder.Transaction(o);
@@ -489,20 +578,50 @@ function makeAssetCreateTxn(from, fee, firstRound, lastRound, note, genesisHash,
  * @param freeze - string representation of new freeze manager Algorand address
  * @param clawback - string representation of new revocation manager Algorand address
  * @param strictEmptyAddressChecking - boolean - throw an error if any of manager, reserve, freeze, or clawback are undefined. optional, defaults to true.
+ * @Deprecated in version 2.0 this will change to use the "WithParams" signature.
  * @returns {Transaction}
  */
 function makeAssetConfigTxn(from, fee, firstRound, lastRound, note, genesisHash, genesisID,
                             assetIndex, manager, reserve, freeze, clawback, strictEmptyAddressChecking=true) {
+    let params = {
+        "genesisHash": genesisHash,
+        "genesisID": genesisID,
+        "firstRound": firstRound,
+        "lastRound": lastRound,
+        "fee": fee
+    };
+    return makeAssetConfigTxnWithParams(from, note, assetIndex, manager, reserve, freeze, clawback, params, strictEmptyAddressChecking);
+}
+
+/** makeAssetConfigTxnWithParams can be issued by the asset manager to change the manager, reserve, freeze, or clawback
+ * you must respecify existing addresses to keep them the same; leaving a field blank is the same as turning
+ * that feature off for this asset
+ *
+ * @param from - string representation of Algorand address of sender
+ * @param note - uint8array of arbitrary data for sender to store
+ * @param assetIndex - int asset index uniquely specifying the asset
+ * @param manager - string representation of new asset manager Algorand address
+ * @param reserve - string representation of new reserve Algorand address
+ * @param freeze - string representation of new freeze manager Algorand address
+ * @param clawback - string representation of new revocation manager Algorand address
+ * @param strictEmptyAddressChecking - boolean - throw an error if any of manager, reserve, freeze, or clawback are undefined. optional, defaults to true.
+ * @param params - a dict holding common-to-all-txns args:
+ * fee - integer fee per byte, in microAlgos. for a flat fee, set flatFee to true
+ * flatFee - bool optionally set this to true to specify fee as microalgos-per-txn
+ * firstRound - integer first protocol round on which this txn is valid
+ * lastRound - integer last protocol round on which this txn is valid
+ * genesisHash - string specifies hash genesis block of network in use
+ * genesisID - string specifies genesis ID of network in use
+ * @returns {Transaction}
+ */
+function makeAssetConfigTxnWithParams(from, note, assetIndex,
+                                      manager, reserve, freeze, clawback, params, strictEmptyAddressChecking=true) {
     if (strictEmptyAddressChecking && ((manager === undefined) || (reserve === undefined) || (freeze === undefined) || (clawback === undefined))) {
         throw Error("strict empty address checking was turned on, but at least one empty address was provided");
     }
     let o = {
         "from": from,
-        "fee": fee,
-        "firstRound": firstRound,
-        "lastRound": lastRound,
-        "genesisHash": genesisHash,
-        "genesisID": genesisID,
+        "params":, params,
         "assetIndex": assetIndex,
         "assetManager": manager,
         "assetReserve": reserve,
@@ -525,16 +644,39 @@ function makeAssetConfigTxn(from, fee, firstRound, lastRound, note, genesisHash,
  * @param genesisHash - string specifies hash genesis block of network in use
  * @param genesisID - string specifies genesis ID of network in use
  * @param assetIndex - int asset index uniquely specifying the asset
+ * @Deprecated in version 2.0 this will change to use the "WithParams" signature.
  * @returns {Transaction}
  */
 function makeAssetDestroyTxn(from, fee, firstRound, lastRound, note, genesisHash, genesisID, assetIndex) {
-    let o = {
-        "from": from,
-        "fee": fee,
-        "firstRound": firstRound,
-        "lastRound": lastRound,
+    let params = {
         "genesisHash": genesisHash,
         "genesisID": genesisID,
+        "firstRound": firstRound,
+        "lastRound": lastRound,
+        "fee": fee
+    };
+    return makeAssetDestroyTxnWithParams(from, note, assetIndex, params);
+}
+
+/** makeAssetDestroyTxnWithParams will allow the asset's manager to remove this asset from the ledger, so long
+ * as all outstanding assets are held by the creator.
+ *
+ * @param from - string representation of Algorand address of sender
+ * @param note - uint8array of arbitrary data for sender to store
+ * @param assetIndex - int asset index uniquely specifying the asset
+ * @param params - a dict holding common-to-all-txns args:
+ * fee - integer fee per byte, in microAlgos. for a flat fee, set flatFee to true
+ * flatFee - bool optionally set this to true to specify fee as microalgos-per-txn
+ * firstRound - integer first protocol round on which this txn is valid
+ * lastRound - integer last protocol round on which this txn is valid
+ * genesisHash - string specifies hash genesis block of network in use
+ * genesisID - string specifies genesis ID of network in use
+ * @returns {Transaction}
+ */
+function makeAssetDestroyTxnWithParams(from, note, assetIndex, params) {
+    let o = {
+        "from": from,
+        "params": params,
         "assetIndex": assetIndex,
         "type": "acfg",
         "note": note
@@ -555,24 +697,51 @@ function makeAssetDestroyTxn(from, fee, firstRound, lastRound, note, genesisHash
  * @param assetIndex - int asset index uniquely specifying the asset
  * @param freezeTarget - string representation of Algorand address being frozen or unfrozen
  * @param freezeState - true if freezeTarget should be frozen, false if freezeTarget should be allowed to transact
+ * @Deprecated in version 2.0 this will change to use the "WithParams" signature.
  * @returns {Transaction}
  */
 function makeAssetFreezeTxn(from, fee, firstRound, lastRound, note, genesisHash, genesisID,
                             assetIndex, freezeTarget, freezeState) {
-    let o = {
-        "from": from,
-        "fee": fee,
+    let params = {
+        "genesisHash": genesisHash,
+        "genesisID": genesisID,
         "firstRound": firstRound,
         "lastRound": lastRound,
-        "genesisHash": genesisHash,
+        "fee": fee
+    };
+    return makeAssetFreezeTxnWithParams(from, note, assetIndex, freezeTarget, freezeState, params);
+}
+
+/** makeAssetFreezeTxnWithParams will allow the asset's freeze manager to freeze or un-freeze an account,
+ * blocking or allowing asset transfers to and from the targeted account.
+ *
+ * @param from - string representation of Algorand address of sender
+ * @param note - uint8array of arbitrary data for sender to store
+ * @param assetIndex - int asset index uniquely specifying the asset
+ * @param freezeTarget - string representation of Algorand address being frozen or unfrozen
+ * @param freezeState - true if freezeTarget should be frozen, false if freezeTarget should be allowed to transact
+ * @param params - a dict holding common-to-all-txns args:
+ * fee - integer fee per byte, in microAlgos. for a flat fee, set flatFee to true
+ * flatFee - bool optionally set this to true to specify fee as microalgos-per-txn
+ * firstRound - integer first protocol round on which this txn is valid
+ * lastRound - integer last protocol round on which this txn is valid
+ * genesisHash - string specifies hash genesis block of network in use
+ * genesisID - string specifies genesis ID of network in use
+ * @returns {Transaction}
+ */
+function makeAssetFreezeTxnWithParams(from, note, assetIndex, freezeTarget, freezeState, params) {
+    let o = {
+        "from": from,
         "type": "afrz",
         "freezeAccount": freezeTarget,
         "assetIndex": assetIndex,
         "freezeState" : freezeState,
-        "note": note
+        "note": note,
+        "params": params
     };
     return new txnBuilder.Transaction(o);
 }
+
 
 /** makeAssetTransferTxn allows for the creation of an asset transfer transaction.
  * Special case: to begin accepting assets, set amount=0 and from=to.
@@ -591,21 +760,51 @@ function makeAssetFreezeTxn(from, fee, firstRound, lastRound, note, genesisHash,
  * @param genesisHash - string specifies hash genesis block of network in use
  * @param genesisID - string specifies genesis ID of network in use
  * @param assetIndex - int asset index uniquely specifying the asset
- * @param lease - see makePaymentTxn
+ * @Deprecated in version 2.0 this will change to use the "WithParams" signature.
  * @returns {Transaction}
  */
 function makeAssetTransferTxn(from, to, closeRemainderTo, revocationTarget,
                               fee, amount, firstRound, lastRound, note, genesisHash, genesisID, assetIndex) {
+    let params = {
+        "genesisHash": genesisHash,
+        "genesisID": genesisID,
+        "firstRound": firstRound,
+        "lastRound": lastRound,
+        "fee": fee
+    };
+    return makeAssetTransferTxnWithParams(from, to, closeRemainderTo, revocationTarget, amount, note, assetIndex, params);
+}
+
+/** makeAssetTransferTxnWithParams allows for the creation of an asset transfer transaction.
+ * Special case: to begin accepting assets, set amount=0 and from=to.
+ *
+ * @param from - string representation of Algorand address of sender
+ * @param to - string representation of Algorand address of asset recipient
+ * @param closeRemainderTo - optional - string representation of Algorand address - if provided,
+ * send all remaining assets after transfer to the "closeRemainderTo" address and close "from"'s asset holdings
+ * @param revocationTarget - optional - string representation of Algorand address - if provided,
+ * and if "from" is the asset's revocation manager, then deduct from "revocationTarget" rather than "from"
+ * @param amount - integer amount of assets to send
+ * @param note - uint8array of arbitrary data for sender to store
+ * @param assetIndex - int asset index uniquely specifying the asset
+ * @Deprecated in version 2.0 this will change to use the "WithParams" signature.
+ * @param params - a dict holding common-to-all-txns args:
+ * fee - integer fee per byte, in microAlgos. for a flat fee, set flatFee to true
+ * flatFee - bool optionally set this to true to specify fee as microalgos-per-txn
+ * firstRound - integer first protocol round on which this txn is valid
+ * lastRound - integer last protocol round on which this txn is valid
+ * genesisHash - string specifies hash genesis block of network in use
+ * genesisID - string specifies genesis ID of network in use
+ * @returns {Transaction}
+ */
+function makeAssetTransferTxnWithParams(from, to, closeRemainderTo, revocationTarget,
+                              amount, note, assetIndex, params) {
     let o = {
         "type": "axfer",
         "from": from,
         "to": to,
         "amount": amount,
-        "fee": fee,
-        "firstRound": firstRound,
-        "lastRound": lastRound,
-        "genesisHash": genesisHash,
-        "genesisID": genesisID,
+        "params": params,
         "assetIndex": assetIndex,
         "note": note,
         "assetRevocationTarget": revocationTarget,
@@ -613,6 +812,7 @@ function makeAssetTransferTxn(from, to, closeRemainderTo, revocationTarget,
     };
     return new txnBuilder.Transaction(o);
 }
+
 
 module.exports = {
     isValidAddress,
@@ -650,4 +850,11 @@ module.exports = {
     makeAssetDestroyTxn,
     makeAssetFreezeTxn,
     makeAssetTransferTxn,
+    makePaymentTxnWithParams,
+    makeKeyRegistrationTxnWithParams,
+    makeAssetCreateTxnWithParams,
+    makeAssetConfigTxnWithParams,
+    makeAssetDestroyTxnWithParams,
+    makeAssetFreezeTxnWithParams,
+    makeAssetTransferTxnWithParams
 };

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -18,9 +18,18 @@ class Transaction {
                  closeRemainderTo, voteKey, selectionKey, voteFirst, voteLast, voteKeyDilution, 
                  assetIndex, assetTotal, assetDecimals, assetDefaultFrozen, assetManager, assetReserve,
                  assetFreeze, assetClawback, assetUnitName, assetName, assetURL, assetMetadataHash,
-                 freezeAccount, freezeState, assetRevocationTarget, type="pay", flatFee=false}) {
+                 freezeAccount, freezeState, assetRevocationTarget, type="pay", flatFee=false, params=undefined}) {
         this.name = "Transaction";
         this.tag = Buffer.from("TX");
+
+        if (params !== undefined) {
+            genesisHash = params.genesisHash;
+            fee = params.fee;
+            if (params.flatFee !== undefined) flatFee = params.flatFee;
+            firstRound = params.firstRound;
+            lastRound = params.lastRound;
+            genesisID = params.genesisID;
+        }
 
         from = address.decode(from);
         if (to !== undefined) to = address.decode(to);

--- a/tests/5.Transaction.js
+++ b/tests/5.Transaction.js
@@ -585,7 +585,8 @@ describe('Sign', function () {
                 "assetIndex": assetIndex,
                 "creator" : creator,
                 "freezeState" : freezeState,
-                "note": note
+                "note": note,
+                "genesisID": genesisID
             };
             let expectedTxn = new transaction.Transaction(o);
             let actualTxn = algosdk.makeAssetFreezeTxn(addr, fee, firstRound, lastRound, note, genesisHash, genesisID,

--- a/tests/8.LogicSig.js
+++ b/tests/8.LogicSig.js
@@ -309,9 +309,9 @@ describe('Template logic validation', function () {
             let goldenAddress = "JMS3K4LSHPULANJIVQBTEDP5PZK6HHMDQS4OKHIMHUZZ6OILYO3FVQW7IY";
             assert.deepStrictEqual(goldenAddress, periodicPayment.getAddress());
             let goldenGenesisHash = "f4OxZX/x/FO5LcGBSKHWXfwtSx+j1ncoSt3SABJtkGk=";
-            let goldenStx = "gqRsc2lngaFsxJkBIAcB6AdkAF+gwh68o5UBJgIgAQIDBAUGBwgBAgMEBQYHCAECAwQFBgcIAQIDBAUGBwggkq+RhOQTPAl/ZqvMk7ERGxKiAb2dDMo+SkihzhPM9MUxECISMQEjDhAxAiQYJRIQMQQhBDECCBIQMQYoEhAxCTIDEjEHKRIQMQghBRIQMQkpEjEHMgMSEDECIQYNEDEIJRIQERCjdHhuiaNhbXTOAAehIKNmZWXOAAQDWKJmds0EsKJnaMQgf4OxZX/x/FO5LcGBSKHWXfwtSx+j1ncoSt3SABJtkGmibHbNBQ+ibHjEIAECAwQFBgcIAQIDBAUGBwgBAgMEBQYHCAECAwQFBgcIo3JjdsQgkq+RhOQTPAl/ZqvMk7ERGxKiAb2dDMo+SkihzhPM9MWjc25kxCBLJbVxcjvosDUorAMyDf1+VeOdg4S45R0MPTOfOQvDtqR0eXBlo3BheQ==";
+            let goldenStx = "gqRsc2lngaFsxJkBIAcB6AdkAF+gwh68o5UBJgIgAQIDBAUGBwgBAgMEBQYHCAECAwQFBgcIAQIDBAUGBwggkq+RhOQTPAl/ZqvMk7ERGxKiAb2dDMo+SkihzhPM9MUxECISMQEjDhAxAiQYJRIQMQQhBDECCBIQMQYoEhAxCTIDEjEHKRIQMQghBRIQMQkpEjEHMgMSEDECIQYNEDEIJRIQERCjdHhuiaNhbXTOAAehIKNmZWXNA+iiZnbNBLCiZ2jEIH+DsWV/8fxTuS3BgUih1l38LUsfo9Z3KErd0gASbZBpomx2zQUPomx4xCABAgMEBQYHCAECAwQFBgcIAQIDBAUGBwgBAgMEBQYHCKNyY3bEIJKvkYTkEzwJf2arzJOxERsSogG9nQzKPkpIoc4TzPTFo3NuZMQgSyW1cXI76LA1KKwDMg39flXjnYOEuOUdDD0znzkLw7akdHlwZaNwYXk=";
             let goldenStxBlob = Buffer.from(goldenStx, 'base64');
-            let stx = periodicPaymentTemplate.getPeriodicPaymentWithdrawalTransaction(actualBytes, 1200, goldenGenesisHash);
+            let stx = periodicPaymentTemplate.getPeriodicPaymentWithdrawalTransaction(actualBytes, 0, 1200, goldenGenesisHash);
             let expectedDict = encoding.decode(goldenStxBlob);
             let actualDict = encoding.decode(stx['blob']);
             assert.deepEqual(expectedDict, actualDict);


### PR DESCRIPTION
## Summary
Class `Transaction` accepts a `params` object, and preferentially uses that to set up `lastRound` `genesisHash` et al. 
`algosdk.MakeFooTxn` helpers now have counterparts in the form of `MakeFooTxnWithParams`. `MakeFooTxn` marked `@Deprecated`, uses `params`-based implementation internally.
Add `suggestParams` function to `algod.js`, which uses `getTransactionParams` to build the `params` object that `Transaction` expects.

### Testing
Unit tests pass; known broken cucumber tests fail. Because the old `MakeFoo` family of funcs calls the new `MakeFoo` family of funcs, they are tested by existing unit tests.

### See also
https://github.com/algorand/js-algorand-sdk/issues/105