### PR TITLE
Rekey-aware indexer

### DIFF
--- a/src/client/v2/indexer/lookupAccountTransactions.js
+++ b/src/client/v2/indexer/lookupAccountTransactions.js
@@ -99,6 +99,12 @@ class LookupAccountTransactions {
 		this.query['next'] = nextToken;
 		return this;
 	}
+
+	// whether or not to include rekeying transactions
+	rekeyTo(rekeyTo) {
+		this.query['rekey-to'] = rekeyTo;
+		return this;
+	}
 }
 
 module.exports = {LookupAccountTransactions};

--- a/src/client/v2/indexer/lookupAssetTransactions.js
+++ b/src/client/v2/indexer/lookupAssetTransactions.js
@@ -116,6 +116,12 @@ class LookupAssetTransactions {
 		this.query['next'] = nextToken;
 		return this;
 	}
+
+	// whether or not to include rekeying transactions
+	rekeyTo(rekeyTo) {
+		this.query['rekey-to'] = rekeyTo;
+		return this;
+	}
 }
 
 module.exports = {LookupAssetTransactions};

--- a/src/client/v2/indexer/searchAccounts.js
+++ b/src/client/v2/indexer/searchAccounts.js
@@ -49,6 +49,12 @@ class SearchAccounts {
 		this.query['round'] = round;
 		return this;
 	}
+
+	// include accounts that use this spending key
+	authAddr(authAddr) {
+		this.query['auth-addr'] = authAddr;
+		return this;
+	}
 }
 
 module.exports = {SearchAccounts};

--- a/src/client/v2/indexer/searchForTransactions.js
+++ b/src/client/v2/indexer/searchForTransactions.js
@@ -115,6 +115,12 @@ class SearchForTransactions {
 		this.query['next'] = nextToken;
 		return this;
 	}
+
+	// whether or not to include rekeying transactions
+	rekeyTo(rekeyTo) {
+		this.query['rekey-to'] = rekeyTo;
+		return this;
+	}
 }
 
 module.exports = {SearchForTransactions};

--- a/tests/cucumber/steps/stepdefs.js
+++ b/tests/cucumber/steps/stepdefs.js
@@ -1764,8 +1764,28 @@ When('we make a Lookup Asset Transactions call against asset index {int} with No
     await this.indexerClient.lookupAssetTransactions(assetIndex).notePrefix(notePrefix).txType(txType).sigType(sigType).txid(txid).round(round).minRound(minRound).maxRound(maxRound).limit(limit).beforeTime(beforeTime).afterTime(afterTime).currencyGreaterThan(currencyGreater).currencyLessThan(currencyLesser).address(address).addressRole(addressRole).excludeCloseTo(excludeCloseTo).do();
 });
 
