### PR TITLE
Add helpers for converting buffers to Transactions and vice versa.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1180,33 +1180,33 @@ function makeApplicationNoOpTxn(from, suggestedParams, appIndex,
 }
 
 /**
- * unsignedTransactionToBuffer takes a completed txnBuilder.Transaction object, such as from the makeFoo
+ * encodeUnsignedTransaction takes a completed txnBuilder.Transaction object, such as from the makeFoo
  * family of transactions, and converts it to a Buffer
  * @param transactionObject the completed Transaction object
  * @returns {Uint8Array}
  */
-function unsignedTransactionToBuffer(transactionObject) {
+function encodeUnsignedTransaction(transactionObject) {
     let objToEncode = transactionObject.get_obj_for_encoding();
     return encoding.encode(objToEncode);
 }
 
 /**
- * bufferToUnsignedTransaction takes a Buffer (as if from unsignedTransactionToBuffer) and converts it to a txnBuilder.Transaction object
+ * decodeUnsignedTransaction takes a Buffer (as if from encodeUnsignedTransaction) and converts it to a txnBuilder.Transaction object
  * @param transactionBuffer the Uint8Array containing a transaction
  * @returns {Transaction}
  */
-function bufferToUnsignedTransaction(transactionBuffer) {
+function decodeUnsignedTransaction(transactionBuffer) {
     let partlyDecodedObject = encoding.decode(transactionBuffer);
     return txnBuilder.Transaction.from_obj_for_encoding(partlyDecodedObject);
 }
 
 /**
- * bufferToSignedTransaction takes a Buffer (from transaction.signTxn) and converts it to an object
+ * decodeSignedTransaction takes a Buffer (from transaction.signTxn) and converts it to an object
  * containing the Transaction (txn), the signature (sig), and the auth-addr field if applicable (sgnr)
  * @param transactionBuffer the Uint8Array containing a transaction
  * @returns {Object} containing a Transaction, the signature, and possibly an auth-addr field
  */
-function bufferToSignedTransaction(transactionBuffer) {
+function decodeSignedTransaction(transactionBuffer) {
     let stxnDecoded = encoding.decode(transactionBuffer);
     stxnDecoded.txn = txnBuilder.Transaction.from_obj_for_encoding(stxnDecoded.txn);
     return stxnDecoded;
@@ -1268,7 +1268,7 @@ module.exports = {
     makeApplicationCloseOutTxn,
     makeApplicationClearStateTxn,
     makeApplicationNoOpTxn,
-    unsignedTransactionToBuffer,
-    bufferToUnsignedTransaction,
-    bufferToSignedTransaction
+    encodeUnsignedTransaction,
+    decodeUnsignedTransaction,
+    decodeSignedTransaction
 };

--- a/src/main.js
+++ b/src/main.js
@@ -1179,6 +1179,39 @@ function makeApplicationNoOpTxn(from, suggestedParams, appIndex,
     return new txnBuilder.Transaction(o);
 }
 
+/**
+ * unsignedTransactionToBuffer takes a completed txnBuilder.Transaction object, such as from the makeFoo
+ * family of transactions, and converts it to a Buffer
+ * @param transactionObject the completed Transaction object
+ * @returns {Uint8Array}
+ */
+function unsignedTransactionToBuffer(transactionObject) {
+    let objToEncode = transactionObject.get_obj_for_encoding();
+    return encoding.encode(objToEncode);
+}
+
+/**
+ * bufferToUnsignedTransaction takes a Buffer (as if from unsignedTransactionToBuffer) and converts it to a txnBuilder.Transaction object
+ * @param transactionBuffer the Uint8Array containing a transaction
+ * @returns {Transaction}
+ */
+function bufferToUnsignedTransaction(transactionBuffer) {
+    let partlyDecodedObject = encoding.decode(transactionBuffer);
+    return txnBuilder.Transaction.from_obj_for_encoding(partlyDecodedObject);
+}
+
+/**
+ * bufferToSignedTransaction takes a Buffer (from transaction.signTxn) and converts it to an object
+ * containing the Transaction (txn), the signature (sig), and the auth-addr field if applicable (sgnr)
+ * @param transactionBuffer the Uint8Array containing a transaction
+ * @returns {Object} containing a Transaction, the signature, and possibly an auth-addr field
+ */
+function bufferToSignedTransaction(transactionBuffer) {
+    let stxnDecoded = encoding.decode(transactionBuffer);
+    stxnDecoded.txn = txnBuilder.Transaction.from_obj_for_encoding(stxnDecoded.txn);
+    return stxnDecoded;
+}
+
 module.exports = {
     isValidAddress,
     generateAccount,
@@ -1234,5 +1267,8 @@ module.exports = {
     makeApplicationOptInTxn,
     makeApplicationCloseOutTxn,
     makeApplicationClearStateTxn,
-    makeApplicationNoOpTxn
+    makeApplicationNoOpTxn,
+    unsignedTransactionToBuffer,
+    bufferToUnsignedTransaction,
+    bufferToSignedTransaction
 };

--- a/tests/7.AlgoSDK.js
+++ b/tests/7.AlgoSDK.js
@@ -46,10 +46,12 @@ describe('Algosdk (AKA end to end)', function () {
             let note = new Uint8Array(Buffer.from("6gAVR0Nsv5Y=", "base64"))
             let from = to;
             let txnAsObj = algosdk.makePaymentTxn(from, to, fee, amount, closeRemainderTo, firstRound, lastRound, note, genesisHash, genesisID);
-            let txnAsBuffer = algosdk.unsignedTransactionToBuffer(txnAsObj);
-            let txnAsObjRecovered = algosdk.bufferToUnsignedTransaction(txnAsBuffer);
-            let txnAsBufferRecovered = algosdk.unsignedTransactionToBuffer(txnAsObjRecovered);
+            let txnAsBuffer = algosdk.encodeUnsignedTransaction(txnAsObj);
+            let txnAsObjRecovered = algosdk.decodeUnsignedTransaction(txnAsBuffer);
+            let txnAsBufferRecovered = algosdk.encodeUnsignedTransaction(txnAsObjRecovered);
             assert.deepStrictEqual(txnAsBuffer, txnAsBufferRecovered);
+            let txnAsBufferGolden = new Uint8Array(Buffer.from("i6NhbXTNA+ilY2xvc2XEIEDpNJKIJWTLzpxZpptnVCaJ6aHDoqnqW2Wm6KRCH/xXo2ZlZc0EmKJmds0wsqNnZW6sZGV2bmV0LXYzMy4womdoxCAmCyAJoJOohot5WHIvpeVG7eftF+TYXEx4r7BFJpDt0qJsds00mqRub3RlxAjqABVHQ2y/lqNyY3bEIHts4k/rW6zAsWTinCIsV/X2PcOH1DkEglhBHF/hD3wCo3NuZMQge2ziT+tbrMCxZOKcIixX9fY9w4fUOQSCWEEcX+EPfAKkdHlwZaNwYXk=", "base64"));
+            assert.deepStrictEqual(txnAsBufferGolden, txnAsBufferRecovered);
         });
 
         it('should not mutate signed transaction when going to or from encoded buffer', function () {
@@ -67,10 +69,13 @@ describe('Algosdk (AKA end to end)', function () {
             let sk = "advice pudding treat near rule blouse same whisper inner electric quit surface sunny dismiss leader blood seat clown cost exist hospital century reform able sponsor";
             sk = algosdk.mnemonicToSecretKey(sk);
             let initialSignedTxnBytes = txnAsObj.signTxn(sk.sk);
-            let signedTxnRecovered = algosdk.bufferToSignedTransaction(initialSignedTxnBytes);
+            let signedTxnRecovered = algosdk.decodeSignedTransaction(initialSignedTxnBytes);
             let txnAsObjRecovered = signedTxnRecovered.txn;
             let recoveredSignedTxnBytes = txnAsObjRecovered.signTxn(sk.sk);
             assert.deepStrictEqual(initialSignedTxnBytes, recoveredSignedTxnBytes);
+            let signedTxnBytesGolden = new Uint8Array(Buffer.from("g6RzZ25yxCDn8PhNBoEd+fMcjYeLEVX0Zx1RoYXCAJCGZ/RJWHBooaNzaWfEQDJHtrytU9p3nhRH1XS8tX+KmeKGyekigG7M704dOkBMTqiOJFuukbK2gUViJtivsPrKNiV0+WIrdbBk7gmNkgGjdHhui6NhbXTNA+ilY2xvc2XEIEDpNJKIJWTLzpxZpptnVCaJ6aHDoqnqW2Wm6KRCH/xXo2ZlZc0EmKJmds0wsqNnZW6sZGV2bmV0LXYzMy4womdoxCAmCyAJoJOohot5WHIvpeVG7eftF+TYXEx4r7BFJpDt0qJsds00mqRub3RlxAjqABVHQ2y/lqNyY3bEIHts4k/rW6zAsWTinCIsV/X2PcOH1DkEglhBHF/hD3wCo3NuZMQge2ziT+tbrMCxZOKcIixX9fY9w4fUOQSCWEEcX+EPfAKkdHlwZaNwYXk=","base64"));
+            console.log(Buffer.from(recoveredSignedTxnBytes).toString('base64'));
+            assert.deepStrictEqual(signedTxnBytesGolden, recoveredSignedTxnBytes)
         });
     });
 

--- a/tests/7.AlgoSDK.js
+++ b/tests/7.AlgoSDK.js
@@ -33,6 +33,45 @@ describe('Algosdk (AKA end to end)', function () {
             let o = "Hi there";
             assert.deepStrictEqual(o, algosdk.decodeObj(algosdk.encodeObj(o)));
         });
+
+        it('should not mutate unsigned transaction when going to or from encoded buffer', function () {
+            let to = "PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI";
+            let fee = 4;
+            let amount = 1000;
+            let firstRound = 12466;
+            let lastRound = 13466;
+            let genesisID = "devnet-v33.0";
+            let genesisHash = "JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=";
+            let closeRemainderTo = "IDUTJEUIEVSMXTU4LGTJWZ2UE2E6TIODUKU6UW3FU3UKIQQ77RLUBBBFLA";
+            let note = new Uint8Array(Buffer.from("6gAVR0Nsv5Y=", "base64"))
+            let from = to;
+            let txnAsObj = algosdk.makePaymentTxn(from, to, fee, amount, closeRemainderTo, firstRound, lastRound, note, genesisHash, genesisID);
+            let txnAsBuffer = algosdk.unsignedTransactionToBuffer(txnAsObj);
+            let txnAsObjRecovered = algosdk.bufferToUnsignedTransaction(txnAsBuffer);
+            let txnAsBufferRecovered = algosdk.unsignedTransactionToBuffer(txnAsObjRecovered);
+            assert.deepStrictEqual(txnAsBuffer, txnAsBufferRecovered);
+        });
+
+        it('should not mutate signed transaction when going to or from encoded buffer', function () {
+            let to = "PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI";
+            let fee = 4;
+            let amount = 1000;
+            let firstRound = 12466;
+            let lastRound = 13466;
+            let genesisID = "devnet-v33.0";
+            let genesisHash = "JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=";
+            let closeRemainderTo = "IDUTJEUIEVSMXTU4LGTJWZ2UE2E6TIODUKU6UW3FU3UKIQQ77RLUBBBFLA";
+            let note = new Uint8Array(Buffer.from("6gAVR0Nsv5Y=", "base64"))
+            let from = to;
+            let txnAsObj = algosdk.makePaymentTxn(from, to, fee, amount, closeRemainderTo, firstRound, lastRound, note, genesisHash, genesisID);
+            let sk = "advice pudding treat near rule blouse same whisper inner electric quit surface sunny dismiss leader blood seat clown cost exist hospital century reform able sponsor";
+            sk = algosdk.mnemonicToSecretKey(sk);
+            let initialSignedTxnBytes = txnAsObj.signTxn(sk.sk);
+            let signedTxnRecovered = algosdk.bufferToSignedTransaction(initialSignedTxnBytes);
+            let txnAsObjRecovered = signedTxnRecovered.txn;
+            let recoveredSignedTxnBytes = txnAsObjRecovered.signTxn(sk.sk);
+            assert.deepStrictEqual(initialSignedTxnBytes, recoveredSignedTxnBytes);
+        });
     });
 
     describe('Sign', function () {

--- a/tests/7.AlgoSDK.js
+++ b/tests/7.AlgoSDK.js
@@ -74,7 +74,6 @@ describe('Algosdk (AKA end to end)', function () {
             let recoveredSignedTxnBytes = txnAsObjRecovered.signTxn(sk.sk);
             assert.deepStrictEqual(initialSignedTxnBytes, recoveredSignedTxnBytes);
             let signedTxnBytesGolden = new Uint8Array(Buffer.from("g6RzZ25yxCDn8PhNBoEd+fMcjYeLEVX0Zx1RoYXCAJCGZ/RJWHBooaNzaWfEQDJHtrytU9p3nhRH1XS8tX+KmeKGyekigG7M704dOkBMTqiOJFuukbK2gUViJtivsPrKNiV0+WIrdbBk7gmNkgGjdHhui6NhbXTNA+ilY2xvc2XEIEDpNJKIJWTLzpxZpptnVCaJ6aHDoqnqW2Wm6KRCH/xXo2ZlZc0EmKJmds0wsqNnZW6sZGV2bmV0LXYzMy4womdoxCAmCyAJoJOohot5WHIvpeVG7eftF+TYXEx4r7BFJpDt0qJsds00mqRub3RlxAjqABVHQ2y/lqNyY3bEIHts4k/rW6zAsWTinCIsV/X2PcOH1DkEglhBHF/hD3wCo3NuZMQge2ziT+tbrMCxZOKcIixX9fY9w4fUOQSCWEEcX+EPfAKkdHlwZaNwYXk=","base64"));
-            console.log(Buffer.from(recoveredSignedTxnBytes).toString('base64'));
             assert.deepStrictEqual(signedTxnBytesGolden, recoveredSignedTxnBytes)
         });
     });


### PR DESCRIPTION
## Summary
It is a _very_ common use case that js user-devs wish to take a `Transaction`, convert it to bytes, and then convert it back to a `Transaction` - either for reading and writing to file, coming in as bytes from a wire, or something else. The js-sdk does support this, but usage is non-obvious and error-prone. So, this PR proposes to add three functions to `algosdk`: `unsignedTransactionToBuffer` to turn a `Transaction` into bytes, `bufferToUnsignedTransaction` to take those bytes back to a `Transaction`, and `bufferToSignedTransaction` to take the output of `Transaction.signTxn` and turn it into something more usable. (`bufferToSignedTransaction` would also work on the `blob` member of the object output by `algosdk.signTransaction`).

### Testing
Added tests to ensure the output buffer is not corrupted by encoding and re-encoding. One test handles the unsigned case, the other handles the signed case.

### See also
Closes #176, closes #114 
It's kind of weird that `bufferToSignedTransaction` works differently with `txn.signTxn` vs `algosdk.signTransaction`, #153 also notes that the two should probably be made to work more like each other
The compatibility-weirdness that came up during this ticket (`Transaction` vs a dict-describing-a-transaction; `signTxn` vs `signTransaction`; etc) is related to the issue described in #81 