### PR TITLE
Validate that assetMetaDataHash is 32 bytes

### DIFF
--- a/src/makeTxn.js
+++ b/src/makeTxn.js
@@ -166,7 +166,7 @@ function makeKeyRegistrationTxnWithSuggestedParamsFromObject(o) {
  * @param unitName - string units name for this asset
  * @param assetName - string name for this asset
  * @param assetURL - string URL relating to this asset
- * @param assetMetadataHash - string representation of some sort of hash commitment with respect to the asset
+ * @param assetMetadataHash - Uint8Array or UTF-8 string representation of a hash commitment with respect to the asset. Must be exactly 32 bytes long.
  * @param rekeyTo - rekeyTo address, optional
  * @Deprecated in version 2.0 this will change to use the "WithSuggestedParams" signature.
  * @returns {Transaction}
@@ -200,7 +200,7 @@ function makeAssetCreateTxn(from, fee, firstRound, lastRound, note, genesisHash,
  * @param unitName - string units name for this asset
  * @param assetName - string name for this asset
  * @param assetURL - string URL relating to this asset
- * @param assetMetadataHash - string representation of some sort of hash commitment with respect to the asset
+ * @param assetMetadataHash - Uint8Array or UTF-8 string representation of a hash commitment with respect to the asset. Must be exactly 32 bytes long.
  * @param suggestedParams - a dict holding common-to-all-txns args:
  * fee - integer fee per byte, in microAlgos. for a flat fee, set flatFee to true
  * flatFee - bool optionally set this to true to specify fee as microalgos-per-txn

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -94,6 +94,18 @@ class Transaction {
                 if (!Number.isSafeInteger(foreignAssetIndex) || foreignAssetIndex < 0) throw Error("each foreign asset index must be a positive number and smaller than 2^53-1");
             });
         }
+        if (assetMetadataHash !== undefined && assetMetadataHash.length !== 0) {
+            if (typeof(assetMetadataHash) === 'string') {
+                const encoded = Buffer.from(assetMetadataHash);
+                if (encoded.byteLength !== 32) {
+                    throw Error("assetMetadataHash must be a 32 byte Uint8Array or string.");
+                }
+                assetMetadataHash = new Uint8Array(encoded);
+            } else if (assetMetadataHash.constructor !== Uint8Array || assetMetadataHash.byteLength !== 32)
+                throw Error("assetMetadataHash must be a 32 byte Uint8Array or string.");
+        } else {
+            assetMetadataHash = undefined;
+        }
         if (note !== undefined) {
             if (note.constructor !== Uint8Array) throw Error("note must be a Uint8Array.");
         }

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -13,6 +13,7 @@ const NUM_ADDL_BYTES_AFTER_SIGNING = 75; // NUM_ADDL_BYTES_AFTER_SIGNING is the 
 const ALGORAND_TRANSACTION_LEASE_LABEL_LENGTH = 5
 const ALGORAND_TRANSACTION_ADDRESS_LENGTH = 32;
 const ALGORAND_TRANSACTION_REKEY_LABEL_LENGTH = 5;
+const ASSET_METADATA_HASH_LENGTH = 32;
 /**
  * Transaction enables construction of Algorand transactions
  * */
