### PR TITLE
Use msgpack fork that supports bigints. 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1192,12 +1192,9 @@
       }
     },
     "@msgpack/msgpack": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-1.9.0.tgz",
-      "integrity": "sha512-m3Z/dOzxgpHMoyeYInpQEPti/ThRRHdtU1ZtHZtJZhoRv9J+xRrRDEUaOf5c2GFf26jlc9HIqF2/ubeI46cvqQ==",
-      "requires": {
-        "base64-js": "^1.3.0"
-      }
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-1.12.2.tgz",
+      "integrity": "sha512-Vwhc3ObxmDZmA5hY8mfsau2rJ4vGPvzbj20QSZ2/E1GDPF61QVyjLfNHak9xmel6pW4heRt3v1fHa6np9Ehfeg=="
     },
     "JSONStream": {
       "version": "1.3.5",
@@ -1250,6 +1247,11 @@
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
+    },
+    "algo-msgpack-with-bigint": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/algo-msgpack-with-bigint/-/algo-msgpack-with-bigint-2.1.0.tgz",
+      "integrity": "sha512-Ac+rO/njXaBvECLLRqZezjQ6z+xtyRMVGcYzW3ghNxAzUPN9Xpo3vTPVhdArh2gehEtCnnAtsPhRpj5OwPMHMQ=="
     },
     "ansi-regex": {
       "version": "2.1.1",
@@ -1929,7 +1931,8 @@
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+      "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "url": "git://github.com/algorand/js-algorand-sdk.git"
   },
   "dependencies": {
-    "@msgpack/msgpack": "^1.9.0",
+    "@msgpack/msgpack": "^1.12.2",
+    "algo-msgpack-with-bigint": "^2.1.0",
     "hi-base32": "^0.5.0",
     "js-sha256": "^0.9.0",
     "js-sha512": "^0.8.0",

--- a/src/encoding/encoding.js
+++ b/src/encoding/encoding.js
@@ -10,7 +10,7 @@
  *  5. Binary blob should be used for binary data and string for strings
  *  */
 
-const msgpack = require("@msgpack/msgpack");
+const msgpack = require("algo-msgpack-with-bigint");
 
 // Errors
 const ERROR_CONTAINS_EMPTY_STRING = "The object contains empty or 0 values. First empty or 0 value encountered during encoding: ";

--- a/tests/2.Encoding.js
+++ b/tests/2.Encoding.js
@@ -51,6 +51,18 @@ describe('encoding', function () {
             assert.notStrictEqual(encoding.encode(o), golden);
         });
 
+        it('should safely encode/decode bigints', function () {
+            let beforeZero = BigInt("0")
+            let afterZero = encoding.decode(encoding.encode(beforeZero));
+            assert.ok(beforeZero == afterZero); //after is a Number because 0 fits into a Number - so we do this loose comparison
+            let beforeLarge = BigInt("18446744073709551612"); // larger than a Number, but fits into a uint64
+            let afterLarge = encoding.decode(encoding.encode(beforeLarge));
+            assert.strictEqual(beforeLarge, afterLarge);
+            let beforeTooLarge = BigInt("18446744073709551616") // larger than even fits into a uint64. we do not want to work with these too-large numbers
+            let afterTooLarge = encoding.decode(encoding.encode(beforeTooLarge));
+            assert.notStrictEqual(beforeTooLarge, afterTooLarge)
+        });
+
         it('should match our go code', function () {
             let golden = new Uint8Array([134, 163, 97, 109, 116, 205, 3, 79, 163, 102, 101, 101, 10, 162, 102, 118, 51, 162, 108, 118, 61, 163, 114, 99, 118, 196, 32, 145, 154, 160, 178, 192, 112, 147, 3, 73, 200, 52, 23, 24, 49, 180, 79, 91, 78, 35, 190, 125, 207, 231, 37, 41, 131, 96, 252, 244, 221, 54, 208, 163, 115, 110, 100, 196, 32, 145, 154, 160, 178, 192, 112, 147, 3, 73, 200, 52, 23, 24, 49, 180, 79, 91, 78, 35, 190, 125, 207, 231, 37, 41, 131, 96, 252, 244, 221, 54, 208]);
            let ad = "SGNKBMWAOCJQGSOIGQLRQMNUJ5NU4I56PXH6OJJJQNQPZ5G5G3IOVLI5VM";


### PR DESCRIPTION
## Summary
See #130. This PR proposes to change the js-sdk to use a fork that supports `BigInt`<->`uint64` encode/decode. 

### See also
Resolves #130 