### PR TITLE
Fix v2 msgpack endpoints for browsers

### DIFF
--- a/src/client/client.js
+++ b/src/client/client.js
@@ -45,13 +45,20 @@ function HTTPClient(token, baseServer, port, headers={}) {
 
     this.get = async function (path, query, requestHeaders={}) {
         try {
-            return await request
+            const format = getAccceptFormat(query);
+            let r = request
                 .get(this.address + path)
                 .set(this.token)
                 .set(this.defaultHeaders)
                 .set(requestHeaders)
-                .set('Accept', getAccceptFormat(query))
+                .set('Accept', format)
                 .query(removeEmpty(query));
+            
+            if (format === 'application/msgpack') {
+                r = r.responseType('arraybuffer');
+            }
+            
+            return await r;
         } catch (e) {
             throw e;
         }

--- a/src/client/v2/algod/block.js
+++ b/src/client/v2/algod/block.js
@@ -15,7 +15,7 @@ class Block {
 	 */
 	async do(headers={}) {
 		let res = await this.c.get("/v2/blocks/" + this.round, this.query, headers);
-		if (res.body) {
+		if (res.body && res.body.length > 0) {
 			return encoding.decode(res.body);
 		}
 		return undefined;

--- a/src/client/v2/algod/pendingTransactionInformation.js
+++ b/src/client/v2/algod/pendingTransactionInformation.js
@@ -15,7 +15,7 @@ class PendingTransactionInformation {
 	 */
 	async do(headers={}){
 		let res = await this.c.get("/v2/transactions/pending/" + this.txid, this.query, headers);
-		if (res.body) {
+		if (res.body && res.body.length > 0) {
 			return encoding.decode(res.body);
 		}
 		return undefined;

--- a/src/client/v2/algod/pendingTransactions.js
+++ b/src/client/v2/algod/pendingTransactions.js
@@ -14,7 +14,7 @@ class PendingTransactions {
 	 */
 	async do(headers={}) {
 		let res = await this.c.get("/v2/transactions/pending", this.query, headers);
-		if (res.body) {
+		if (res.body && res.body.length > 0) {
 			return encoding.decode(res.body);
 		}
 		return undefined;

--- a/src/client/v2/algod/pendingTransactionsByAddress.js
+++ b/src/client/v2/algod/pendingTransactionsByAddress.js
@@ -14,7 +14,7 @@ class PendingTransactionsByAddress {
 	 */
 	async do(headers={}) {
 		let res = await this.c.get("/v2/accounts/" + this.address + "/transactions/pending", this.query, headers);
-		if (res.body) {
+		if (res.body && res.body.length > 0) {
 			return encoding.decode(res.body);
 		}
 		return undefined;


### PR DESCRIPTION
This properly exposes msgpack responses in the browser for v2 endpoints such as `/v2/transactions/pending`.

Closes #209.