### PR TITLE
Hotfix/1.6.1 : add algodv2 and indexer client to module exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.6.1
+## Fixed
+- Fixed bug where Indexer and algod V2 clients were omitted from module exports.
 # 1.6.0
 # Added
 - Clients for Indexer and algod V2

--- a/src/main.js
+++ b/src/main.js
@@ -9,9 +9,13 @@ const algod = require('./client/algod');
 const kmd = require('./client/kmd');
 const utils = require('./utils/utils');
 const logicsig = require('./logicsig');
+const algodv2 = require('./client/v2/algod/algod')
+const indexer = require('./client/v2/indexer/indexer')
 
 let Algod = algod.Algod;
 let Kmd = kmd.Kmd;
+let Algodv2 = algodv2.AlgodClient
+let Indexer = indexer.IndexerClient
 
 const SIGN_BYTES_PREFIX = Buffer.from([77, 88]); // "MX"
 const MICROALGOS_TO_ALGOS_RATIO = 1e6;
@@ -827,6 +831,8 @@ module.exports = {
     decodeObj,
     Algod,
     Kmd,
+    Algodv2,
+    Indexer,
     mnemonicToMasterDerivationKey,
     masterDerivationKeyToMnemonic,
     appendSignMultisigTransaction,


### PR DESCRIPTION
## Summary
Internal SDK tests were able to access the algodv2 and indexer clients just fine, but they weren't added to the list of module exports in `main.js`. This PR proposes to fix this.