### PR TITLE
Add rekey param to make txn functions

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -426,10 +426,11 @@ function tealSignFromProgram(sk, data, program) {
  * @param note - uint8array of arbitrary data for sender to store
  * @param genesisHash - string specifies hash genesis block of network in use
  * @param genesisID - string specifies genesis ID of network in use
+ * @param rekeyTo - rekeyTo address, optional
  * @Deprecated in version 2.0 this will change to use the "WithSuggestedParams" signature.
  * @returns {Transaction}
  */
-function makePaymentTxn(from, to, fee, amount, closeRemainderTo, firstRound, lastRound, note, genesisHash, genesisID) {
+function makePaymentTxn(from, to, fee, amount, closeRemainderTo, firstRound, lastRound, note, genesisHash, genesisID, rekeyTo=undefined) {
     let suggestedParams = {
         "genesisHash": genesisHash,
         "genesisID": genesisID,
@@ -437,7 +438,7 @@ function makePaymentTxn(from, to, fee, amount, closeRemainderTo, firstRound, las
         "lastRound": lastRound,
         "fee": fee
     };
-    return makePaymentTxnWithSuggestedParams(from, to, amount, closeRemainderTo, note, suggestedParams);
+    return makePaymentTxnWithSuggestedParams(from, to, amount, closeRemainderTo, note, suggestedParams, rekeyTo);
 }
 
 /**
@@ -454,10 +455,11 @@ function makePaymentTxn(from, to, fee, amount, closeRemainderTo, firstRound, las
  * lastRound - integer last protocol round on which this txn is valid
  * genesisHash - string specifies hash genesis block of network in use
  * genesisID - string specifies genesis ID of network in use
+ * @param rekeyTo - rekeyTo address, optional
  * @Deprecated in version 2.0 this will change to use the "WithSuggestedParams" signature.
  * @returns {Transaction}
  */
-function makePaymentTxnWithSuggestedParams(from, to, amount, closeRemainderTo, note, suggestedParams) {
+function makePaymentTxnWithSuggestedParams(from, to, amount, closeRemainderTo, note, suggestedParams, rekeyTo=undefined) {
     let o = {
         "from": from,
         "to": to,
@@ -465,7 +467,8 @@ function makePaymentTxnWithSuggestedParams(from, to, amount, closeRemainderTo, n
         "closeRemainderTo": closeRemainderTo,
         "note": note,
         "suggestedParams": suggestedParams,
-        "type": "pay"
+        "type": "pay",
+        "rekeyTo": rekeyTo
     };
     return new txnBuilder.Transaction(o);
 }
@@ -486,11 +489,12 @@ function makePaymentTxnWithSuggestedParams(from, to, amount, closeRemainderTo, n
  * @param voteFirst - first round on which voteKey is valid
  * @param voteLast - last round on which voteKey is valid
  * @param voteKeyDilution - integer
+ * @param rekeyTo - rekeyTo address, optional
  * @Deprecated in version 2.0 this will change to use the "WithSuggestedParams" signature.
  * @returns {Transaction}
  */
 function makeKeyRegistrationTxn(from, fee, firstRound, lastRound, note, genesisHash, genesisID,
-                                voteKey, selectionKey, voteFirst, voteLast, voteKeyDilution) {
+                                voteKey, selectionKey, voteFirst, voteLast, voteKeyDilution, rekeyTo=undefined) {
     let suggestedParams = {
         "genesisHash": genesisHash,
         "genesisID": genesisID,
@@ -498,7 +502,7 @@ function makeKeyRegistrationTxn(from, fee, firstRound, lastRound, note, genesisH
         "lastRound": lastRound,
         "fee": fee
     };
-    return makeKeyRegistrationTxnWithSuggestedParams(from, note, voteKey, selectionKey, voteFirst, voteLast, voteKeyDilution, suggestedParams);
+    return makeKeyRegistrationTxnWithSuggestedParams(from, note, voteKey, selectionKey, voteFirst, voteLast, voteKeyDilution, suggestedParams, rekeyTo);
 }
 
 /**
@@ -519,10 +523,11 @@ function makeKeyRegistrationTxn(from, fee, firstRound, lastRound, note, genesisH
  * lastRound - integer last protocol round on which this txn is valid
  * genesisHash - string specifies hash genesis block of network in use
  * genesisID - string specifies genesis ID of network in use
+ * @param rekeyTo - rekeyTo address, optional
  * @Deprecated in version 2.0 this will change to use the "WithSuggestedParams" signature.
  * @returns {Transaction}
  */
-function makeKeyRegistrationTxnWithSuggestedParams(from, note, voteKey, selectionKey, voteFirst, voteLast, voteKeyDilution, suggestedParams) {
+function makeKeyRegistrationTxnWithSuggestedParams(from, note, voteKey, selectionKey, voteFirst, voteLast, voteKeyDilution, suggestedParams, rekeyTo=undefined) {
     let o = {
         "from": from,
         "note": note,
@@ -532,7 +537,8 @@ function makeKeyRegistrationTxnWithSuggestedParams(from, note, voteKey, selectio
         "voteLast": voteLast,
         "voteKeyDilution": voteKeyDilution,
         "suggestedParams": suggestedParams,
-        "type": "keyreg"
+        "type": "keyreg",
+        "rekeyTo": rekeyTo
     };
     return new txnBuilder.Transaction(o);
 }
@@ -558,12 +564,13 @@ function makeKeyRegistrationTxnWithSuggestedParams(from, note, voteKey, selectio
  * @param assetName - string name for this asset
  * @param assetURL - string URL relating to this asset
  * @param assetMetadataHash - string representation of some sort of hash commitment with respect to the asset
+ * @param rekeyTo - rekeyTo address, optional
  * @Deprecated in version 2.0 this will change to use the "WithSuggestedParams" signature.
  * @returns {Transaction}
  */
 function makeAssetCreateTxn(from, fee, firstRound, lastRound, note, genesisHash, genesisID,
                             total, decimals, defaultFrozen, manager, reserve, freeze,
-                            clawback, unitName, assetName, assetURL, assetMetadataHash) {
+                            clawback, unitName, assetName, assetURL, assetMetadataHash, rekeyTo=undefined) {
     let suggestedParams = {
         "genesisHash": genesisHash,
         "genesisID": genesisID,
@@ -572,7 +579,7 @@ function makeAssetCreateTxn(from, fee, firstRound, lastRound, note, genesisHash,
         "fee": fee
     };
     return makeAssetCreateTxnWithSuggestedParams(from, note, total, decimals, defaultFrozen, manager, reserve, freeze, clawback,
-        unitName, assetName, assetURL, assetMetadataHash, suggestedParams);
+        unitName, assetName, assetURL, assetMetadataHash, suggestedParams, rekeyTo);
 }
 
 /** makeAssetCreateTxnWithSuggestedParams takes asset creation arguments and returns a Transaction object
@@ -598,10 +605,11 @@ function makeAssetCreateTxn(from, fee, firstRound, lastRound, note, genesisHash,
  * lastRound - integer last protocol round on which this txn is valid
  * genesisHash - string specifies hash genesis block of network in use
  * genesisID - string specifies genesis ID of network in use
+ * @param rekeyTo - rekeyTo address, optional
  * @returns {Transaction}
  */
 function makeAssetCreateTxnWithSuggestedParams(from, note, total, decimals, defaultFrozen, manager, reserve, freeze,
-                            clawback, unitName, assetName, assetURL, assetMetadataHash, suggestedParams) {
+                            clawback, unitName, assetName, assetURL, assetMetadataHash, suggestedParams, rekeyTo=undefined) {
     let o = {
         "from": from,
         "note": note,
@@ -617,7 +625,8 @@ function makeAssetCreateTxnWithSuggestedParams(from, note, total, decimals, defa
         "assetReserve": reserve,
         "assetFreeze": freeze,
         "assetClawback": clawback,
-        "type": "acfg"
+        "type": "acfg",
+        "rekeyTo": rekeyTo
     };
     return new txnBuilder.Transaction(o);
 }
@@ -639,11 +648,12 @@ function makeAssetCreateTxnWithSuggestedParams(from, note, total, decimals, defa
  * @param freeze - string representation of new freeze manager Algorand address
  * @param clawback - string representation of new revocation manager Algorand address
  * @param strictEmptyAddressChecking - boolean - throw an error if any of manager, reserve, freeze, or clawback are undefined. optional, defaults to true.
+ * @param rekeyTo - rekeyTo address, optional
  * @Deprecated in version 2.0 this will change to use the "WithSuggestedParams" signature.
  * @returns {Transaction}
  */
 function makeAssetConfigTxn(from, fee, firstRound, lastRound, note, genesisHash, genesisID,
-                            assetIndex, manager, reserve, freeze, clawback, strictEmptyAddressChecking=true) {
+                            assetIndex, manager, reserve, freeze, clawback, strictEmptyAddressChecking=true, rekeyTo=undefined) {
     let suggestedParams = {
         "genesisHash": genesisHash,
         "genesisID": genesisID,
@@ -651,7 +661,7 @@ function makeAssetConfigTxn(from, fee, firstRound, lastRound, note, genesisHash,
         "lastRound": lastRound,
         "fee": fee
     };
-    return makeAssetConfigTxnWithSuggestedParams(from, note, assetIndex, manager, reserve, freeze, clawback, suggestedParams, strictEmptyAddressChecking);
+    return makeAssetConfigTxnWithSuggestedParams(from, note, assetIndex, manager, reserve, freeze, clawback, suggestedParams, strictEmptyAddressChecking, rekeyTo);
 }
 
 /** makeAssetConfigTxnWithSuggestedParams can be issued by the asset manager to change the manager, reserve, freeze, or clawback
@@ -673,10 +683,11 @@ function makeAssetConfigTxn(from, fee, firstRound, lastRound, note, genesisHash,
  * lastRound - integer last protocol round on which this txn is valid
  * genesisHash - string specifies hash genesis block of network in use
  * genesisID - string specifies genesis ID of network in use
+ * @param rekeyTo - rekeyTo address, optional
  * @returns {Transaction}
  */
 function makeAssetConfigTxnWithSuggestedParams(from, note, assetIndex,
-                                      manager, reserve, freeze, clawback, suggestedParams, strictEmptyAddressChecking=true) {
+                                      manager, reserve, freeze, clawback, suggestedParams, strictEmptyAddressChecking=true, rekeyTo=undefined) {
     if (strictEmptyAddressChecking && ((manager === undefined) || (reserve === undefined) || (freeze === undefined) || (clawback === undefined))) {
         throw Error("strict empty address checking was turned on, but at least one empty address was provided");
     }
@@ -689,7 +700,8 @@ function makeAssetConfigTxnWithSuggestedParams(from, note, assetIndex,
         "assetFreeze": freeze,
         "assetClawback": clawback,
         "type": "acfg",
-        "note": note
+        "note": note,
+        "rekeyTo": rekeyTo
     };
     return new txnBuilder.Transaction(o);
 }
@@ -705,10 +717,11 @@ function makeAssetConfigTxnWithSuggestedParams(from, note, assetIndex,
  * @param genesisHash - string specifies hash genesis block of network in use
  * @param genesisID - string specifies genesis ID of network in use
  * @param assetIndex - int asset index uniquely specifying the asset
+ * @param rekeyTo - rekeyTo address, optional
  * @Deprecated in version 2.0 this will change to use the "WithSuggestedParams" signature.
  * @returns {Transaction}
  */
-function makeAssetDestroyTxn(from, fee, firstRound, lastRound, note, genesisHash, genesisID, assetIndex) {
+function makeAssetDestroyTxn(from, fee, firstRound, lastRound, note, genesisHash, genesisID, assetIndex, rekeyTo=undefined) {
     let suggestedParams = {
         "genesisHash": genesisHash,
         "genesisID": genesisID,
@@ -716,7 +729,7 @@ function makeAssetDestroyTxn(from, fee, firstRound, lastRound, note, genesisHash
         "lastRound": lastRound,
         "fee": fee
     };
-    return makeAssetDestroyTxnWithSuggestedParams(from, note, assetIndex, suggestedParams);
+    return makeAssetDestroyTxnWithSuggestedParams(from, note, assetIndex, suggestedParams, rekeyTo);
 }
 
 /** makeAssetDestroyTxnWithSuggestedParams will allow the asset's manager to remove this asset from the ledger, so long
@@ -732,15 +745,17 @@ function makeAssetDestroyTxn(from, fee, firstRound, lastRound, note, genesisHash
  * lastRound - integer last protocol round on which this txn is valid
  * genesisHash - string specifies hash genesis block of network in use
  * genesisID - string specifies genesis ID of network in use
+ * @param rekeyTo - rekeyTo address, optional
  * @returns {Transaction}
  */
-function makeAssetDestroyTxnWithSuggestedParams(from, note, assetIndex, suggestedParams) {
+function makeAssetDestroyTxnWithSuggestedParams(from, note, assetIndex, suggestedParams, rekeyTo=undefined) {
     let o = {
         "from": from,
         "suggestedParams": suggestedParams,
         "assetIndex": assetIndex,
         "type": "acfg",
-        "note": note
+        "note": note,
+        "rekeyTo": rekeyTo
     };
     return new txnBuilder.Transaction(o);
 }
@@ -758,11 +773,12 @@ function makeAssetDestroyTxnWithSuggestedParams(from, note, assetIndex, suggeste
  * @param assetIndex - int asset index uniquely specifying the asset
  * @param freezeTarget - string representation of Algorand address being frozen or unfrozen
  * @param freezeState - true if freezeTarget should be frozen, false if freezeTarget should be allowed to transact
+ * @param rekeyTo - rekeyTo address, optional
  * @Deprecated in version 2.0 this will change to use the "WithSuggestedParams" signature.
  * @returns {Transaction}
  */
 function makeAssetFreezeTxn(from, fee, firstRound, lastRound, note, genesisHash, genesisID,
-                            assetIndex, freezeTarget, freezeState) {
+                            assetIndex, freezeTarget, freezeState, rekeyTo=undefined) {
     let suggestedParams = {
         "genesisHash": genesisHash,
         "genesisID": genesisID,
@@ -770,7 +786,7 @@ function makeAssetFreezeTxn(from, fee, firstRound, lastRound, note, genesisHash,
         "lastRound": lastRound,
         "fee": fee
     };
-    return makeAssetFreezeTxnWithSuggestedParams(from, note, assetIndex, freezeTarget, freezeState, suggestedParams);
+    return makeAssetFreezeTxnWithSuggestedParams(from, note, assetIndex, freezeTarget, freezeState, suggestedParams, rekeyTo);
 }
 
 /** makeAssetFreezeTxnWithSuggestedParams will allow the asset's freeze manager to freeze or un-freeze an account,
@@ -788,9 +804,10 @@ function makeAssetFreezeTxn(from, fee, firstRound, lastRound, note, genesisHash,
  * lastRound - integer last protocol round on which this txn is valid
  * genesisHash - string specifies hash genesis block of network in use
  * genesisID - string specifies genesis ID of network in use
+ * @param rekeyTo - rekeyTo address, optional
  * @returns {Transaction}
  */
-function makeAssetFreezeTxnWithSuggestedParams(from, note, assetIndex, freezeTarget, freezeState, suggestedParams) {
+function makeAssetFreezeTxnWithSuggestedParams(from, note, assetIndex, freezeTarget, freezeState, suggestedParams, rekeyTo=undefined) {
     let o = {
         "from": from,
         "type": "afrz",
@@ -798,7 +815,8 @@ function makeAssetFreezeTxnWithSuggestedParams(from, note, assetIndex, freezeTar
         "assetIndex": assetIndex,
         "freezeState" : freezeState,
         "note": note,
-        "suggestedParams": suggestedParams
+        "suggestedParams": suggestedParams,
+        "rekeyTo": rekeyTo
     };
     return new txnBuilder.Transaction(o);
 }
@@ -821,11 +839,12 @@ function makeAssetFreezeTxnWithSuggestedParams(from, note, assetIndex, freezeTar
  * @param genesisHash - string specifies hash genesis block of network in use
  * @param genesisID - string specifies genesis ID of network in use
  * @param assetIndex - int asset index uniquely specifying the asset
+ * @param rekeyTo - rekeyTo address, optional
  * @Deprecated in version 2.0 this will change to use the "WithSuggestedParams" signature.
  * @returns {Transaction}
  */
 function makeAssetTransferTxn(from, to, closeRemainderTo, revocationTarget,
-                              fee, amount, firstRound, lastRound, note, genesisHash, genesisID, assetIndex) {
+                              fee, amount, firstRound, lastRound, note, genesisHash, genesisID, assetIndex, rekeyTo=undefined) {
     let suggestedParams = {
         "genesisHash": genesisHash,
         "genesisID": genesisID,
@@ -833,7 +852,7 @@ function makeAssetTransferTxn(from, to, closeRemainderTo, revocationTarget,
         "lastRound": lastRound,
         "fee": fee
     };
-    return makeAssetTransferTxnWithSuggestedParams(from, to, closeRemainderTo, revocationTarget, amount, note, assetIndex, suggestedParams);
+    return makeAssetTransferTxnWithSuggestedParams(from, to, closeRemainderTo, revocationTarget, amount, note, assetIndex, suggestedParams, rekeyTo);
 }
 
 /** makeAssetTransferTxnWithSuggestedParams allows for the creation of an asset transfer transaction.
@@ -855,10 +874,11 @@ function makeAssetTransferTxn(from, to, closeRemainderTo, revocationTarget,
  * lastRound - integer last protocol round on which this txn is valid
  * genesisHash - string specifies hash genesis block of network in use
  * genesisID - string specifies genesis ID of network in use
+ * @param rekeyTo - rekeyTo address, optional
  * @returns {Transaction}
  */
 function makeAssetTransferTxnWithSuggestedParams(from, to, closeRemainderTo, revocationTarget,
-                              amount, note, assetIndex, suggestedParams) {
+                              amount, note, assetIndex, suggestedParams, rekeyTo=undefined) {
     let o = {
         "type": "axfer",
         "from": from,
@@ -868,7 +888,8 @@ function makeAssetTransferTxnWithSuggestedParams(from, to, closeRemainderTo, rev
         "assetIndex": assetIndex,
         "note": note,
         "assetRevocationTarget": revocationTarget,
-        "closeRemainderTo": closeRemainderTo
+        "closeRemainderTo": closeRemainderTo,
+        "rekeyTo": rekeyTo
     };
     return new txnBuilder.Transaction(o);
 }

--- a/tests/5.Transaction.js
+++ b/tests/5.Transaction.js
@@ -346,6 +346,7 @@ describe('Sign', function () {
             let note = new Uint8Array([123, 12, 200]);
             let genesisHash = "JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=";
             let genesisID = "";
+            let rekeyTo = "GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM";
             let closeRemainderTo = undefined;
             let o = {
                 "from": from,
@@ -357,10 +358,11 @@ describe('Sign', function () {
                 "lastRound": lastRound,
                 "note": note,
                 "genesisHash": genesisHash,
-                "genesisID": genesisID
+                "genesisID": genesisID,
+                "rekeyTo": rekeyTo
             };
             let expectedTxn = new transaction.Transaction(o);
-            let actualTxn = algosdk.makePaymentTxn(from, to, fee, amount, closeRemainderTo, firstRound, lastRound, note, genesisHash, genesisID);
+            let actualTxn = algosdk.makePaymentTxn(from, to, fee, amount, closeRemainderTo, firstRound, lastRound, note, genesisHash, genesisID, rekeyTo);
             assert.deepStrictEqual(expectedTxn, actualTxn);
         });
 
@@ -372,6 +374,7 @@ describe('Sign', function () {
             let note = new Uint8Array([123, 12, 200]);
             let genesisHash = "JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=";
             let genesisID = "";
+            let rekeyTo = "GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM";
             let voteKey = "5/D4TQaBHfnzHI2HixFV9GcdUaGFwgCQhmf0SVhwaKE=";
             let selectionKey = "oImqaSLjuZj63/bNSAjd+eAh5JROOJ6j1cY4eGaJGX4=";
             let voteKeyDilution = 1234;
@@ -390,11 +393,12 @@ describe('Sign', function () {
                 "voteLast": voteLast,
                 "voteKeyDilution": voteKeyDilution,
                 "genesisID": genesisID,
+                "rekeyTo": rekeyTo,
                 "type": "keyreg"
             };
             let expectedTxn = new transaction.Transaction(o);
             let actualTxn = algosdk.makeKeyRegistrationTxn(from, fee, firstRound, lastRound, note, genesisHash, genesisID,
-                voteKey, selectionKey, voteFirst, voteLast, voteKeyDilution);
+                voteKey, selectionKey, voteFirst, voteLast, voteKeyDilution, rekeyTo);
             assert.deepStrictEqual(expectedTxn, actualTxn);
         });
 
@@ -416,6 +420,7 @@ describe('Sign', function () {
             let firstRound = 322575;
             let lastRound = 322575;
             let note = new Uint8Array([123, 12, 200]);
+            let rekeyTo = "GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM";
             let o = {
                 "from": addr,
                 "fee": fee,
@@ -435,11 +440,12 @@ describe('Sign', function () {
                 "assetFreeze": freeze,
                 "assetClawback": clawback,
                 "genesisID": genesisID,
+                "rekeyTo": rekeyTo,
                 "type": "acfg"
             };
             let expectedTxn = new transaction.Transaction(o);
             let actualTxn = algosdk.makeAssetCreateTxn(addr, fee, firstRound, lastRound, note, genesisHash, genesisID,
-                total, decimals, defaultFrozen, addr, reserve, freeze, clawback, unitName, assetName, assetURL, assetMetadataHash);
+                total, decimals, defaultFrozen, addr, reserve, freeze, clawback, unitName, assetName, assetURL, assetMetadataHash, rekeyTo);
             assert.deepStrictEqual(expectedTxn, actualTxn);
         });
 
@@ -456,6 +462,7 @@ describe('Sign', function () {
             let firstRound = 322575;
             let lastRound = 322575;
             let note = new Uint8Array([123, 12, 200]);
+            let rekeyTo = "GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM";
             let o = {
                 "from": addr,
                 "fee": fee,
@@ -469,11 +476,12 @@ describe('Sign', function () {
                 "assetFreeze": freeze,
                 "assetClawback": clawback,
                 "type": "acfg",
-                "note": note
+                "note": note,
+                "rekeyTo": rekeyTo
             };
             let expectedTxn = new transaction.Transaction(o);
             let actualTxn = algosdk.makeAssetConfigTxn(addr, fee, firstRound, lastRound, note, genesisHash, genesisID,
-                assetIndex, manager, reserve, freeze, clawback);
+                assetIndex, manager, reserve, freeze, clawback, true, rekeyTo);
             assert.deepStrictEqual(expectedTxn, actualTxn);
         });
 
@@ -509,6 +517,7 @@ describe('Sign', function () {
             let firstRound = 322575;
             let lastRound = 322575;
             let note = new Uint8Array([123, 12, 200]);
+            let rekeyTo = "GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM";
             let o = {
                 "from": addr,
                 "fee": fee,
@@ -518,11 +527,12 @@ describe('Sign', function () {
                 "genesisID": genesisID,
                 "assetIndex": assetIndex,
                 "type": "acfg",
-                "note": note
+                "note": note,
+                "rekeyTo": rekeyTo
             };
             let expectedTxn = new transaction.Transaction(o);
             let actualTxn = algosdk.makeAssetDestroyTxn(addr, fee, firstRound, lastRound, note, genesisHash, genesisID,
-                assetIndex);
+                assetIndex, rekeyTo);
             assert.deepStrictEqual(expectedTxn, actualTxn);
         });
 
@@ -541,6 +551,7 @@ describe('Sign', function () {
             let firstRound = 322575;
             let lastRound = 322575;
             let note = new Uint8Array([123, 12, 200]);
+            let rekeyTo = "GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM";
             let o = {
                 "type": "axfer",
                 "from": sender,
@@ -554,11 +565,12 @@ describe('Sign', function () {
                 "assetIndex": assetIndex,
                 "note": note,
                 "assetRevocationTarget": revocationTarget,
-                "closeRemainderTo": closeRemainderTo
+                "closeRemainderTo": closeRemainderTo,
+                "rekeyTo": rekeyTo
             };
             let expectedTxn = new transaction.Transaction(o);
             let actualTxn = algosdk.makeAssetTransferTxn(sender, recipient, closeRemainderTo, revocationTarget,
-                fee, amount, firstRound, lastRound, note, genesisHash, genesisID, assetIndex);
+                fee, amount, firstRound, lastRound, note, genesisHash, genesisID, assetIndex, rekeyTo);
             assert.deepStrictEqual(expectedTxn, actualTxn);
         });
 
@@ -574,6 +586,7 @@ describe('Sign', function () {
             let lastRound = 322575;
             let freezeState = true;
             let note = new Uint8Array([123, 12, 200]);
+            let rekeyTo = "GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM";
             let o = {
                 "from": addr,
                 "fee": fee,
@@ -586,11 +599,12 @@ describe('Sign', function () {
                 "creator" : creator,
                 "freezeState" : freezeState,
                 "note": note,
-                "genesisID": genesisID
+                "genesisID": genesisID,
+                "rekeyTo": rekeyTo
             };
             let expectedTxn = new transaction.Transaction(o);
             let actualTxn = algosdk.makeAssetFreezeTxn(addr, fee, firstRound, lastRound, note, genesisHash, genesisID,
-                assetIndex, freezeTarget, freezeState);
+                assetIndex, freezeTarget, freezeState, rekeyTo);
             assert.deepStrictEqual(expectedTxn, actualTxn);
         });
     });


### PR DESCRIPTION
All make transaction functions now take in an optional `rekeyTo` parameter.

Closes #207