@@ -97,12 +98,12 @@ class Transaction {
         if (assetMetadataHash !== undefined && assetMetadataHash.length !== 0) {
             if (typeof(assetMetadataHash) === 'string') {
                 const encoded = Buffer.from(assetMetadataHash);
-                if (encoded.byteLength !== 32) {
-                    throw Error("assetMetadataHash must be a 32 byte Uint8Array or string.");
+                if (encoded.byteLength !== ASSET_METADATA_HASH_LENGTH) {
+                    throw Error("assetMetadataHash must be a " + ASSET_METADATA_HASH_LENGTH + " byte Uint8Array or string.");
                 }
                 assetMetadataHash = new Uint8Array(encoded);
-            } else if (assetMetadataHash.constructor !== Uint8Array || assetMetadataHash.byteLength !== 32)
-                throw Error("assetMetadataHash must be a 32 byte Uint8Array or string.");
+            } else if (assetMetadataHash.constructor !== Uint8Array || assetMetadataHash.byteLength !== ASSET_METADATA_HASH_LENGTH)
+                throw Error("assetMetadataHash must be a " + ASSET_METADATA_HASH_LENGTH + " byte Uint8Array or string.");
         } else {
             assetMetadataHash = undefined;
         }

--- a/tests/5.Transaction.js
+++ b/tests/5.Transaction.js
@@ -1,5 +1,6 @@
 
 const assert = require('assert');
+const { Buffer } = require('buffer');
 const algosdk = require('../index');
 const group = require('../src/group');
 

--- a/tests/5.Transaction.js
+++ b/tests/5.Transaction.js
@@ -210,7 +210,7 @@ describe('Sign', function () {
                 "assetUnitName": "tests",
                 "assetName": "testcoin",
                 "assetURL": "testURL",
-                "assetMetadataHash": "metadatahash",
+                "assetMetadataHash": new Uint8Array(Buffer.from("ZkFDUE80blJnTzU1ajFuZEFLM1c2U2djNEFQa2N5Rmg=", "base64")),
                 "assetManager": address,
                 "assetReserve": address,
                 "assetFreeze": address,
@@ -430,7 +430,7 @@ describe('Sign', function () {
             let unitName = "tst";
             let assetName = "testcoin";
             let assetURL = "testURL";
-            let assetMetadataHash = "testhash";
+            let assetMetadataHash = new Uint8Array(Buffer.from("dGVzdGhhc2gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", "base64"));
             let genesisID = "";
             let firstRound = 322575;
             let lastRound = 322575;
@@ -462,6 +462,103 @@ describe('Sign', function () {
             let actualTxn = algosdk.makeAssetCreateTxn(addr, fee, firstRound, lastRound, note, genesisHash, genesisID,
                 total, decimals, defaultFrozen, addr, reserve, freeze, clawback, unitName, assetName, assetURL, assetMetadataHash, rekeyTo);
             assert.deepStrictEqual(expectedTxn, actualTxn);
+        });
+
+        it('should fail to make an asset create transaction with an invalid assetMetadataHash', function() {
+            let addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4";
+            let fee = 10;
+            let defaultFrozen = false;
+            let genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=";
+            let total = 100;
+            let decimals = 0;
+            let reserve = addr;
+            let freeze = addr;
+            let clawback = addr;
+            let unitName = "tst";
+            let assetName = "testcoin";
+            let assetURL = "testURL";
+            let genesisID = "";
+            let firstRound = 322575;
+            let lastRound = 322575;
+            let note = new Uint8Array([123, 12, 200]);
+            let rekeyTo = "GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM";
+            let txnTemplate = {
+                "from": addr,
+                "fee": fee,
+                "firstRound": firstRound,
+                "lastRound": lastRound,
+                "note": note,
+                "genesisHash": genesisHash,
+                "assetTotal": total,
+                "assetDecimals": decimals,
+                "assetDefaultFrozen": defaultFrozen,
+                "assetUnitName": unitName,
+                "assetName": assetName,
+                "assetURL": assetURL,
+                "assetManager": addr,
+                "assetReserve": reserve,
+                "assetFreeze": freeze,
+                "assetClawback": clawback,
+                "genesisID": genesisID,
+                "rekeyTo": rekeyTo,
+                "type": "acfg"
+            };
+            assert.doesNotThrow(() => {
+                let txnParams = {
+                    assetMetadataHash: '',
+                    ...txnTemplate
+                };
+                new algosdk.Transaction(txnParams);
+            });
+            assert.throws(() => {
+                let txnParams = {
+                    assetMetadataHash: 'abc',
+                    ...txnTemplate
+                };
+                new algosdk.Transaction(txnParams);
+            });
+            assert.doesNotThrow(() => {
+                let txnParams = {
+                    assetMetadataHash: 'fACPO4nRgO55j1ndAK3W6Sgc4APkcyFh',
+                    ...txnTemplate
+                };
+                new algosdk.Transaction(txnParams);
+            });
+            assert.throws(() => {
+                let txnParams = {
+                    assetMetadataHash: 'fACPO4nRgO55j1ndAK3W6Sgc4APkcyFh1',
+                    ...txnTemplate
+                };
+                new algosdk.Transaction(txnParams);
+            });
+            assert.doesNotThrow(() => {
+                let txnParams = {
+                    assetMetadataHash: new Uint8Array(0),
+                    ...txnTemplate
+                };
+                new algosdk.Transaction(txnParams);
+            });
+            assert.throws(() => {
+                let txnParams = {
+                    assetMetadataHash: new Uint8Array([1, 2, 3]),
+                    ...txnTemplate
+                };
+                new algosdk.Transaction(txnParams);
+            });
+            assert.doesNotThrow(() => {
+                let txnParams = {
+                    assetMetadataHash: new Uint8Array(32),
+                    ...txnTemplate
+                };
+                new algosdk.Transaction(txnParams);
+            });
+            assert.throws(() => {
+                let txnParams = {
+                    assetMetadataHash: new Uint8Array(33),
+                    ...txnTemplate
+                };
+                new algosdk.Transaction(txnParams);
+            });
         });
 
         it('should be able to use helper to make an asset config transaction', function() {


### PR DESCRIPTION
Currently, the Javascript SDK does not validate `assetMetadataHash` properly. This value is supposed to be exactly 32 bytes long, but if you pass in a smaller value the Javascript SDK will construct and sign a transaction with that smaller value.

Then when the transaction reaches the server, the `assetMetadataHash` gets unpacked into [the field here](https://github.com/algorand/go-algorand/blob/1424855ad2b5f6755ff3feba7e419ee06f2493da/data/basics/userBalance.go#L354), which is 32 bytes long. In the case of a smaller value, it appears extra 0s are added. This means that when the server tries to verify the transaction signature it fails because a different transaction with a shorter `assetMetadataHash` was actually signed in Javascript.

This PR fixes this by throwing an error if `assetMetadataHash` isn't 32 bytes long, and I've made it so that an empty string or a zero-length Uint8Array also get treated the same as `undefined` for this field.

Closes #250.