+When('we make a Lookup Asset Transactions call against asset index {int} with NotePrefix {string} TxType {string} SigType {string} txid {string} round {int} minRound {int} maxRound {int} limit {int} beforeTime {string} afterTime {string} currencyGreaterThan {int} currencyLessThan {int} address {string} addressRole {string} ExcluseCloseTo {string} RekeyTo {string}', async function (assetIndex, notePrefix, txType, sigType, txid, round, minRound, maxRound, limit, beforeTime, afterTime, currencyGreater, currencyLesser, address, addressRole, excludeCloseToAsString, rekeyToAsString) {
+    let excludeCloseTo = false;
+    if (excludeCloseToAsString === "true") {
+        excludeCloseTo = true;
+    }
+    let rekeyTo = false;
+    if (rekeyToAsString === "true") {
+        rekeyTo = true;
+    }
+    await this.indexerClient.lookupAssetTransactions(assetIndex).notePrefix(notePrefix).txType(txType).sigType(sigType).txid(txid).round(round).minRound(minRound).maxRound(maxRound).limit(limit).beforeTime(beforeTime).afterTime(afterTime).currencyGreaterThan(currencyGreater).currencyLessThan(currencyLesser).address(address).addressRole(addressRole).excludeCloseTo(excludeCloseTo).rekeyTo(rekeyTo).do();
+});
+
 When('we make a Lookup Account Transactions call against account {string} with NotePrefix {string} TxType {string} SigType {string} txid {string} round {int} minRound {int} maxRound {int} limit {int} beforeTime {string} afterTime {string} currencyGreaterThan {int} currencyLessThan {int} assetIndex {int}',async function (account, notePrefix, txType, sigType, txid, round, minRound, maxRound, limit, beforeTime, afterTime, currencyGreater, currencyLesser, assetIndex) {
     await this.indexerClient.lookupAccountTransactions(account).notePrefix(notePrefix).txType(txType).sigType(sigType).txid(txid).round(round).minRound(minRound).maxRound(maxRound).limit(limit).beforeTime(beforeTime).afterTime(afterTime).currencyGreaterThan(currencyGreater).currencyLessThan(currencyLesser).assetID(assetIndex).do();
+});
+
+When('we make a Lookup Account Transactions call against account {string} with NotePrefix {string} TxType {string} SigType {string} txid {string} round {int} minRound {int} maxRound {int} limit {int} beforeTime {string} afterTime {string} currencyGreaterThan {int} currencyLessThan {int} assetIndex {int} rekeyTo {string}', async function (account, notePrefix, txType, sigType, txid, round, minRound, maxRound, limit, beforeTime, afterTime, currencyGreater, currencyLesser, assetIndex, rekeyToAsString) {
+    let rekeyTo = false;
+    if (rekeyToAsString === "true") {
+        rekeyTo = true;
+    }
+    await this.indexerClient.lookupAccountTransactions(account).notePrefix(notePrefix).txType(txType).sigType(sigType).txid(txid).round(round).minRound(minRound).maxRound(maxRound).limit(limit).beforeTime(beforeTime).afterTime(afterTime).currencyGreaterThan(currencyGreater).currencyLessThan(currencyLesser).assetID(assetIndex).rekeyTo(rekeyTo).do();
 });
 
 When('we make a Lookup Block call against round {int}', async function (round) {
@@ -1787,6 +1807,11 @@ When('we make a Search Accounts call with assetID {int} limit {int} currencyGrea
 When('we make a Search Accounts call with assetID {int} limit {int} currencyGreaterThan {int} currencyLessThan {int} and round {int}', async function (assetIndex, limit, currencyGreater, currencyLesser, round) {
     await this.indexerClient.searchAccounts().assetID(assetIndex).limit(limit).currencyGreaterThan(currencyGreater).currencyLessThan(currencyLesser).round(round).do();
 });
+
+When('we make a Search Accounts call with assetID {int} limit {int} currencyGreaterThan {int} currencyLessThan {int} round {int} and authenticating address {string}', async function (assetIndex, limit, currencyGreater, currencyLesser, round, authAddress) {
+    await this.indexerClient.searchAccounts().assetID(assetIndex).limit(limit).currencyGreaterThan(currencyGreater).currencyLessThan(currencyLesser).round(round).authAddr(authAddress).do();
+});
+
 When('we make a Search For Transactions call with account {string} NotePrefix {string} TxType {string} SigType {string} txid {string} round {int} minRound {int} maxRound {int} limit {int} beforeTime {int} afterTime {int} currencyGreaterThan {int} currencyLessThan {int} assetIndex {int} addressRole {string} ExcluseCloseTo {string}', async function (account, notePrefix, txType, sigType, txid, round, minRound, maxRound, limit, beforeTime, afterTime, currencyGreater, currencyLesser, assetIndex, addressRole, excludeCloseToAsString) {
     let excludeCloseTo = false;
     if (excludeCloseToAsString === "true") {
@@ -1803,9 +1828,22 @@ When('we make a Search For Transactions call with account {string} NotePrefix {s
     await this.indexerClient.searchForTransactions().address(account).notePrefix(notePrefix).txType(txType).sigType(sigType).txid(txid).round(round).minRound(minRound).maxRound(maxRound).limit(limit).beforeTime(beforeTime).afterTime(afterTime).currencyGreaterThan(currencyGreater).currencyLessThan(currencyLesser).assetID(assetIndex).addressRole(addressRole).excludeCloseTo(excludeCloseTo).do();
 });
 
+When('we make a Search For Transactions call with account {string} NotePrefix {string} TxType {string} SigType {string} txid {string} round {int} minRound {int} maxRound {int} limit {int} beforeTime {string} afterTime {string} currencyGreaterThan {int} currencyLessThan {int} assetIndex {int} addressRole {string} ExcluseCloseTo {string} rekeyTo {string}', async function (account, notePrefix, txType, sigType, txid, round, minRound, maxRound, limit, beforeTime, afterTime, currencyGreater, currencyLesser, assetIndex, addressRole, excludeCloseToAsString, rekeyToAsString) {
+    let excludeCloseTo = false;
+    if (excludeCloseToAsString === "true") {
+        excludeCloseTo = true;
+    }
+    let rekeyTo = false;
+    if (rekeyToAsString === "true") {
+        rekeyTo = true;
+    }
+    await this.indexerClient.searchForTransactions().address(account).notePrefix(notePrefix).txType(txType).sigType(sigType).txid(txid).round(round).minRound(minRound).maxRound(maxRound).limit(limit).beforeTime(beforeTime).afterTime(afterTime).currencyGreaterThan(currencyGreater).currencyLessThan(currencyLesser).assetID(assetIndex).addressRole(addressRole).excludeCloseTo(excludeCloseTo).rekeyTo(rekeyTo).do();
+});
+
 When('we make a SearchForAssets call with limit {int} creator {string} name {string} unit {string} index {int} and nextToken {string}', async function (limit, creator, name, unit, index, nextToken) {
     await this.indexerClient.searchForAssets().limit(limit).creator(creator).name(name).unit(unit).index(index).nextToken(nextToken).do();
 });
+
 When('we make a SearchForAssets call with limit {int} creator {string} name {string} unit {string} index {int}', async function (limit, creator, name, unit, index) {
     await this.indexerClient.searchForAssets().limit(limit).creator(creator).name(name).unit(unit).index(index).do();
 });
@@ -1905,6 +1943,15 @@ Then('the parsed SearchAccounts response should be valid on round {int} and the 
     assert.equal(address, anySearchAccountsResponse['accounts'][idx]['address']);
 });
 
+Then('the parsed SearchAccounts response should be valid on round {int} and the array should be of len {int} and the element at index {int} should have authorizing address {string}', function (round, length, idx, authAddress) {
+    assert.equal(round, anySearchAccountsResponse['current-round']);
+    assert.equal(length, anySearchAccountsResponse['accounts'].length);
+    if (length == 0) {
+        return;
+    }
+    assert.equal(authAddress, anySearchAccountsResponse['accounts'][idx]['auth-addr']);
+});
+
 let anySearchForTransactionsResponse;
 
 When('we make any SearchForTransactions call', async function () {
@@ -1918,6 +1965,15 @@ Then('the parsed SearchForTransactions response should be valid on round {int} a
         return;
     }
     assert.equal(sender, anySearchForTransactionsResponse['transactions'][idx]['sender']);
+});
+
+Then('the parsed SearchForTransactions response should be valid on round {int} and the array should be of len {int} and the element at index {int} should have rekey-to {string}', function (round, length, idx, rekeyTo) {
+    assert.equal(round, anySearchForTransactionsResponse['current-round']);
+    assert.equal(length, anySearchForTransactionsResponse['transactions'].length);
+    if (length == 0) {
+        return;
+    }
+    assert.equal(rekeyTo, anySearchForTransactionsResponse['transactions'][idx]['rekey-to']);
 });
 
 let anySearchForAssetsResponse;


### PR DESCRIPTION
## Summary
The `indexer` received an update to support rekey-related transactions. This PR proposes to likewise add support in the indexer client.

### Testing
See https://github.com/algorand/algorand-sdk-testing/pull/81