### PR TITLE
Pretty Print function for Transaction

### DIFF
--- a/src/transaction.js
+++ b/src/transaction.js
@@ -591,6 +591,27 @@ class Transaction {
             this.fee += (ALGORAND_TRANSACTION_REKEY_LABEL_LENGTH + ALGORAND_TRANSACTION_ADDRESS_LENGTH) * feePerByte;
         }
     }
+
+    // pretty print the transaction to console
+    prettyPrint() {
+        let forPrinting = {
+            ...this
+        };
+        forPrinting.tag = forPrinting.tag.toString();
+        forPrinting.from = address.encodeAddress(forPrinting.from.publicKey);
+        if (forPrinting.to !== undefined) forPrinting.to = address.encodeAddress(forPrinting.to.publicKey);
+        // things that need fixing:
+        if (forPrinting.closeRemainderTo !== undefined) forPrinting.closeRemainderTo = address.encodeAddress(forPrinting.closeRemainderTo.publicKey);
+        if (forPrinting.assetManager !== undefined) forPrinting.assetManager = address.encodeAddress(forPrinting.assetManager.publicKey);
+        if (forPrinting.assetReserve !== undefined) forPrinting.assetReserve = address.encodeAddress(forPrinting.assetReserve.publicKey);
+        if (forPrinting.assetFreeze !== undefined) forPrinting.assetFreeze = address.encodeAddress(forPrinting.assetFreeze.publicKey);
+        if (forPrinting.assetClawback !== undefined) forPrinting.assetClawback = address.encodeAddress(forPrinting.assetClawback.publicKey);
+        if (forPrinting.assetRevocationTarget !== undefined) forPrinting.assetRevocationTarget = address.encodeAddress(forPrinting.assetRevocationTarget.publicKey);
+        if (forPrinting.reKeyTo !== undefined) forPrinting.reKeyTo = address.encodeAddress(forPrinting.reKeyTo.publicKey);
+        forPrinting.genesisHash = forPrinting.genesisHash.toString('base64');
+
+        console.log(forPrinting);
+    }
 }
 
 /**

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -592,8 +592,7 @@ class Transaction {
         }
     }
 
-    // pretty print the transaction to console
-    prettyPrint() {
+    getDictForDisplay() {
         let forPrinting = {
             ...this
         };
@@ -609,8 +608,17 @@ class Transaction {
         if (forPrinting.assetRevocationTarget !== undefined) forPrinting.assetRevocationTarget = address.encodeAddress(forPrinting.assetRevocationTarget.publicKey);
         if (forPrinting.reKeyTo !== undefined) forPrinting.reKeyTo = address.encodeAddress(forPrinting.reKeyTo.publicKey);
         forPrinting.genesisHash = forPrinting.genesisHash.toString('base64');
+        return forPrinting;
+    }
 
-        console.log(forPrinting);
+    // pretty print the transaction to console
+    prettyPrint() {
+        console.log(this.getDictForDisplay());
+    }
+
+    // get string representation
+    toString() {
+        return JSON.stringify(this.getDictForDisplay());
     }
 }
 

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -592,7 +592,8 @@ class Transaction {
         }
     }
 
-    getDictForDisplay() {
+    // build display dict for prettyPrint and toString
+    _getDictForDisplay() {
         let forPrinting = {
             ...this
         };
@@ -613,12 +614,12 @@ class Transaction {
 
     // pretty print the transaction to console
     prettyPrint() {
-        console.log(this.getDictForDisplay());
+        console.log(this._getDictForDisplay());
     }
 
     // get string representation
     toString() {
-        return JSON.stringify(this.getDictForDisplay());
+        return JSON.stringify(this._getDictForDisplay());
     }
 }
 

--- a/tests/5.Transaction.js
+++ b/tests/5.Transaction.js
@@ -87,6 +87,22 @@ describe('Sign', function () {
 
     });
 
+    it('should be able to prettyprint without throwing', function() {
+        let o = {
+            "from": "7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q",
+            "to": "7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q",
+            "fee": 10,
+            "amount": 847,
+            "firstRound": 51,
+            "lastRound": 61,
+            "genesisHash": "JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=",
+            "note": new Uint8Array(0)
+        };
+        let txn = new algosdk.Transaction(o);
+        // assert package recommends just calling prettyPrint over using assert.doesNotThrow
+        txn.prettyPrint(); // should not throw
+    });
+
     describe('should correctly serialize and deserialize from msgpack representation', function () {
         it('should correctly serialize and deserialize from msgpack representation', function() {
             let o = {

--- a/tests/5.Transaction.js
+++ b/tests/5.Transaction.js
@@ -87,7 +87,7 @@ describe('Sign', function () {
 
     });
 
-    it('should be able to prettyprint without throwing', function() {
+    it('should be able to prettyprint and go toString without throwing', function() {
         let o = {
             "from": "7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q",
             "to": "7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q",
@@ -101,6 +101,7 @@ describe('Sign', function () {
         let txn = new algosdk.Transaction(o);
         // assert package recommends just calling prettyPrint over using assert.doesNotThrow
         txn.prettyPrint(); // should not throw
+        let dummyString = txn.toString(); // also should not throw
     });
 
     describe('should correctly serialize and deserialize from msgpack representation', function () {


### PR DESCRIPTION
## Summary 
If you have a built `Transaction`, then calling `console.log(theTxn)` does not give very useful information. Addresses are formatted for bytes, for example. This PR proposes to add a `prettyPrint()` function on class `Transaction` for user-dev debug.

I am especially looking for feedback on what fields should be edited and how. Currently the focus is on returning addresses to string, the genesis hash displays as b64, and the tag is returned to normal.

## Testing
Added a minimal unit test that checks if pretty print throws.

### See Also
Closes #240