### PR TITLE
Remove travis token from build status image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # js-algorand-sdk
-[![Build Status](https://travis-ci.com/algorand/js-algorand-sdk.svg?token=25XP72ADqbCQJ3TJVC9S&branch=master)](https://travis-ci.com/algorand/js-algorand-sdk) [![npm version](https://badge.fury.io/js/algosdk.svg)](https://badge.fury.io/js/algosdk)
+[![Build Status](https://travis-ci.com/algorand/js-algorand-sdk.svg?branch=master)](https://travis-ci.com/algorand/js-algorand-sdk) [![npm version](https://badge.fury.io/js/algosdk.svg)](https://badge.fury.io/js/algosdk)
 
 AlgoSDK is a javascript library for communicating with the Algorand network for modern browsers and node.js.
 


### PR DESCRIPTION
This token is only necessary for private repositories and could potentially leak private repository (i.e. not this repository) information.