### PR TITLE
Fix React multisig error

### DIFF
--- a/src/multisig.js
+++ b/src/multisig.js
@@ -146,7 +146,11 @@ function mergeMultisigTransactions(multisigTxnBlobs) {
         newSubsigs = unisig.msig.subsig.map((uniSubsig, index) => {
             let current = newSubsigs[index];
             if (current.s) {
-                if (uniSubsig.s && Buffer.compare(uniSubsig.s, current.s) !== 0) {
+                // we convert the Uint8Arrays uniSubsig.s and current.s to Buffers here because (as
+                // of Dec 2020) React overrides the buffer package with an older version that does
+                // not support Uint8Arrays in the comparison function. See this thread for more
+                // info: https://github.com/algorand/js-algorand-sdk/issues/252
+                if (uniSubsig.s && Buffer.compare(Buffer.from(uniSubsig.s), Buffer.from(current.s)) !== 0) {
                     // mismatch
                     throw ERROR_MULTISIG_MERGE_SIG_MISMATCH;
                 }


### PR DESCRIPTION
The `mergeMultisigTransactions` function currently does not work when used in a React app because it calls `Buffer.compare` with Uint8Array arguments. The latest version of the `buffer` package supports this, but unfortunately [react-scripts](https://www.npmjs.com/package/react-scripts) v4.0.1 uses an older version of webpack to build apps, which overrides the `buffer` package with an older version that does not support comparing Uint8Arrays.

This PR converts the Uint8Array arguments to Buffers before calling `Buffer.compare` to fix this issue.

When react-scripts updates to webpack v5 (tracked by [this issue](https://github.com/facebook/create-react-app/issues/9994)), it should stop overriding the `buffer` module and this change can be reverted.

Fixes #252.