### PR TITLE
Fix firefox tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ script:
   - make docker-test
 
 jobs:
-  allow_failures:
-    - name: Firefox test
   include:
     - stage: Testing
       name: Node test

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -82,7 +82,7 @@ function HTTPClient(token, baseServer, port, headers={}) {
                 .set(requestHeaders)
                 .send(data);
         } catch (e) {
-            throw e.response;
+            throw e;
         }
     };
 
@@ -95,7 +95,7 @@ function HTTPClient(token, baseServer, port, headers={}) {
                 .set(requestHeaders)
                 .send(data);
         } catch (e) {
-            throw e.response;
+            throw e;
         }
     };
 }

--- a/src/client/v2/algod/models/base.js
+++ b/src/client/v2/algod/models/base.js
@@ -14,12 +14,12 @@ class BaseModel {
         let targetPropValue;
         if (typeof val.get_obj_for_encoding === "function") {
             targetPropValue = val.get_obj_for_encoding();
-        } else if (val instanceof Array) {
-            targetPropValue = new Array();
+        } else if (Array.isArray(val)) {
+            targetPropValue = [];
             for (const elem of val) {
                 targetPropValue.push(this._get_obj_for_encoding(elem))
             }
-        } else if (typeof val == "object") {
+        } else if (typeof val === "object") {
             const obj = {};
             for (const prop of Object.keys(val)) {
                 obj[prop] = this._get_obj_for_encoding(val[prop])

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -71,7 +71,7 @@ class Transaction {
             if (appClearProgram.constructor !== Uint8Array) throw Error("appClearProgram must be a Uint8Array.");
         }
         if (appArgs !== undefined) {
-            if (appArgs.constructor !== Array) throw Error("appArgs must be an Array of Uint8Array.");
+            if (!Array.isArray(appArgs)) throw Error("appArgs must be an Array of Uint8Array.");
             appArgs.forEach((arg) => {
                 if (arg.constructor !== Uint8Array) throw Error("each element of AppArgs must be a Uint8Array.");
             });

--- a/tests/cucumber/browser/test.js
+++ b/tests/cucumber/browser/test.js
@@ -37,3 +37,11 @@ window.getStep = function getStep(type, name) {
 }
 
 window.testWorld = {};
+
+window.makeUint8Array = function makeUint8Array(arg) {
+    return new Uint8Array(arg);
+}
+
+window.makeEmptyObject = function makeEmptyObject() {
+    return {};
+}

--- a/tests/cucumber/docker/Dockerfile
+++ b/tests/cucumber/docker/Dockerfile
@@ -2,24 +2,20 @@ FROM ubuntu:bionic
 
 # install wget, gnupg2, make
 RUN apt-get update -qqy \
-  && apt-get -qqy install wget gnupg2 make \
-  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+  && apt-get -qqy install wget gnupg2 make
 
 # install chrome, firefox
 # based on https://github.com/SeleniumHQ/docker-selenium/blob/trunk/NodeChrome/Dockerfile
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
   && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list \
   && apt-get update -qqy \
-  && apt-get -qqy install google-chrome-stable firefox \
-  && rm /etc/apt/sources.list.d/google-chrome.list \
-  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+  && apt-get -qqy --no-install-recommends install google-chrome-stable firefox
 
 # install node
 RUN wget -q -O - https://deb.nodesource.com/setup_12.x | bash \
-  && apt-get -qqy install nodejs \
+  && apt-get -qqy --no-install-recommends install nodejs \
   && echo "node version: $(node --version)" \
-  && echo "npm version: $(npm --version)" \
-  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+  && echo "npm version: $(npm --version)"
 
 # Copy SDK code into the container
 RUN mkdir -p $HOME/js-algorand-sdk

--- a/tests/cucumber/docker/Dockerfile
+++ b/tests/cucumber/docker/Dockerfile
@@ -1,13 +1,24 @@
-FROM node:14.1.0-stretch
+FROM ubuntu:bionic
 
-# TODO: install firefox
+# install wget, gnupg2, make
+RUN apt-get update -qqy \
+  && apt-get -qqy install wget gnupg2 make \
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
+# install chrome, firefox
 # based on https://github.com/SeleniumHQ/docker-selenium/blob/trunk/NodeChrome/Dockerfile
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
   && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list \
   && apt-get update -qqy \
-  && apt-get -qqy install google-chrome-stable \
+  && apt-get -qqy install google-chrome-stable firefox \
   && rm /etc/apt/sources.list.d/google-chrome.list \
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
+# install node
+RUN wget -q -O - https://deb.nodesource.com/setup_12.x | bash \
+  && apt-get -qqy install nodejs \
+  && echo "node version: $(node --version)" \
+  && echo "npm version: $(npm --version)" \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 # Copy SDK code into the container

--- a/tests/cucumber/steps/index.js
+++ b/tests/cucumber/steps/index.js
@@ -21,8 +21,8 @@ if (browser) {
     const firefoxOptions = new firefox.Options();
 
     if (process.env.CI) {
-        chromeOptions.addArguments(['--no-sandbox','--headless','--disable-gpu']);
-        firefoxOptions.addArguments(['-headless']);
+        chromeOptions.addArguments('--no-sandbox','--headless','--disable-gpu');
+        firefoxOptions.addArguments('-headless');
     }
 
     driverBuilder = new webdriver.Builder()

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -27,6 +27,22 @@ async function loadResource(res) {
     });
 }
 
+/**
+ * This function must be used instead of creating Uint8Arrays directly because of this firefox
+ * issue: https://github.com/mozilla/geckodriver/issues/1798
+ */
+function makeUint8Array(arg) {
+    return new Uint8Array(arg);
+}
+
+/**
+ * This function must be used instead of creating an empty object for use in assert.deepStructEqual
+ * because of this firefox issue: https://github.com/mozilla/geckodriver/issues/1798
+ */
+function makeEmptyObject() {
+    return {};
+}
+
 const steps = {
     given: {},
     when: {},
@@ -153,7 +169,7 @@ module.exports = function getSteps(options) {
             this.gen = gen
         }
         if (note !== "none") {
-            this.note = new Uint8Array(Buffer.from(note, "base64"))
+            this.note = makeUint8Array(Buffer.from(note, "base64"))
         }
     })
     
@@ -313,7 +329,7 @@ module.exports = function getSteps(options) {
                 "lastRound": result["lastRound"] + 1000,
                 "genesisHash": result["genesishashb64"],
                 "genesisID": result["genesisID"],
-                "note": new Uint8Array(Buffer.from(note, "base64")),
+                "note": makeUint8Array(Buffer.from(note, "base64")),
                 "amount": parseInt(amt)
             }
         return this.txn
@@ -337,7 +353,7 @@ module.exports = function getSteps(options) {
                 "lastRound": result["lastRound"] + 1000,
                 "genesisHash": result["genesishashb64"],
                 "genesisID": result["genesisID"],
-                "note": new Uint8Array(Buffer.from(note, "base64")),
+                "note": makeUint8Array(Buffer.from(note, "base64")),
                 "amount": parseInt(amt)
             }
         return this.txn
@@ -393,7 +409,7 @@ module.exports = function getSteps(options) {
     
     Then('the node should be healthy', async function () {
         health = await this.acl.healthCheck();
-        assert.deepStrictEqual(health, {});
+        assert.deepStrictEqual(health, makeEmptyObject());
     });
     
     
@@ -715,7 +731,7 @@ module.exports = function getSteps(options) {
     
     // When("I read a transaction {string} from file {string}", function(string, num){
     //     this.num = num
-    //     this.txn = algosdk.decodeObj(new Uint8Array(fs.readFileSync(maindir + '/temp/raw' + num + '.tx')));
+    //     this.txn = algosdk.decodeObj(makeUint8Array(fs.readFileSync(maindir + '/temp/raw' + num + '.tx')));
     //     return this.txn
     // })
     
@@ -724,13 +740,13 @@ module.exports = function getSteps(options) {
     // })
     
     // Then("the transaction should still be the same", function(){
-    //     stxnew = new Uint8Array(fs.readFileSync(maindir + '/temp/raw' + this.num + '.tx'));
-    //     stxold = new Uint8Array(fs.readFileSync(maindir + '/temp/old' + this.num + '.tx'));
+    //     stxnew = makeUint8Array(fs.readFileSync(maindir + '/temp/raw' + this.num + '.tx'));
+    //     stxold = makeUint8Array(fs.readFileSync(maindir + '/temp/old' + this.num + '.tx'));
     //     assert.deepStrictEqual(stxnew, stxold)
     // })
     
     // Then("I do my part", async function(){
-    //     stx = new Uint8Array(fs.readFileSync(maindir + '/temp/txn.tx'));
+    //     stx = makeUint8Array(fs.readFileSync(maindir + '/temp/txn.tx'));
     //     this.txid = await this.acl.sendRawTransaction(stx)
     //     this.txid = this.txid.txId
     //     return this.txid
@@ -754,7 +770,7 @@ module.exports = function getSteps(options) {
             this.gen = gen
         }
         if (note !== "none") {
-            this.note = new Uint8Array(Buffer.from(note, "base64"))
+            this.note = makeUint8Array(Buffer.from(note, "base64"))
         }
         this.votekey = votekey
         this.selkey = selkey
@@ -1632,7 +1648,7 @@ module.exports = function getSteps(options) {
     let anySendRawTransactionResponse;
     
     When('we make any Send Raw Transaction call', async function () {
-        anySendRawTransactionResponse = await this.v2Client.sendRawTransaction(new Uint8Array(0)).do()
+        anySendRawTransactionResponse = await this.v2Client.sendRawTransaction(makeUint8Array(0)).do()
     });
     
     Then('the parsed Send Raw Transaction response should have txid {string}', function (txid) {
@@ -2436,7 +2452,7 @@ module.exports = function getSteps(options) {
             compileResponse = await this.v2Client.compile(data).do();
             compileStatusCode = 200
         } catch (e) {
-            compileStatusCode = e.statusCode;
+            compileStatusCode = e.response.statusCode;
             compileResponse = {
                 result: "",
                 hash: ""
@@ -2479,7 +2495,7 @@ module.exports = function getSteps(options) {
     });
     
     Then('the signature should be equal to {string}', function (expectedEncoded) {
-        const expected = new Uint8Array(Buffer.from(expectedEncoded, "base64"));
+        const expected = makeUint8Array(Buffer.from(expectedEncoded, "base64"));
         assert.deepStrictEqual(this.sig, expected);
     });
     
@@ -2522,11 +2538,11 @@ module.exports = function getSteps(options) {
         subArgs.forEach((subArg) => {
            switch (subArg[0]) {
                case "str":
-                   appArgs.push(new Uint8Array(Buffer.from(subArg[1])));
+                   appArgs.push(makeUint8Array(Buffer.from(subArg[1])));
                    break;
                case "int":
     
-                   appArgs.push(new Uint8Array([parseInt(subArg[1])]));
+                   appArgs.push(makeUint8Array([parseInt(subArg[1])]));
                    break;
                case "addr":
                    appArgs.push(algosdk.decodeAddress(subArg[1])["publicKey"]);
@@ -2546,13 +2562,13 @@ module.exports = function getSteps(options) {
         let approvalProgramBytes = undefined;
         if (approvalProgramFile !== "") {
             const resource = await loadResource(approvalProgramFile);
-            approvalProgramBytes = new Uint8Array(resource);
+            approvalProgramBytes = makeUint8Array(resource);
         }
         // open and load in clear program
         let clearProgramBytes = undefined;
         if (clearProgramFile !== "") {
             const resource = await loadResource(clearProgramFile);
-            clearProgramBytes = new Uint8Array(resource);
+            clearProgramBytes = makeUint8Array(resource);
         }
         // split and process app args
         let appArgs = undefined;
@@ -2663,13 +2679,13 @@ module.exports = function getSteps(options) {
         let approvalProgramBytes = undefined;
         if (approvalProgramFile !== "") {
             const resouce = await loadResource(approvalProgramFile);
-            approvalProgramBytes = new Uint8Array(resouce);
+            approvalProgramBytes = makeUint8Array(resouce);
         }
         // open and load in clear program
         let clearProgramBytes = undefined;
         if (clearProgramFile !== "") {
             const resouce = await loadResource(clearProgramFile);
-            clearProgramBytes = new Uint8Array(resouce);
+            clearProgramBytes = makeUint8Array(resouce);
         }
         // split and process app args
         let appArgs = undefined;
@@ -2726,8 +2742,8 @@ module.exports = function getSteps(options) {
         }
         catch(err) {
             if (errorString !== "") {
-                // error was expected. check that err.text includes expected string.
-                let errorContainsString = err.text.includes(errorString);
+                // error was expected. check that err.response.text includes expected string.
+                let errorContainsString = err.response.text.includes(errorString);
                 assert.deepStrictEqual(true, errorContainsString)
             } else {
                 // unexpected error, rethrow.

--- a/tests/mocha.js
+++ b/tests/mocha.js
@@ -50,8 +50,8 @@ async function testRunner() {
         const firefoxOptions = new firefox.Options();
     
         if (process.env.CI) {
-            chromeOptions.addArguments(['--no-sandbox','--headless','--disable-gpu']);
-            firefoxOptions.addArguments(['-headless']);
+            chromeOptions.addArguments('--no-sandbox','--headless','--disable-gpu');
+            firefoxOptions.addArguments('-headless');
         }
     
         const driver = await new webdriver.Builder()


### PR DESCRIPTION
* Switched to an Ubuntu base image for the docker test runner since installing Firefox on Debian proved to be more difficult.
* Firefox tests were failing because of the issue I pointed out here: https://github.com/mozilla/geckodriver/issues/1798. I implemented a workaround to this by using the helper functions `makeUint8Array` and `makeEmptyObject` and by fixing how we check for arrays in the SDK.
* I also found that the code for POST and DELETE requests throw a `Response` object instead of an `Error` if an error occurs, so I fixed this to improve the error message that gets displayed.