### PR TITLE
Support for decoding BigInts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -573,6 +573,11 @@
       "integrity": "sha1-Qpzuu/pffpNueNc/vcfacWKyDiA=",
       "dev": true
     },
+    "bignumber.js": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -2286,6 +2291,14 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true
+    },
+    "json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "requires": {
+        "bignumber.js": "^9.0.0"
+      }
     },
     "json-parse-better-errors": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "js-sha256": "^0.9.0",
     "js-sha3": "^0.8.0",
     "js-sha512": "^0.8.0",
+    "json-bigint": "^1.0.0",
     "superagent": "^6.1.0",
     "tweetnacl": "^1.0.3"
   },

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -1,5 +1,39 @@
 const { Buffer } = require("buffer");
 const request = require("superagent");
+const utils = require("../utils/utils");
+
+function createJSONParser(options) {
+    return (value, fn) => {
+        if (fn == null) {
+            // in browser
+            return utils.parseJSON(value, options);
+        }
+
+        // in node
+        // based off https://github.com/visionmedia/superagent/blob/1277a880c32191e300b229e352e0633e421046c8/src/node/parsers/json.js
+        const res = value;
+        res.text = '';
+        res.setEncoding('utf8');
+        res.on('data', (chunk) => {
+            res.text += chunk;
+        });
+        res.on('end', () => {
+            let body;
+            let err;
+            try {
+                body = res.text && utils.parseJSON(res.text, options);
+            } catch (err_) {
+                err = err_;
+                // issue #675: return the raw response if the response parsing fails
+                err.rawResponse = res.text || null;
+                // issue #876: return the http status code if the response parsing fails
+                err.statusCode = res.statusCode;
+            } finally {
+                fn(err, body);
+            }
+        });
+    };
+}
 
 /**
  * removeEmpty gets a dictionary and removes empty values
@@ -44,7 +78,7 @@ function HTTPClient(token, baseServer, port, headers={}) {
     this.token = token;
     this.defaultHeaders = headers;
 
-    this.get = async function (path, query, requestHeaders={}) {
+    this.get = async function (path, query, requestHeaders={}, useBigInt=false) {
         try {
             const format = getAccceptFormat(query);
             let r = request
@@ -57,6 +91,8 @@ function HTTPClient(token, baseServer, port, headers={}) {
             
             if (format === 'application/msgpack') {
                 r = r.responseType('arraybuffer');
+            } else if (format === 'application/json') {
+                r = r.buffer(true).parse(createJSONParser({ useBigInt }));
             }
             
             const res = await r;

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -77,7 +77,20 @@ function HTTPClient(token, baseServer, port, headers={}) {
     this.token = token;
     this.defaultHeaders = headers;
 
-    this.get = async function (path, query, requestHeaders={}, useBigInt=false) {
+    /**
+     * Send a GET request.
+     * @param {string} path The path of the request.
+     * @param {object} query An object containing the query paramters of the request.
+     * @param {object} requestHeaders An object containing additional request headers to use.
+     * @param {boolean} useBigInt If true and the response for this request returns JSON, the all
+     *   integers in the response will be decoded as BigInts. If false and the request returns JSON,
+     *   all integers will be decoded as Numbers and if the response contains any integers greater
+     *   than Number.MAX_SAFE_INTEGER an error will be thrown. If this parameter is omitted, the
+     *   JSON response will be parsed regularly and no additional checks on integer values will be
+     *   performed.
+     * @returns {Promise<object>} Response object.
+     */
+    this.get = async function (path, query, requestHeaders={}, useBigInt=undefined) {
         try {
             const format = getAccceptFormat(query);
             let r = request
@@ -90,7 +103,7 @@ function HTTPClient(token, baseServer, port, headers={}) {
             
             if (format === 'application/msgpack') {
                 r = r.responseType('arraybuffer');
-            } else if (format === 'application/json') {
+            } else if (format === 'application/json' && useBigInt != null) {
                 if (r.buffer !== r.ca) {
                     // in node, need to set buffer
                     r = r.buffer(true);

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -6,7 +6,7 @@ function createJSONParser(options) {
     return (res, fn) => {
         if (typeof fn === 'string') {
             // in browser
-            return utils.parseJSON(fn, options);
+            return fn && utils.parseJSON(fn, options);
         }
 
         // in node

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -3,15 +3,14 @@ const request = require("superagent");
 const utils = require("../utils/utils");
 
 function createJSONParser(options) {
-    return (value, fn) => {
-        if (fn == null) {
+    return (res, fn) => {
+        if (typeof fn === 'string') {
             // in browser
-            return utils.parseJSON(value, options);
+            return utils.parseJSON(fn, options);
         }
 
         // in node
         // based off https://github.com/visionmedia/superagent/blob/1277a880c32191e300b229e352e0633e421046c8/src/node/parsers/json.js
-        const res = value;
         res.text = '';
         res.setEncoding('utf8');
         res.on('data', (chunk) => {
@@ -92,7 +91,11 @@ function HTTPClient(token, baseServer, port, headers={}) {
             if (format === 'application/msgpack') {
                 r = r.responseType('arraybuffer');
             } else if (format === 'application/json') {
-                r = r.buffer(true).parse(createJSONParser({ useBigInt }));
+                if (r.buffer !== r.ca) {
+                    // in node, need to set buffer
+                    r = r.buffer(true);
+                }
+                r = r.parse(createJSONParser({ useBigInt }));
             }
             
             const res = await r;

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -82,15 +82,11 @@ function HTTPClient(token, baseServer, port, headers={}) {
      * @param {string} path The path of the request.
      * @param {object} query An object containing the query paramters of the request.
      * @param {object} requestHeaders An object containing additional request headers to use.
-     * @param {boolean} useBigInt If true and the response for this request returns JSON, the all
-     *   integers in the response will be decoded as BigInts. If false and the request returns JSON,
-     *   all integers will be decoded as Numbers and if the response contains any integers greater
-     *   than Number.MAX_SAFE_INTEGER an error will be thrown. If this parameter is omitted, the
-     *   JSON response will be parsed regularly and no additional checks on integer values will be
-     *   performed.
+     * @param {object} jsonOptions Options object to use to decode JSON responses. See
+     *   utils.parseJSON for the options available.
      * @returns {Promise<object>} Response object.
      */
-    this.get = async function (path, query, requestHeaders={}, useBigInt=undefined) {
+    this.get = async function (path, query, requestHeaders={}, jsonOptions={}) {
         try {
             const format = getAccceptFormat(query);
             let r = request
@@ -103,12 +99,12 @@ function HTTPClient(token, baseServer, port, headers={}) {
             
             if (format === 'application/msgpack') {
                 r = r.responseType('arraybuffer');
-            } else if (format === 'application/json' && useBigInt != null) {
+            } else if (format === 'application/json' && Object.keys(jsonOptions).length !== 0) {
                 if (r.buffer !== r.ca) {
                     // in node, need to set buffer
                     r = r.buffer(true);
                 }
-                r = r.parse(createJSONParser({ useBigInt }));
+                r = r.parse(createJSONParser(jsonOptions));
             }
             
             const res = await r;

--- a/src/client/v2/algod/accountInformation.js
+++ b/src/client/v2/algod/accountInformation.js
@@ -1,8 +1,8 @@
 const { JSONRequest } = require('../jsonrequest');
 
 class AccountInformation extends JSONRequest {
-	constructor(c, account) {
-	    super(c);
+	constructor(c, intDecoding, account) {
+	    super(c, intDecoding);
         this.account = account;
     }
 

--- a/src/client/v2/algod/accountInformation.js
+++ b/src/client/v2/algod/accountInformation.js
@@ -1,20 +1,13 @@
-class AccountInformation {
+const { JSONRequest } = require('../jsonrequest');
+
+class AccountInformation extends JSONRequest {
 	constructor(c, account) {
-	    this.c = c;
+	    super(c);
         this.account = account;
     }
 
-    /**
-     * accountInformation returns the passed account's information
-     * @param {object} headers Additional headers to include in the request.
-     * @param {boolean} useBigInt If true, all integers in the response will be decoded as BigInts.
-     *   If false, all integers will be decoded as Numbers and if the response contains integers
-     *   greater than Number.MAX_SAFE_INTEGER, an error will be thrown. Defaults to false.
-     * @returns {Promise<*>}
-     */
-    async do(headers={}, useBigInt=false) {
-        const res = await this.c.get("/v2/accounts/" + this.account, {}, headers, useBigInt);
-        return res.body;
+    _path() {
+        return "/v2/accounts/" + this.account;
     }
 }
 

--- a/src/client/v2/algod/accountInformation.js
+++ b/src/client/v2/algod/accountInformation.js
@@ -1,3 +1,5 @@
+const utils = require('../../../utils/utils');
+
 class AccountInformation {
 	constructor(c, account) {
 	    this.c = c;
@@ -10,7 +12,10 @@ class AccountInformation {
      * @returns {Promise<*>}
      */
     async do(headers={}) {
-        let res = await this.c.get("/v2/accounts/" + this.account, {}, headers);
+        const res = await this.c.get("/v2/accounts/" + this.account, {}, headers);
+        if (res.text) {
+            res.body = utils.JSONParseWithBigInt(res.text);
+        }
         return res.body;
     }
 }

--- a/src/client/v2/algod/accountInformation.js
+++ b/src/client/v2/algod/accountInformation.js
@@ -1,5 +1,3 @@
-const utils = require('../../../utils/utils');
-
 class AccountInformation {
 	constructor(c, account) {
 	    this.c = c;
@@ -8,14 +6,14 @@ class AccountInformation {
 
     /**
      * accountInformation returns the passed account's information
-     * @param headers, optional
+     * @param {object} headers Additional headers to include in the request.
+     * @param {boolean} useBigInt If true, all integers in the response will be decoded as BigInts.
+     *   If false, all integers will be decoded as Numbers and if the response contains integers
+     *   greater than Number.MAX_SAFE_INTEGER, an error will be thrown. Defaults to false.
      * @returns {Promise<*>}
      */
-    async do(headers={}) {
-        const res = await this.c.get("/v2/accounts/" + this.account, {}, headers);
-        if (res.text) {
-            res.body = utils.JSONParseWithBigInt(res.text);
-        }
+    async do(headers={}, useBigInt=false) {
+        const res = await this.c.get("/v2/accounts/" + this.account, {}, headers, useBigInt);
         return res.body;
     }
 }

--- a/src/client/v2/algod/algod.js
+++ b/src/client/v2/algod/algod.js
@@ -48,15 +48,15 @@ class AlgodClient {
     }
 
     healthCheck() {
-        return new hc.HealthCheck(this.c, this.intDecoding);
+        return new hc.HealthCheck(this.c);
     }
 
     versionsCheck() {
-        return new versions.Versions(this.c, this.intDecoding);
+        return new versions.Versions(this.c);
     }
 
     sendRawTransaction(stx_or_stxs) {
-        return new srt.SendRawTransaction(this.c, this.intDecoding, stx_or_stxs);
+        return new srt.SendRawTransaction(this.c, stx_or_stxs);
     }
 
     /**
@@ -72,7 +72,7 @@ class AlgodClient {
      * @param {number} roundNumber The round number of the block to get.
      */
     block(roundNumber) {
-        return new blk.Block(this.c, this.intDecoding, roundNumber);
+        return new blk.Block(this.c, roundNumber);
     }
 
     /**
@@ -80,14 +80,14 @@ class AlgodClient {
      * @param {string} txid The TxID string of the pending transaction to look up.
      */
     pendingTransactionInformation(txid) {
-        return new pti.PendingTransactionInformation(this.c, this.intDecoding, txid);
+        return new pti.PendingTransactionInformation(this.c, txid);
     }
 
     /**
      * Returns transactions that are pending in the pool.
      */
     pendingTransactionsInformation() {
-        return new pt.PendingTransactions(this.c, this.intDecoding);
+        return new pt.PendingTransactions(this.c);
     }
 
     /**
@@ -95,7 +95,7 @@ class AlgodClient {
      * @param {string} address The address of the sender.
      */
     pendingTransactionByAddress(address) {
-        return new ptba.PendingTransactionsByAddress(this.c, this.intDecoding, address);
+        return new ptba.PendingTransactionsByAddress(this.c, address);
     }
 
     /**
@@ -117,7 +117,7 @@ class AlgodClient {
      * Returns the common needed parameters for a new transaction.
      */
     getTransactionParams() {
-        return new sp.SuggestedParams(this.c, this.intDecoding);
+        return new sp.SuggestedParams(this.c);
     }
 
     /**
@@ -128,11 +128,11 @@ class AlgodClient {
     }
 
     compile(source) {
-        return new compile.Compile(this.c, this.intDecoding, source);
+        return new compile.Compile(this.c, source);
     }
 
     dryrun(dr) {
-        return new dryrun.Dryrun(this.c, this.intDecoding, dr);
+        return new dryrun.Dryrun(this.c, dr);
     }
 
     /**

--- a/src/client/v2/algod/algod.js
+++ b/src/client/v2/algod/algod.js
@@ -39,38 +39,70 @@ class AlgodClient {
             return new srt.SendRawTransaction(c, stx_or_stxs);
         };
 
+        /**
+         * Returns the given account's information.
+         * @param {string} account The address of the account to look up.
+         */
         this.accountInformation = function(account) {
             return new ai.AccountInformation(c, account);
         };
 
+        /**
+         * Gets the block info for the given round.
+         * @param {number} roundNumber The round number of the block to get.
+         */
         this.block = function(roundNumber) {
             return new blk.Block(c, roundNumber);
         };
 
+        /**
+         * Returns the transaction information for a specific pending transaction.
+         * @param {string} txid The TxID string of the pending transaction to look up.
+         */
         this.pendingTransactionInformation = function(txid) {
             return new pti.PendingTransactionInformation(c, txid);
         };
 
+        /**
+         * Returns transactions that are pending in the pool.
+         */
         this.pendingTransactionsInformation = function() {
             return new pt.PendingTransactions(c);
         };
 
+        /**
+         * Returns transactions that are pending in the pool sent by a specific sender.
+         * @param {string} address The address of the sender.
+         */
         this.pendingTransactionByAddress = function(address) {
             return new ptba.PendingTransactionsByAddress(c, address);
         };
 
+        /**
+         * Retrieves the StatusResponse from the running node.
+         */
         this.status = function() {
             return new status.Status(c);
         };
 
+        /**
+         * Waits for a specific round to occur then returns the StatusResponse for that round.
+         * @param {number} round The number of the round to wait for.
+         */
         this.statusAfterBlock = function (round) {
             return new sab.StatusAfterBlock(c, round);
         };
 
+        /**
+         * Returns the common needed parameters for a new transaction.
+         */
         this.getTransactionParams = function () {
             return new sp.SuggestedParams(c);
         };
 
+        /**
+         * Gets the supply details for the specified node's ledger.
+         */
         this.supply = function () {
             return new supply.Supply(c);
         };
@@ -83,10 +115,20 @@ class AlgodClient {
             return new dryrun.Dryrun(c, dr);
         };
 
+        /**
+         * Given an asset ID, return asset information including creator, name, total supply and
+         * special addresses.
+         * @param {number} index The asset ID to look up.
+         */
         this.getAssetByID = function (index) {
             return new gasbid.GetAssetByID(c, index);
         }
 
+        /**
+         * Given an application ID, it returns application information including creator, approval
+         * and clear programs, global and local schemas, and global state.
+         * @param {number} index The application ID to look up.
+         */
         this.getApplicationByID = function (index) {
             return new gapbid.GetApplicationByID(c, index);
         }

--- a/src/client/v2/algod/algod.js
+++ b/src/client/v2/algod/algod.js
@@ -25,113 +25,132 @@ class AlgodClient {
         }
 
         // Get client
-        let c = new client.HTTPClient(tokenHeader, baseServer, port, headers);
+        this.c = new client.HTTPClient(tokenHeader, baseServer, port, headers);
 
-        this.healthCheck = function () {
-            return new hc.HealthCheck(c);
-        };
+        this.intDecoding = 'default';
+    }
 
-        this.versionsCheck = function () {
-            return new versions.Versions(c);
-        };
+    /**
+     * Set the default int decoding method for all JSON requests this client creates.
+     * @param {"default" | "safe" | "mixed" | "bigint"} method The method to use when parsing the
+     *   response for request. Must be one of "default", "safe", "mixed", or "bigint". See
+     *   JSONRequest.setIntDecoding for more details about what each method does.
+     */
+    setIntEncoding(method) {
+        this.intDecoding = method;
+    }
 
-        this.sendRawTransaction = function(stx_or_stxs) {
-            return new srt.SendRawTransaction(c, stx_or_stxs);
-        };
+    /**
+     * Get the default int decoding method for all JSON requests this client creates.
+     */
+    getIntEncoding() {
+        return this.intDecoding;
+    }
 
-        /**
-         * Returns the given account's information.
-         * @param {string} account The address of the account to look up.
-         */
-        this.accountInformation = function(account) {
-            return new ai.AccountInformation(c, account);
-        };
+    healthCheck() {
+        return new hc.HealthCheck(this.c, this.intDecoding);
+    }
 
-        /**
-         * Gets the block info for the given round.
-         * @param {number} roundNumber The round number of the block to get.
-         */
-        this.block = function(roundNumber) {
-            return new blk.Block(c, roundNumber);
-        };
+    versionsCheck() {
+        return new versions.Versions(this.c, this.intDecoding);
+    }
 
-        /**
-         * Returns the transaction information for a specific pending transaction.
-         * @param {string} txid The TxID string of the pending transaction to look up.
-         */
-        this.pendingTransactionInformation = function(txid) {
-            return new pti.PendingTransactionInformation(c, txid);
-        };
+    sendRawTransaction(stx_or_stxs) {
+        return new srt.SendRawTransaction(this.c, this.intDecoding, stx_or_stxs);
+    }
 
-        /**
-         * Returns transactions that are pending in the pool.
-         */
-        this.pendingTransactionsInformation = function() {
-            return new pt.PendingTransactions(c);
-        };
+    /**
+     * Returns the given account's information.
+     * @param {string} account The address of the account to look up.
+     */
+    accountInformation(account) {
+        return new ai.AccountInformation(this.c, this.intDecoding, account);
+    }
 
-        /**
-         * Returns transactions that are pending in the pool sent by a specific sender.
-         * @param {string} address The address of the sender.
-         */
-        this.pendingTransactionByAddress = function(address) {
-            return new ptba.PendingTransactionsByAddress(c, address);
-        };
+    /**
+     * Gets the block info for the given round.
+     * @param {number} roundNumber The round number of the block to get.
+     */
+    block(roundNumber) {
+        return new blk.Block(this.c, this.intDecoding, roundNumber);
+    }
 
-        /**
-         * Retrieves the StatusResponse from the running node.
-         */
-        this.status = function() {
-            return new status.Status(c);
-        };
+    /**
+     * Returns the transaction information for a specific pending transaction.
+     * @param {string} txid The TxID string of the pending transaction to look up.
+     */
+    pendingTransactionInformation(txid) {
+        return new pti.PendingTransactionInformation(this.c, this.intDecoding, txid);
+    }
 
-        /**
-         * Waits for a specific round to occur then returns the StatusResponse for that round.
-         * @param {number} round The number of the round to wait for.
-         */
-        this.statusAfterBlock = function (round) {
-            return new sab.StatusAfterBlock(c, round);
-        };
+    /**
+     * Returns transactions that are pending in the pool.
+     */
+    pendingTransactionsInformation() {
+        return new pt.PendingTransactions(this.c, this.intDecoding);
+    }
 
-        /**
-         * Returns the common needed parameters for a new transaction.
-         */
-        this.getTransactionParams = function () {
-            return new sp.SuggestedParams(c);
-        };
+    /**
+     * Returns transactions that are pending in the pool sent by a specific sender.
+     * @param {string} address The address of the sender.
+     */
+    pendingTransactionByAddress(address) {
+        return new ptba.PendingTransactionsByAddress(this.c, this.intDecoding, address);
+    }
 
-        /**
-         * Gets the supply details for the specified node's ledger.
-         */
-        this.supply = function () {
-            return new supply.Supply(c);
-        };
+    /**
+     * Retrieves the StatusResponse from the running node.
+     */
+    status() {
+        return new status.Status(this.c, this.intDecoding);
+    }
 
-        this.compile = function (source) {
-            return new compile.Compile(c, source);
-        };
+    /**
+     * Waits for a specific round to occur then returns the StatusResponse for that round.
+     * @param {number} round The number of the round to wait for.
+     */
+    statusAfterBlock(round) {
+        return new sab.StatusAfterBlock(this.c, this.intDecoding, round);
+    }
 
-        this.dryrun = function (dr) {
-            return new dryrun.Dryrun(c, dr);
-        };
+    /**
+     * Returns the common needed parameters for a new transaction.
+     */
+    getTransactionParams() {
+        return new sp.SuggestedParams(this.c, this.intDecoding);
+    }
 
-        /**
-         * Given an asset ID, return asset information including creator, name, total supply and
-         * special addresses.
-         * @param {number} index The asset ID to look up.
-         */
-        this.getAssetByID = function (index) {
-            return new gasbid.GetAssetByID(c, index);
-        }
+    /**
+     * Gets the supply details for the specified node's ledger.
+     */
+    supply() {
+        return new supply.Supply(this.c, this.intDecoding);
+    }
 
-        /**
-         * Given an application ID, it returns application information including creator, approval
-         * and clear programs, global and local schemas, and global state.
-         * @param {number} index The application ID to look up.
-         */
-        this.getApplicationByID = function (index) {
-            return new gapbid.GetApplicationByID(c, index);
-        }
+    compile(source) {
+        return new compile.Compile(this.c, this.intDecoding, source);
+    }
+
+    dryrun(dr) {
+        return new dryrun.Dryrun(this.c, this.intDecoding, dr);
+    }
+
+    /**
+     * Given an asset ID, return asset information including creator, name, total supply and
+     * special addresses.
+     * @param {number} index The asset ID to look up.
+     */
+    getAssetByID(index) {
+        return new gasbid.GetAssetByID(this.c, this.intDecoding, index);
+    }
+
+    /**
+     * Given an application ID, it returns application information including creator, approval
+     * and clear programs, global and local schemas, and global state.
+     * @param {number} index The application ID to look up.
+     */
+    getApplicationByID(index) {
+        return new gapbid.GetApplicationByID(this.c, this.intDecoding, index);
     }
 }
 

--- a/src/client/v2/algod/compile.js
+++ b/src/client/v2/algod/compile.js
@@ -21,7 +21,7 @@ class Compile {
 	}
 
 	/**
-	 * Executes dryrun
+	 * Executes compile
 	 * @param headers, optional
 	 * @returns {Promise<*>}
 	 */

--- a/src/client/v2/algod/getApplicationByID.js
+++ b/src/client/v2/algod/getApplicationByID.js
@@ -1,3 +1,5 @@
+const utils = require('../../../utils/utils');
+
 class GetApplicationByID {
     constructor(c, index) {
         this.c = c;
@@ -11,7 +13,10 @@ class GetApplicationByID {
      * @returns {Promise<*>}
      */
     async do(headers={}) {
-        let res = await this.c.get("/v2/applications/" + this.index, this.query, headers);
+        const res = await this.c.get("/v2/applications/" + this.index, this.query, headers);
+        if (res.text) {
+            res.body = utils.JSONParseWithBigInt(res.text);
+        }
         return res.body;
     }
 }

--- a/src/client/v2/algod/getApplicationByID.js
+++ b/src/client/v2/algod/getApplicationByID.js
@@ -1,5 +1,3 @@
-const utils = require('../../../utils/utils');
-
 class GetApplicationByID {
     constructor(c, index) {
         this.c = c;
@@ -9,14 +7,14 @@ class GetApplicationByID {
 
     /**
      * Given an application id, it returns application information including creator, approval and clear programs, global and local schemas, and global state
-     * @param headers, optional
+     * @param {object} headers Additional headers to include in the request.
+     * @param {boolean} useBigInt If true, all integers in the response will be decoded as BigInts.
+     *   If false, all integers will be decoded as Numbers and if the response contains integers
+     *   greater than Number.MAX_SAFE_INTEGER, an error will be thrown. Defaults to false.
      * @returns {Promise<*>}
      */
-    async do(headers={}) {
-        const res = await this.c.get("/v2/applications/" + this.index, this.query, headers);
-        if (res.text) {
-            res.body = utils.JSONParseWithBigInt(res.text);
-        }
+    async do(headers={}, useBigInt=false) {
+        const res = await this.c.get("/v2/applications/" + this.index, this.query, headers, useBigInt);
         return res.body;
     }
 }

--- a/src/client/v2/algod/getApplicationByID.js
+++ b/src/client/v2/algod/getApplicationByID.js
@@ -1,8 +1,8 @@
 const { JSONRequest } = require('../jsonrequest');
 
 class GetApplicationByID extends JSONRequest {
-    constructor(c, index) {
-        super(c);
+    constructor(c, intDecoding, index) {
+        super(c, intDecoding);
         this.index = index;
     }
 

--- a/src/client/v2/algod/getApplicationByID.js
+++ b/src/client/v2/algod/getApplicationByID.js
@@ -1,21 +1,13 @@
-class GetApplicationByID {
+const { JSONRequest } = require('../jsonrequest');
+
+class GetApplicationByID extends JSONRequest {
     constructor(c, index) {
-        this.c = c;
+        super(c);
         this.index = index;
-        this.query = {};
     }
 
-    /**
-     * Given an application id, it returns application information including creator, approval and clear programs, global and local schemas, and global state
-     * @param {object} headers Additional headers to include in the request.
-     * @param {boolean} useBigInt If true, all integers in the response will be decoded as BigInts.
-     *   If false, all integers will be decoded as Numbers and if the response contains integers
-     *   greater than Number.MAX_SAFE_INTEGER, an error will be thrown. Defaults to false.
-     * @returns {Promise<*>}
-     */
-    async do(headers={}, useBigInt=false) {
-        const res = await this.c.get("/v2/applications/" + this.index, this.query, headers, useBigInt);
-        return res.body;
+    _path() {
+        return "/v2/applications/" + this.index;
     }
 }
 

--- a/src/client/v2/algod/getAssetByID.js
+++ b/src/client/v2/algod/getAssetByID.js
@@ -1,3 +1,5 @@
+const utils = require('../../../utils/utils');
+
 class GetAssetByID {
     constructor(c, index) {
         this.c = c;
@@ -11,7 +13,10 @@ class GetAssetByID {
      * @returns {Promise<*>}
      */
     async do(headers={}) {
-        let res = await this.c.get("/v2/assets/" + this.index, this.query, headers);
+        const res = await this.c.get("/v2/assets/" + this.index, this.query, headers);
+        if (res.text) {
+            res.body = utils.JSONParseWithBigInt(res.text);
+        }
         return res.body;
     }
 }

--- a/src/client/v2/algod/getAssetByID.js
+++ b/src/client/v2/algod/getAssetByID.js
@@ -1,5 +1,3 @@
-const utils = require('../../../utils/utils');
-
 class GetAssetByID {
     constructor(c, index) {
         this.c = c;
@@ -9,14 +7,14 @@ class GetAssetByID {
 
     /**
      * Given an asset id, return asset information including creator, name, total supply and special addresses
-     * @param headers, optional
+     * @param {object} headers Additional headers to include in the request.
+     * @param {boolean} useBigInt If true, all integers in the response will be decoded as BigInts.
+     *   If false, all integers will be decoded as Numbers and if the response contains integers
+     *   greater than Number.MAX_SAFE_INTEGER, an error will be thrown. Defaults to false.
      * @returns {Promise<*>}
      */
-    async do(headers={}) {
-        const res = await this.c.get("/v2/assets/" + this.index, this.query, headers);
-        if (res.text) {
-            res.body = utils.JSONParseWithBigInt(res.text);
-        }
+    async do(headers={}, useBigInt=false) {
+        const res = await this.c.get("/v2/assets/" + this.index, this.query, headers, useBigInt);
         return res.body;
     }
 }

--- a/src/client/v2/algod/getAssetByID.js
+++ b/src/client/v2/algod/getAssetByID.js
@@ -1,8 +1,8 @@
 const { JSONRequest } = require('../jsonrequest');
 
 class GetAssetByID extends JSONRequest {
-    constructor(c, index) {
-        super(c);
+    constructor(c, intDecoding, index) {
+        super(c, intDecoding,);
         this.index = index;
     }
 

--- a/src/client/v2/algod/getAssetByID.js
+++ b/src/client/v2/algod/getAssetByID.js
@@ -1,21 +1,13 @@
-class GetAssetByID {
+const { JSONRequest } = require('../jsonrequest');
+
+class GetAssetByID extends JSONRequest {
     constructor(c, index) {
-        this.c = c;
+        super(c);
         this.index = index;
-        this.query = {};
     }
 
-    /**
-     * Given an asset id, return asset information including creator, name, total supply and special addresses
-     * @param {object} headers Additional headers to include in the request.
-     * @param {boolean} useBigInt If true, all integers in the response will be decoded as BigInts.
-     *   If false, all integers will be decoded as Numbers and if the response contains integers
-     *   greater than Number.MAX_SAFE_INTEGER, an error will be thrown. Defaults to false.
-     * @returns {Promise<*>}
-     */
-    async do(headers={}, useBigInt=false) {
-        const res = await this.c.get("/v2/assets/" + this.index, this.query, headers, useBigInt);
-        return res.body;
+    _path() {
+        return "/v2/assets/" + this.index;
     }
 }
 

--- a/src/client/v2/algod/status.js
+++ b/src/client/v2/algod/status.js
@@ -1,8 +1,8 @@
 const { JSONRequest } = require('../jsonrequest');
 
 class Status extends JSONRequest {
-	constructor(c) {
-		super(c);
+	constructor(c, intDecoding) {
+		super(c, intDecoding);
 	}
 
 	_path() {

--- a/src/client/v2/algod/status.js
+++ b/src/client/v2/algod/status.js
@@ -1,17 +1,13 @@
-class Status {
+const { JSONRequest } = require('../jsonrequest');
+
+class Status extends JSONRequest {
 	constructor(c) {
-		this.c = c
+		super(c);
 	}
 
-	/**
-	 * retrieves the StatusResponse from the running node
-	 * @param headers, optional
-	 * @returns {Promise<*>}
-	 */
-	async do(headers={}) {
-		let res = await this.c.get("/v2/status", {}, headers);
-		return res.body;
-	};
+	_path() {
+		return "/v2/status";
+	}
 }
 
 module.exports = { Status };

--- a/src/client/v2/algod/statusAfterBlock.js
+++ b/src/client/v2/algod/statusAfterBlock.js
@@ -1,8 +1,8 @@
 const { JSONRequest } = require('../jsonrequest');
 
 class StatusAfterBlock extends JSONRequest {
-	constructor(c, round) {
-		super(c);
+	constructor(c, intDecoding, round) {
+		super(c, intDecoding);
 		if (!Number.isInteger(round)) throw Error("round should be an integer");
 		this.round = round;
 	}

--- a/src/client/v2/algod/statusAfterBlock.js
+++ b/src/client/v2/algod/statusAfterBlock.js
@@ -1,20 +1,15 @@
-class StatusAfterBlock {
+const { JSONRequest } = require('../jsonrequest');
+
+class StatusAfterBlock extends JSONRequest {
 	constructor(c, round) {
-		this.c = c;
+		super(c);
 		if (!Number.isInteger(round)) throw Error("round should be an integer");
 		this.round = round;
 	}
 
-	/**
-	 * waits for round roundNumber to occur then returns the StatusResponse for this round.
-	 * This call blocks
-	 * @param headers, optional
-	 * @returns {Promise<*>}
-	 */
-	async do(headers={}){
-		let res = await this.c.get("/v2/status/wait-for-block-after/" + this.round, {}, headers);
-		return res.body;
-	};
+	_path() {
+		return "/v2/status/wait-for-block-after/" + this.round;
+	}
 }
 
 module.exports = { StatusAfterBlock };

--- a/src/client/v2/algod/supply.js
+++ b/src/client/v2/algod/supply.js
@@ -1,17 +1,13 @@
-class Supply {
+const { JSONRequest } = require('../jsonrequest');
+
+class Supply extends JSONRequest {
 	constructor(c) {
-		this.c = c;
+		super(c);
 	}
 
-	/**
-	 * gets the supply details for the specified node's ledger
-	 * @param headers, optional
-	 * @returns {Promise<*>}
-	 */
-	async do(headers={}) {
-		let res = await this.c.get("/v2/ledger/supply", {}, headers);
-		return res.body;
-	};
+	_path() {
+		return "/v2/ledger/supply";
+	}
 }
 
 module.exports = { Supply };

--- a/src/client/v2/algod/supply.js
+++ b/src/client/v2/algod/supply.js
@@ -1,8 +1,8 @@
 const { JSONRequest } = require('../jsonrequest');
 
 class Supply extends JSONRequest {
-	constructor(c) {
-		super(c);
+	constructor(c, intDecoding) {
+		super(c, intDecoding);
 	}
 
 	_path() {

--- a/src/client/v2/indexer/indexer.js
+++ b/src/client/v2/indexer/indexer.js
@@ -21,98 +21,117 @@ class IndexerClient {
             tokenHeader = {"X-Indexer-API-Token": tokenHeader};
         }
 
-        let c = new client.HTTPClient(tokenHeader, baseServer, port, headers);
+        this.c = new client.HTTPClient(tokenHeader, baseServer, port, headers);
 
-        /**
-         * Returns the health object for the service.
-         */
-        this.makeHealthCheck = function() {
-            return new mhc.MakeHealthCheck(c);
-        };
+        this.intDecoding = 'default';
+    }
 
-        /**
-         * Returns holder balances for the given asset.
-         * @param {number} index The asset ID to look up.
-         */
-        this.lookupAssetBalances = function(index) {
-            return new lasb.LookupAssetBalances(c, index);
-        };
+    /**
+     * Set the default int decoding method for all JSON requests this client creates.
+     * @param {"default" | "safe" | "mixed" | "bigint"} method The method to use when parsing the
+     *   response for request. Must be one of "default", "safe", "mixed", or "bigint". See
+     *   JSONRequest.setIntDecoding for more details about what each method does.
+     */
+    setIntEncoding(method) {
+        this.intDecoding = method;
+    }
 
-        /**
-         * Returns transactions relating to the given asset.
-         * @param {number} index The asset ID to look up.
-         */
-        this.lookupAssetTransactions = function (index) {
-            return new last.LookupAssetTransactions(c, index);
-        };
+    /**
+     * Get the default int decoding method for all JSON requests this client creates.
+     */
+    getIntEncoding() {
+        return this.intDecoding;
+    }
 
-        /**
-         * Returns transactions relating to the given account.
-         * @param {string} account The address of the account.
-         */
-        this.lookupAccountTransactions = function(account) {
-            return new lact.LookupAccountTransactions(c, account);
-        };
+    /**
+     * Returns the health object for the service.
+     */
+    makeHealthCheck() {
+        return new mhc.MakeHealthCheck(this.c, this.intDecoding);
+    }
 
-        /**
-         * Returns the block for the passed round.
-         * @param {number} round The number of the round to look up.
-         */
-        this.lookupBlock = function(round) {
-            return new lb.LookupBlock(c, round);
-        };
+    /**
+     * Returns holder balances for the given asset.
+     * @param {number} index The asset ID to look up.
+     */
+    lookupAssetBalances(index) {
+        return new lasb.LookupAssetBalances(this.c, this.intDecoding, index);
+    }
 
-        /**
-         * Returns information about the given account.
-         * @param {string} account The address of the account to look up.
-         */
-        this.lookupAccountByID = function(account){
-            return new lacbid.LookupAccountByID(c, account);
-        };
+    /**
+     * Returns transactions relating to the given asset.
+     * @param {number} index The asset ID to look up.
+     */
+    lookupAssetTransactions(index) {
+        return new last.LookupAssetTransactions(this.c, this.intDecoding, index);
+    }
 
-        /**
-         * Returns information about the passed asset.
-         * @param {number} index The ID of the asset ot look up.
-         */
-        this.lookupAssetByID = function(index) {
-            return new lasbid.LookupAssetByID(c, index);
-        };
+    /**
+     * Returns transactions relating to the given account.
+     * @param {string} account The address of the account.
+     */
+    lookupAccountTransactions(account) {
+        return new lact.LookupAccountTransactions(this.c, this.intDecoding, account);
+    }
 
-        /**
-         * Returns information about the passed application.
-         * @param {number} index The ID of the application to look up. 
-         */
-        this.lookupApplications = function(index) {
-            return new lapp.LookupApplications(c, index);
-        }
+    /**
+     * Returns the block for the passed round.
+     * @param {number} round The number of the round to look up.
+     */
+    lookupBlock(round) {
+        return new lb.LookupBlock(this.c, this.intDecoding, round);
+    }
 
-        /**
-         * Returns information about indexed accounts.
-         */
-        this.searchAccounts = function() {
-            return new sac.SearchAccounts(c);
-        };
+    /**
+     * Returns information about the given account.
+     * @param {string} account The address of the account to look up.
+     */
+    lookupAccountByID(account){
+        return new lacbid.LookupAccountByID(this.c, this.intDecoding, account);
+    }
 
-        /**
-         * Returns information about indexed transactions.
-         */
-        this.searchForTransactions = function() {
-            return new sft.SearchForTransactions(c);
-        };
+    /**
+     * Returns information about the passed asset.
+     * @param {number} index The ID of the asset ot look up.
+     */
+    lookupAssetByID(index) {
+        return new lasbid.LookupAssetByID(this.c, this.intDecoding, index);
+    }
 
-        /**
-         * Returns information about indexed assets.
-         */
-        this.searchForAssets = function() {
-            return new sfas.SearchForAssets(c);
-        };
+    /**
+     * Returns information about the passed application.
+     * @param {number} index The ID of the application to look up. 
+     */
+    lookupApplications(index) {
+        return new lapp.LookupApplications(this.c, this.intDecoding, index);
+    }
 
-        /**
-         * Returns information about indexed applications.
-         */
-        this.searchForApplications = function() {
-            return new sfapp.SearchForApplications(c);
-        }
+    /**
+     * Returns information about indexed accounts.
+     */
+    searchAccounts() {
+        return new sac.SearchAccounts(this.c, this.intDecoding);
+    }
+
+    /**
+     * Returns information about indexed transactions.
+     */
+    searchForTransactions() {
+        return new sft.SearchForTransactions(this.c, this.intDecoding);
+    }
+
+    /**
+     * Returns information about indexed assets.
+     */
+    searchForAssets() {
+        return new sfas.SearchForAssets(this.c, this.intDecoding);
+    }
+
+    /**
+     * Returns information about indexed applications.
+     */
+    searchForApplications() {
+        return new sfapp.SearchForApplications(this.c, this.intDecoding);
     }
 }
 module.exports = {IndexerClient};

--- a/src/client/v2/indexer/indexer.js
+++ b/src/client/v2/indexer/indexer.js
@@ -23,50 +23,93 @@ class IndexerClient {
 
         let c = new client.HTTPClient(tokenHeader, baseServer, port, headers);
 
+        /**
+         * Returns the health object for the service.
+         */
         this.makeHealthCheck = function() {
             return new mhc.MakeHealthCheck(c);
         };
 
+        /**
+         * Returns holder balances for the given asset.
+         * @param {number} index The asset ID to look up.
+         */
         this.lookupAssetBalances = function(index) {
             return new lasb.LookupAssetBalances(c, index);
         };
 
+        /**
+         * Returns transactions relating to the given asset.
+         * @param {number} index The asset ID to look up.
+         */
         this.lookupAssetTransactions = function (index) {
             return new last.LookupAssetTransactions(c, index);
         };
 
+        /**
+         * Returns transactions relating to the given account.
+         * @param {string} account The address of the account.
+         */
         this.lookupAccountTransactions = function(account) {
             return new lact.LookupAccountTransactions(c, account);
         };
 
+        /**
+         * Returns the block for the passed round.
+         * @param {number} round The number of the round to look up.
+         */
         this.lookupBlock = function(round) {
             return new lb.LookupBlock(c, round);
         };
 
+        /**
+         * Returns information about the given account.
+         * @param {string} account The address of the account to look up.
+         */
         this.lookupAccountByID = function(account){
             return new lacbid.LookupAccountByID(c, account);
         };
 
+        /**
+         * Returns information about the passed asset.
+         * @param {number} index The ID of the asset ot look up.
+         */
         this.lookupAssetByID = function(index) {
             return new lasbid.LookupAssetByID(c, index);
         };
 
+        /**
+         * Returns information about the passed application.
+         * @param {number} index The ID of the application to look up. 
+         */
         this.lookupApplications = function(index) {
             return new lapp.LookupApplications(c, index);
         }
 
+        /**
+         * Returns information about indexed accounts.
+         */
         this.searchAccounts = function() {
             return new sac.SearchAccounts(c);
         };
 
+        /**
+         * Returns information about indexed transactions.
+         */
         this.searchForTransactions = function() {
             return new sft.SearchForTransactions(c);
         };
 
+        /**
+         * Returns information about indexed assets.
+         */
         this.searchForAssets = function() {
             return new sfas.SearchForAssets(c);
         };
 
+        /**
+         * Returns information about indexed applications.
+         */
         this.searchForApplications = function() {
             return new sfapp.SearchForApplications(c);
         }

--- a/src/client/v2/indexer/lookupAccountByID.js
+++ b/src/client/v2/indexer/lookupAccountByID.js
@@ -1,8 +1,8 @@
 const { JSONRequest } = require('../jsonrequest');
 
 class LookupAccountByID extends JSONRequest {
-	constructor(c, account) {
-		super(c);
+	constructor(c, intDecoding, account) {
+		super(c, intDecoding);
 		this.account = account;
 	}
 

--- a/src/client/v2/indexer/lookupAccountByID.js
+++ b/src/client/v2/indexer/lookupAccountByID.js
@@ -1,19 +1,14 @@
-class LookupAccountByID {
+const { JSONRequest } = require('../jsonrequest');
+
+class LookupAccountByID extends JSONRequest {
 	constructor(c, account) {
-		this.c = c;
+		super(c);
 		this.account = account;
-		this.query = {}
 	}
 
-	/**
-	 * returns information about the identified account
-	 * @param headers, optional
-	 * @returns Promise<*>
-	 */
-	async do (headers = {}) {
-		let res = await this.c.get("/v2/accounts/" + this.account, this.query, headers);
-		return res.body;
-	};
+	_path() {
+		return "/v2/accounts/" + this.account;
+	}
 
 	round(round) {
 		this.query["round"] = round;

--- a/src/client/v2/indexer/lookupAccountTransactions.js
+++ b/src/client/v2/indexer/lookupAccountTransactions.js
@@ -1,8 +1,8 @@
 const { JSONRequest } = require('../jsonrequest');
 
 class LookupAccountTransactions extends JSONRequest {
-	constructor(c, account) {
-		super(c);
+	constructor(c, intDecoding, account) {
+		super(c, intDecoding);
 		this.account = account;
 	}
 

--- a/src/client/v2/indexer/lookupAccountTransactions.js
+++ b/src/client/v2/indexer/lookupAccountTransactions.js
@@ -1,20 +1,14 @@
+const { JSONRequest } = require('../jsonrequest');
 
-class LookupAccountTransactions {
+class LookupAccountTransactions extends JSONRequest {
 	constructor(c, account) {
-		this.c = c;
+		super(c);
 		this.account = account;
-		this.query = {}
 	}
 
-	/**
-	 * returns transactions relating to the given account
-	 * @param headers, optional
-	 * @returns Promise<*>
-	 */
-	async do(headers = {}) {
-		let res = await this.c.get("/v2/accounts/" + this.account + "/transactions", this.query, headers);
-		return res.body;
-	};
+	_path() {
+		return "/v2/accounts/" + this.account + "/transactions";
+	}
 
 	// notePrefix to filter with, as uint8array
 	notePrefix(prefix) {

--- a/src/client/v2/indexer/lookupApplications.js
+++ b/src/client/v2/indexer/lookupApplications.js
@@ -1,19 +1,14 @@
-class LookupApplications {
+const { JSONRequest } = require('../jsonrequest');
+
+class LookupApplications extends JSONRequest {
     constructor(c, index) {
-        this.c = c;
-        this.query = {};
+        super(c);
         this.index = index;
     }
 
-    /**
-     * returns information about indexed applications
-     * @param headers, optional
-     * @returns Promise<*>
-     */
-    async do(headers = {}) {
-        let res = await this.c.get("/v2/applications/" + this.index, this.query, headers);
-        return res.body;
-    };
+    _path() {
+        return "/v2/applications/" + this.index;
+    }
 
     // specific round to search
     round(round) {

--- a/src/client/v2/indexer/lookupApplications.js
+++ b/src/client/v2/indexer/lookupApplications.js
@@ -1,8 +1,8 @@
 const { JSONRequest } = require('../jsonrequest');
 
 class LookupApplications extends JSONRequest {
-    constructor(c, index) {
-        super(c);
+    constructor(c, intDecoding, index) {
+        super(c, intDecoding);
         this.index = index;
     }
 

--- a/src/client/v2/indexer/lookupAssetBalances.js
+++ b/src/client/v2/indexer/lookupAssetBalances.js
@@ -1,8 +1,8 @@
 const { JSONRequest } = require('../jsonrequest');
 
 class LookupAssetBalances extends JSONRequest {
-	constructor(c, index) {
-		super(c);
+	constructor(c, intDecoding, index) {
+		super(c, intDecoding);
 		this.index = index;
 	}
 

--- a/src/client/v2/indexer/lookupAssetBalances.js
+++ b/src/client/v2/indexer/lookupAssetBalances.js
@@ -1,19 +1,14 @@
-class LookupAssetBalances {
+const { JSONRequest } = require('../jsonrequest');
+
+class LookupAssetBalances extends JSONRequest {
 	constructor(c, index) {
-		this.c = c;
+		super(c);
 		this.index = index;
-		this.query = {}
 	}
 
-	/**
-	 * returns holder balances for the given asset
-	 * @param headers, optional
-	 * @returns Promise<*>
-	 */
-	async do(headers = {}) {
-		let res = await this.c.get("/v2/assets/" + this.index + "/balances", this.query, headers);
-		return res.body;
-	};
+	_path() {
+		return "/v2/assets/" + this.index + "/balances";
+	}
 
 	// limit for filter, as int
 	limit(limit) {

--- a/src/client/v2/indexer/lookupAssetByID.js
+++ b/src/client/v2/indexer/lookupAssetByID.js
@@ -1,18 +1,14 @@
-class LookupAssetByID {
+const { JSONRequest } = require('../jsonrequest');
+
+class LookupAssetByID extends JSONRequest {
 	constructor(c, index){
-		this.c = c;
+		super(c);
 		this.index = index;
 	}
 
-	/**
-	 * returns information about the passed asset
-	 * @param headers, optional
-	 * @returns Promise<*>
-	 */
-	async do(headers = {}) {
-		let res = await this.c.get("/v2/assets/" + this.index, {}, headers);
-		return res.body;
-	};
+	_path() {
+		return "/v2/assets/" + this.index;
+	}
 }
 
 module.exports = {LookupAssetByID};

--- a/src/client/v2/indexer/lookupAssetByID.js
+++ b/src/client/v2/indexer/lookupAssetByID.js
@@ -1,8 +1,8 @@
 const { JSONRequest } = require('../jsonrequest');
 
 class LookupAssetByID extends JSONRequest {
-	constructor(c, index){
-		super(c);
+	constructor(c, intDecoding, index){
+		super(c, intDecoding);
 		this.index = index;
 	}
 

--- a/src/client/v2/indexer/lookupAssetTransactions.js
+++ b/src/client/v2/indexer/lookupAssetTransactions.js
@@ -1,8 +1,8 @@
 const { JSONRequest } = require('../jsonrequest');
 
 class LookupAssetTransactions extends JSONRequest {
-	constructor (c, index) {
-		super(c);
+	constructor (c, intDecoding, index) {
+		super(c, intDecoding);
 		this.index = index;
 	}
 

--- a/src/client/v2/indexer/lookupAssetTransactions.js
+++ b/src/client/v2/indexer/lookupAssetTransactions.js
@@ -1,19 +1,14 @@
-class LookupAssetTransactions {
+const { JSONRequest } = require('../jsonrequest');
+
+class LookupAssetTransactions extends JSONRequest {
 	constructor (c, index) {
-		this.c = c;
+		super(c);
 		this.index = index;
-		this.query = {};
 	}
 
-	/**
-	 * returns information about the passed asset
-	 * @param headers, optional
-	 * @returns Promise<*>
-	 */
-	async do(headers = {}) {
-		let res = await this.c.get("/v2/assets/" + this.index + "/transactions", this.query, headers);
-		return res.body;
-	};
+	_path() {
+		return "/v2/assets/" + this.index + "/transactions";
+	}
 
 	// notePrefix to filter with, as uint8array
 	notePrefix(prefix) {

--- a/src/client/v2/indexer/lookupBlock.js
+++ b/src/client/v2/indexer/lookupBlock.js
@@ -1,8 +1,8 @@
 const { JSONRequest } = require('../jsonrequest');
 
 class LookupBlock extends JSONRequest {
-	constructor(c, round) {
-		super(c);
+	constructor(c, intDecoding, round) {
+		super(c, intDecoding);
 		this.round = round;
 	}
 

--- a/src/client/v2/indexer/lookupBlock.js
+++ b/src/client/v2/indexer/lookupBlock.js
@@ -1,18 +1,14 @@
-class LookupBlock {
+const { JSONRequest } = require('../jsonrequest');
+
+class LookupBlock extends JSONRequest {
 	constructor(c, round) {
-		this.c = c;
+		super(c);
 		this.round = round;
 	}
 
-	/**
-	 * returns the block for the passed round
-	 * @param headers, optional
-	 * @returns Promise<*>
-	 */
-	async do (headers = {}) {
-		let res = await this.c.get("/v2/blocks/" + this.round, {}, headers);
-		return res.body;
-	};
+	_path() {
+		return "/v2/blocks/" + this.round;
+	}
 }
 
 module.exports = {LookupBlock};

--- a/src/client/v2/indexer/makeHealthCheck.js
+++ b/src/client/v2/indexer/makeHealthCheck.js
@@ -1,8 +1,8 @@
 const { JSONRequest } = require('../jsonrequest');
 
 class MakeHealthCheck extends JSONRequest {
-	constructor(c) {
-		super(c);
+	constructor(c, intDecoding) {
+		super(c, intDecoding);
 	}
 
 	_path() {

--- a/src/client/v2/indexer/makeHealthCheck.js
+++ b/src/client/v2/indexer/makeHealthCheck.js
@@ -1,17 +1,13 @@
-class MakeHealthCheck{
+const { JSONRequest } = require('../jsonrequest');
+
+class MakeHealthCheck extends JSONRequest {
 	constructor(c) {
-		this.c = c;
+		super(c);
 	}
 
-	/**
-	 * returns the health object for the service
-	 * @param headers, optional
-	 * @returns Promise<*>
-	 */
-	async do (headers = {}) {
-		let res = await this.c.get("/health", {}, headers);
-		return res.body;
-	};
+	_path() {
+		return "/health";
+	}
 }
 
 module.exports = {MakeHealthCheck};

--- a/src/client/v2/indexer/searchAccounts.js
+++ b/src/client/v2/indexer/searchAccounts.js
@@ -1,8 +1,8 @@
 const { JSONRequest } = require('../jsonrequest');
 
 class SearchAccounts extends JSONRequest{
-	constructor(c) {
-		super(c);
+	constructor(c, intDecoding) {
+		super(c, intDecoding);
 	}
 
 	_path() {

--- a/src/client/v2/indexer/searchAccounts.js
+++ b/src/client/v2/indexer/searchAccounts.js
@@ -1,18 +1,13 @@
-class SearchAccounts {
+const { JSONRequest } = require('../jsonrequest');
+
+class SearchAccounts extends JSONRequest{
 	constructor(c) {
-		this.c = c;
-		this.query = {};
+		super(c);
 	}
 
-	/**
-	 * returns information about indexed accounts
-	 * @param headers, optional
-	 * @returns Promise<*>
-	 */
-	async do(headers = {}) {
-		let res = await this.c.get("/v2/accounts", this.query, headers);
-		return res.body;
-	};
+	_path() {
+		return "/v2/accounts";
+	}
 
 	// filtered results should have an amount greater than this value, as int, representing microAlgos, unless an asset-id is provided, in which case units are in the asset's units
 	currencyGreaterThan(greater) {

--- a/src/client/v2/indexer/searchForApplications.js
+++ b/src/client/v2/indexer/searchForApplications.js
@@ -1,8 +1,8 @@
 const { JSONRequest } = require('../jsonrequest');
 
 class SearchForApplications extends JSONRequest {
-    constructor(c) {
-        super(c);
+    constructor(c, intDecoding) {
+        super(c, intDecoding);
     }
 
     _path() {

--- a/src/client/v2/indexer/searchForApplications.js
+++ b/src/client/v2/indexer/searchForApplications.js
@@ -1,18 +1,13 @@
-class SearchForApplications{
+const { JSONRequest } = require('../jsonrequest');
+
+class SearchForApplications extends JSONRequest {
     constructor(c) {
-        this.c = c;
-        this.query = {}
+        super(c);
     }
 
-    /**
-     * returns information about indexed applications
-     * @param headers, optional
-     * @returns Promise<*>
-     */
-    async do(headers = {}) {
-        let res = await this.c.get("/v2/applications", this.query, headers);
-        return res.body;
-    };
+    _path() {
+        return "/v2/applications";
+    }
 
     // application ID for filter, as int
     index(index) {

--- a/src/client/v2/indexer/searchForAssets.js
+++ b/src/client/v2/indexer/searchForAssets.js
@@ -1,8 +1,8 @@
 const { JSONRequest } = require('../jsonrequest');
 
 class SearchForAssets extends JSONRequest {
-	constructor(c) {
-		super(c);
+	constructor(c, intDecoding) {
+		super(c, intDecoding);
 	}
 
 	_path() {

--- a/src/client/v2/indexer/searchForAssets.js
+++ b/src/client/v2/indexer/searchForAssets.js
@@ -1,18 +1,13 @@
-class SearchForAssets{
+const { JSONRequest } = require('../jsonrequest');
+
+class SearchForAssets extends JSONRequest {
 	constructor(c) {
-		this.c = c;
-		this.query = {}
+		super(c);
 	}
 
-	/**
-	 * returns information about indexed assets
-	 * @param headers, optional
-	 * @returns Promise<*>
-	 */
-	async do(headers = {}) {
-		let res = await this.c.get("/v2/assets", this.query, headers);
-		return res.body;
-	};
+	_path() {
+		return "/v2/assets";
+	}
 
 	// limit for filter, as int
 	limit(limit) {

--- a/src/client/v2/indexer/searchForTransactions.js
+++ b/src/client/v2/indexer/searchForTransactions.js
@@ -1,8 +1,8 @@
 const { JSONRequest } = require('../jsonrequest');
 
 class SearchForTransactions extends JSONRequest {
-	constructor(c) {
-		super(c);
+	constructor(c, intDecoding) {
+		super(c, intDecoding);
 	}
 
 	_path() {

--- a/src/client/v2/indexer/searchForTransactions.js
+++ b/src/client/v2/indexer/searchForTransactions.js
@@ -1,18 +1,13 @@
-class SearchForTransactions {
+const { JSONRequest } = require('../jsonrequest');
+
+class SearchForTransactions extends JSONRequest {
 	constructor(c) {
-		this.c = c;
-		this.query = {};
+		super(c);
 	}
 
-	/**
-	 * returns information about indexed transactions
-	 * @param headers, optional
-	 * @returns Promise<*>
-	 */
-	async do(headers = {}) {
-		let res = await this.c.get("/v2/transactions", this.query, headers);
-		return res.body;
-	};
+	_path() {
+		return "/v2/transactions";
+	}
 
 	// notePrefix to filter with, as uint8array
 	notePrefix(prefix) {

--- a/src/client/v2/jsonrequest.js
+++ b/src/client/v2/jsonrequest.js
@@ -1,0 +1,40 @@
+class JSONRequest {
+    /**
+     * @param {HttpClient} client HTTPClient object.
+     */
+    constructor(client) {
+        this.c = client;
+        this.query = {};
+        this.requestBigInt = false;
+    }
+
+    /**
+     * @returns {string} The path of this request.
+     */
+    _path() {
+        throw new Error("Must be overriden by implementing class.");
+    }
+
+    /**
+	 * returns holder balances for the given asset
+	 * @param {object} headers Additional headers to send in the request. Optional.
+	 * @returns {Promise<*>}
+	 */
+	async do(headers = {}) {
+		let res = await this.c.get(this._path(), this.query, headers, this.requestBigInt);
+		return res.body;
+	};
+
+    /**
+     * Set the useBigInt option. If not set, defaults to false.
+     * @param {boolean} useBigInt If true, all integers in the response will be decoded as BigInts.
+     *   If false, all integers will be decoded as Numbers and if the response contains integers
+     *   greater than Number.MAX_SAFE_INTEGER, an error will be thrown.
+     */
+    useBigInt(useBigInt) {
+        this.requestBigInt = useBigInt;
+        return this;
+    }
+}
+
+module.exports = { JSONRequest };

--- a/src/client/v2/jsonrequest.js
+++ b/src/client/v2/jsonrequest.js
@@ -1,11 +1,14 @@
 class JSONRequest {
     /**
      * @param {HttpClient} client HTTPClient object.
+     * @param {"default" | "safe" | "mixed" | "bigint" | undefined} intDecoding The method to use
+     *   for decoding integers from this request's response. See the setIntDecoding method for more
+     *   details.
      */
-    constructor(client) {
+    constructor(client, intDecoding = undefined) {
         this.c = client;
         this.query = {};
-        this.intDecoding = 'default';
+        this.intDecoding = intDecoding || 'default';
     }
 
     /**

--- a/src/client/v2/jsonrequest.js
+++ b/src/client/v2/jsonrequest.js
@@ -26,13 +26,14 @@ class JSONRequest {
 	};
 
     /**
-     * Set the useBigInt option. If not set, defaults to false.
-     * @param {boolean} useBigInt If true, all integers in the response will be decoded as BigInts.
-     *   If false, all integers will be decoded as Numbers and if the response contains integers
-     *   greater than Number.MAX_SAFE_INTEGER, an error will be thrown.
+     * Configure the useBigInt option. If this option is set for a request, all integers in the
+     * response will be decoded as BigInts. If this option is not set, all integers will be decoded
+     * as Numbers and if the response contains any integers greater than Number.MAX_SAFE_INTEGER an
+     * error will be thrown.
+     * @param {boolean} enabled Whether to enable BigInt support for this request. Defaults to true.
      */
-    useBigInt(useBigInt) {
-        this.requestBigInt = useBigInt;
+    useBigInt(enabled=true) {
+        this.requestBigInt = enabled;
         return this;
     }
 }

--- a/src/client/v2/jsonrequest.js
+++ b/src/client/v2/jsonrequest.js
@@ -16,9 +16,9 @@ class JSONRequest {
     }
 
     /**
-	 * returns holder balances for the given asset
+	 * Execute the request.
 	 * @param {object} headers Additional headers to send in the request. Optional.
-	 * @returns {Promise<*>}
+	 * @returns {Promise<object>} A promise which resolves to the response data.
 	 */
 	async do(headers = {}) {
 		let res = await this.c.get(this._path(), this.query, headers, this.requestBigInt);

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,3 +1,28 @@
+const JSONbig = require('json-bigint')({ useNativeBigInt: true, strict: true });
+
+/**
+ * Parse JSON with support for BigInts. Any integers greater than Number.MAX_SAFE_INTEGER will be
+ * parsed as BigInts.
+ * @param {string} value The stringified JSON to parse. 
+ */
+function JSONParseWithBigInt(value) {
+    const parsed = JSONbig.parse(value, function (_, value) {
+        if (value != null && typeof value === 'object' && Object.getPrototypeOf(value) == null) {
+            // for some reason the Objects returned by JSONbig.parse have a null prototype, so we
+            // need to fix that.
+            Object.setPrototypeOf(value, Object.prototype);
+        } else if (typeof value === 'bigint') {
+            // JSONbig.parse converts number to BigInts if they are >= 10**15. This is smaller than
+            // Number.MAX_SAFE_INTEGER, so we can convert some BigInts back to normal numbers.
+            if (value <= Number.MAX_SAFE_INTEGER) {
+                return Number(value);
+            }
+        }
+        return value;
+    });
+    return parsed;
+}
+
 /**
  * ArrayEqual takes two arrays and return true if equal, false otherwise
  * @return {boolean}
@@ -20,4 +45,8 @@ function concatArrays(a, b) {
     return c;
 }
 
-module.exports = {arrayEqual, concatArrays};
+module.exports = {
+    JSONParseWithBigInt,
+    arrayEqual,
+    concatArrays
+};

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -25,7 +25,9 @@ function parseJSON(str, options=undefined) {
             // for some reason the Objects returned by JSONbig.parse have a null prototype, so we
             // need to fix that.
             Object.setPrototypeOf(value, Object.prototype);
-        } else if (typeof value === 'bigint') {
+        }
+        
+        if (typeof value === 'bigint') {
             if (intDecoding === 'bigint' || (intDecoding === 'mixed' && value > Number.MAX_SAFE_INTEGER)) {
                 return value;
             }
@@ -37,11 +39,14 @@ function parseJSON(str, options=undefined) {
             }
 
             throw new Error("Integer exceeds maximum safe integer: " + value.toString() + ". Try parsing with a different intDecoding option.");
-        } else if (typeof value === 'number') {
+        }
+        
+        if (typeof value === 'number') {
             if (intDecoding === 'bigint' && Number.isInteger(value)) {
                 return BigInt(value);
             }
         }
+        
         return value;
     });
     return parsed;

--- a/tests/2.Encoding.js
+++ b/tests/2.Encoding.js
@@ -1,6 +1,5 @@
 const assert = require('assert');
 const { Buffer } = require('buffer');
-const e = require('express');
 const algosdk = require('../index');
 const utils = require('../src/utils/utils');
 

--- a/tests/2.Encoding.js
+++ b/tests/2.Encoding.js
@@ -84,80 +84,137 @@ describe('encoding', function () {
     });
 
     describe('JSON parse BigInt', function () {
+        it('should parse null', function () {
+            const input = 'null';
+
+            const actualDefault = utils.parseJSON(input);
+            const actualBigInt = utils.parseJSON(input, { useBigInt: true });
+            const expected = null;
+
+            assert.deepStrictEqual(actualDefault, expected);
+            assert.deepStrictEqual(actualBigInt, expected);
+        });
+
+        it('should parse number', function () {
+            const input = '17';
+
+            const actualDefault = utils.parseJSON(input);
+            const expectedDefault = 17;
+
+            assert.deepStrictEqual(actualDefault, expectedDefault);
+
+            const actualBigInt = utils.parseJSON(input, { useBigInt: true });
+            const expectedBigInt = 17n;
+            
+            assert.deepStrictEqual(actualBigInt, expectedBigInt);
+        });
+
         it('should parse empty object', function () {
             const input = '{}';
 
-            const actual = utils.JSONParseWithBigInt(input);
+            const actualDefault = utils.parseJSON(input);
+            const actualBigInt = utils.parseJSON(input, { useBigInt: true });
             const expected = {};
 
-            assert.deepStrictEqual(actual, expected);
+            assert.deepStrictEqual(actualDefault, expected);
+            assert.deepStrictEqual(actualBigInt, expected);
         });
 
         it('should parse populated object', function () {
-            const input = '{"a":1,"b":"value","c":[1,2,3],"d":null,"e":{}}';
+            const input = '{"a":1,"b":"value","c":[1,2,3],"d":null,"e":{},"f":true}';
 
-            const actual = utils.JSONParseWithBigInt(input);
-            const expected = {
+            const actualDefault = utils.parseJSON(input);
+            const expectedDefault = {
                 a: 1,
                 b: 'value',
                 c: [1,2,3],
                 d: null,
-                e: {}
+                e: {},
+                f: true
             };
 
-            assert.deepStrictEqual(actual, expected);
+            assert.deepStrictEqual(actualDefault, expectedDefault);
+
+            const actualBigInt = utils.parseJSON(input, { useBigInt: true });
+            const expectedBigInt = {
+                a: 1n,
+                b: 'value',
+                c: [1n,2n,3n],
+                d: null,
+                e: {},
+                f: true
+            };
+
+            assert.deepStrictEqual(actualBigInt, expectedBigInt);
         });
 
         it('should parse object with BigInt', function () {
             const input = '{"a":0,"b":9007199254740991,"c":9007199254740992,"d":9223372036854775807}';
 
-            const actual = utils.JSONParseWithBigInt(input);
-            const expected = {
-                a: 0,
-                b: 9007199254740991,
+            assert.throws(() => utils.parseJSON(input));
+            const actualBigInt = utils.parseJSON(input, { useBigInt: true });
+            const expectedBigInt = {
+                a: 0n,
+                b: 9007199254740991n,
                 c: 9007199254740992n,
                 d: 9223372036854775807n
             };
 
-            assert.deepStrictEqual(actual, expected);
+            assert.deepStrictEqual(actualBigInt, expectedBigInt);
         });
 
         it('should parse empty array', function () {
             const input = '[]';
 
-            const actual = utils.JSONParseWithBigInt(input);
+            const actualDefault = utils.parseJSON(input);
+            const actualBigInt = utils.parseJSON(input, { useBigInt: true });
             const expected = [];
 
-            assert.deepStrictEqual(actual, expected);
+            assert.deepStrictEqual(actualDefault, expected);
+            assert.deepStrictEqual(actualBigInt, expected);
         });
 
         it('should parse populated array', function () {
-            const input = '["test",2,null,[7],{"a":9.0}]';
+            const input = '["test",2,null,[7],{"a":9.5},true]';
 
-            const actual = utils.JSONParseWithBigInt(input);
-            const expected = [
+            const actualDefault = utils.parseJSON(input);
+            const expectedDefault = [
                 'test',
                 2,
                 null,
                 [7],
-                {a: 9.0}
+                {a: 9.5},
+                true
             ];
 
-            assert.deepStrictEqual(actual, expected);
+            assert.deepStrictEqual(actualDefault, expectedDefault);
+
+            const actualBigInt = utils.parseJSON(input, { useBigInt: true });
+            const expectedBigInt = [
+                'test',
+                2n,
+                null,
+                [7n],
+                {a: 9.5},
+                true
+            ];
+
+            assert.deepStrictEqual(actualBigInt, expectedBigInt);
         });
 
         it('should parse array with BigInt', function () {
             const input = '[0,9007199254740991,9007199254740992,9223372036854775807]';
 
-            const actual = utils.JSONParseWithBigInt(input);
-            const expected = [
-                0,
-                9007199254740991,
+            assert.throws(() => utils.parseJSON(input));
+            const actualBigInt = utils.parseJSON(input, { useBigInt: true });
+            const expectedBigInt = [
+                0n,
+                9007199254740991n,
                 9007199254740992n,
                 9223372036854775807n
             ];
 
-            assert.deepStrictEqual(actual, expected);
+            assert.deepStrictEqual(actualBigInt, expectedBigInt);
         });
     });
 });

--- a/tests/2.Encoding.js
+++ b/tests/2.Encoding.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const { Buffer } = require('buffer');
 const algosdk = require('../index');
+const utils = require('../src/utils/utils');
 
 const ERROR_CONTAINS_EMPTY_STRING = "The object contains empty or 0 values. First empty or 0 value encountered during encoding: ";
 
@@ -82,4 +83,81 @@ describe('encoding', function () {
         });
     });
 
+    describe('JSON parse BigInt', function () {
+        it('should parse empty object', function () {
+            const input = '{}';
+
+            const actual = utils.JSONParseWithBigInt(input);
+            const expected = {};
+
+            assert.deepStrictEqual(actual, expected);
+        });
+
+        it('should parse populated object', function () {
+            const input = '{"a":1,"b":"value","c":[1,2,3],"d":null,"e":{}}';
+
+            const actual = utils.JSONParseWithBigInt(input);
+            const expected = {
+                a: 1,
+                b: 'value',
+                c: [1,2,3],
+                d: null,
+                e: {}
+            };
+
+            assert.deepStrictEqual(actual, expected);
+        });
+
+        it('should parse object with BigInt', function () {
+            const input = '{"a":0,"b":9007199254740991,"c":9007199254740992,"d":9223372036854775807}';
+
+            const actual = utils.JSONParseWithBigInt(input);
+            const expected = {
+                a: 0,
+                b: 9007199254740991,
+                c: 9007199254740992n,
+                d: 9223372036854775807n
+            };
+
+            assert.deepStrictEqual(actual, expected);
+        });
+
+        it('should parse empty array', function () {
+            const input = '[]';
+
+            const actual = utils.JSONParseWithBigInt(input);
+            const expected = [];
+
+            assert.deepStrictEqual(actual, expected);
+        });
+
+        it('should parse populated array', function () {
+            const input = '["test",2,null,[7],{"a":9.0}]';
+
+            const actual = utils.JSONParseWithBigInt(input);
+            const expected = [
+                'test',
+                2,
+                null,
+                [7],
+                {a: 9.0}
+            ];
+
+            assert.deepStrictEqual(actual, expected);
+        });
+
+        it('should parse array with BigInt', function () {
+            const input = '[0,9007199254740991,9007199254740992,9223372036854775807]';
+
+            const actual = utils.JSONParseWithBigInt(input);
+            const expected = [
+                0,
+                9007199254740991,
+                9007199254740992n,
+                9223372036854775807n
+            ];
+
+            assert.deepStrictEqual(actual, expected);
+        });
+    });
 });

--- a/tests/2.Encoding.js
+++ b/tests/2.Encoding.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const { Buffer } = require('buffer');
+const e = require('express');
 const algosdk = require('../index');
 const utils = require('../src/utils/utils');
 
@@ -87,134 +88,179 @@ describe('encoding', function () {
         it('should parse null', function () {
             const input = 'null';
 
-            const actualDefault = utils.parseJSON(input);
-            const actualBigInt = utils.parseJSON(input, { useBigInt: true });
-            const expected = null;
+            for (const intDecoding of ['default', 'safe', 'mixed', 'bigint']) {
+                const actual = utils.parseJSON(input, { intDecoding });
+                const expected = null;
 
-            assert.deepStrictEqual(actualDefault, expected);
-            assert.deepStrictEqual(actualBigInt, expected);
+                assert.deepStrictEqual(actual, expected, `Error when intDecoding = ${intDecoding}`);
+            }
         });
 
         it('should parse number', function () {
             const input = '17';
 
-            const actualDefault = utils.parseJSON(input);
-            const expectedDefault = 17;
+            for (const intDecoding of ['default', 'safe', 'mixed', 'bigint']) {
+                const actual = utils.parseJSON(input, { intDecoding });
+                const expected = intDecoding === 'bigint' ? 17n : 17;
 
-            assert.deepStrictEqual(actualDefault, expectedDefault);
-
-            const actualBigInt = utils.parseJSON(input, { useBigInt: true });
-            const expectedBigInt = 17n;
-            
-            assert.deepStrictEqual(actualBigInt, expectedBigInt);
+                assert.deepStrictEqual(actual, expected, `Error when intDecoding = ${intDecoding}`);
+            }
         });
 
         it('should parse empty object', function () {
             const input = '{}';
 
-            const actualDefault = utils.parseJSON(input);
-            const actualBigInt = utils.parseJSON(input, { useBigInt: true });
-            const expected = {};
+            for (const intDecoding of ['default', 'safe', 'mixed', 'bigint']) {
+                const actual = utils.parseJSON(input, { intDecoding });
+                const expected = {};
 
-            assert.deepStrictEqual(actualDefault, expected);
-            assert.deepStrictEqual(actualBigInt, expected);
+                assert.deepStrictEqual(actual, expected, `Error when intDecoding = ${intDecoding}`);
+            }
         });
 
         it('should parse populated object', function () {
             const input = '{"a":1,"b":"value","c":[1,2,3],"d":null,"e":{},"f":true}';
 
-            const actualDefault = utils.parseJSON(input);
-            const expectedDefault = {
-                a: 1,
-                b: 'value',
-                c: [1,2,3],
-                d: null,
-                e: {},
-                f: true
-            };
+            for (const intDecoding of ['default', 'safe', 'mixed', 'bigint']) {
+                const actual = utils.parseJSON(input, { intDecoding });
 
-            assert.deepStrictEqual(actualDefault, expectedDefault);
+                let expected;
+                if (intDecoding === 'bigint') {
+                    expected = {
+                        a: 1n,
+                        b: 'value',
+                        c: [1n,2n,3n],
+                        d: null,
+                        e: {},
+                        f: true
+                    };
+                } else {
+                    expected = {
+                        a: 1,
+                        b: 'value',
+                        c: [1,2,3],
+                        d: null,
+                        e: {},
+                        f: true
+                    };
+                }
 
-            const actualBigInt = utils.parseJSON(input, { useBigInt: true });
-            const expectedBigInt = {
-                a: 1n,
-                b: 'value',
-                c: [1n,2n,3n],
-                d: null,
-                e: {},
-                f: true
-            };
-
-            assert.deepStrictEqual(actualBigInt, expectedBigInt);
+                assert.deepStrictEqual(actual, expected, `Error when intDecoding = ${intDecoding}`);
+            }
         });
 
         it('should parse object with BigInt', function () {
             const input = '{"a":0,"b":9007199254740991,"c":9007199254740992,"d":9223372036854775807}';
 
-            assert.throws(() => utils.parseJSON(input));
-            const actualBigInt = utils.parseJSON(input, { useBigInt: true });
-            const expectedBigInt = {
-                a: 0n,
-                b: 9007199254740991n,
-                c: 9007199254740992n,
-                d: 9223372036854775807n
-            };
+            assert.throws(() => utils.parseJSON(input, { intDecoding: 'safe' }));
 
-            assert.deepStrictEqual(actualBigInt, expectedBigInt);
+            for (const intDecoding of ['default', 'mixed', 'bigint']) {
+                const actual = utils.parseJSON(input, { intDecoding });
+
+                let expected;
+                if (intDecoding === 'bigint') {
+                    expected = {
+                        a: 0n,
+                        b: 9007199254740991n,
+                        c: 9007199254740992n,
+                        d: 9223372036854775807n
+                    };
+                } else if (intDecoding === 'mixed') {
+                    expected = {
+                        a: 0,
+                        b: 9007199254740991,
+                        c: 9007199254740992n,
+                        d: 9223372036854775807n
+                    };
+                } else {
+                    expected = {
+                        a: 0,
+                        b: 9007199254740991,
+                        c: Number(9007199254740992n),
+                        d: Number(9223372036854775807n)
+                    };
+                }
+
+                assert.deepStrictEqual(actual, expected, `Error when intDecoding = ${intDecoding}`);
+            }
         });
 
         it('should parse empty array', function () {
             const input = '[]';
 
-            const actualDefault = utils.parseJSON(input);
-            const actualBigInt = utils.parseJSON(input, { useBigInt: true });
-            const expected = [];
+            for (const intDecoding of ['default', 'safe', 'mixed', 'bigint']) {
+                const actual = utils.parseJSON(input, { intDecoding });
+                const expected = [];
 
-            assert.deepStrictEqual(actualDefault, expected);
-            assert.deepStrictEqual(actualBigInt, expected);
+                assert.deepStrictEqual(actual, expected, `Error when intDecoding = ${intDecoding}`);
+            }
         });
 
         it('should parse populated array', function () {
             const input = '["test",2,null,[7],{"a":9.5},true]';
 
-            const actualDefault = utils.parseJSON(input);
-            const expectedDefault = [
-                'test',
-                2,
-                null,
-                [7],
-                {a: 9.5},
-                true
-            ];
+            for (const intDecoding of ['default', 'safe', 'mixed', 'bigint']) {
+                const actual = utils.parseJSON(input, { intDecoding });
 
-            assert.deepStrictEqual(actualDefault, expectedDefault);
+                let expected;
+                if (intDecoding === 'bigint') {
+                    expected = [
+                        'test',
+                        2n,
+                        null,
+                        [7n],
+                        {a: 9.5},
+                        true
+                    ];
+                } else {
+                    expected = [
+                        'test',
+                        2,
+                        null,
+                        [7],
+                        {a: 9.5},
+                        true
+                    ];
+                }
 
-            const actualBigInt = utils.parseJSON(input, { useBigInt: true });
-            const expectedBigInt = [
-                'test',
-                2n,
-                null,
-                [7n],
-                {a: 9.5},
-                true
-            ];
-
-            assert.deepStrictEqual(actualBigInt, expectedBigInt);
+                assert.deepStrictEqual(actual, expected, `Error when intDecoding = ${intDecoding}`);
+            }
         });
 
         it('should parse array with BigInt', function () {
             const input = '[0,9007199254740991,9007199254740992,9223372036854775807]';
 
-            assert.throws(() => utils.parseJSON(input));
-            const actualBigInt = utils.parseJSON(input, { useBigInt: true });
-            const expectedBigInt = [
-                0n,
-                9007199254740991n,
-                9007199254740992n,
-                9223372036854775807n
-            ];
+            assert.throws(() => utils.parseJSON(input, { intDecoding: 'safe' }));
 
-            assert.deepStrictEqual(actualBigInt, expectedBigInt);
+            for (const intDecoding of ['default', 'mixed', 'bigint']) {
+                const actual = utils.parseJSON(input, { intDecoding });
+
+                let expected;
+                if (intDecoding === 'bigint') {
+                    expected = [
+                        0n,
+                        9007199254740991n,
+                        9007199254740992n,
+                        9223372036854775807n
+                    ];
+                } else if (intDecoding === 'mixed') {
+                    expected = [
+                        0,
+                        9007199254740991,
+                        9007199254740992n,
+                        9223372036854775807n
+                    ];
+                } else {
+                    expected = [
+                        0,
+                        9007199254740991,
+                        Number(9007199254740992n),
+                        Number(9223372036854775807n)
+                    ];
+                }
+
+                assert.deepStrictEqual(actual, expected, `Error when intDecoding = ${intDecoding}`);
+            }
         });
     });
 });

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -976,7 +976,7 @@ module.exports = function getSteps(options) {
     
     Then("the asset info should match the expected asset info", function () {
         for (var k in this.assetTestFixture.expectedParams) {
-            assert.equal(true, this.assetTestFixture.expectedParams[k] === this.assetTestFixture.queriedParams[k] || ((!this.assetTestFixture.expectedParams[k]) && (!this.assetTestFixture.queriedParams[k])))
+            assert.strictEqual(true, this.assetTestFixture.expectedParams[k] === this.assetTestFixture.queriedParams[k] || ((!this.assetTestFixture.expectedParams[k]) && (!this.assetTestFixture.queriedParams[k])))
         }
     });
     
@@ -1528,16 +1528,16 @@ module.exports = function getSteps(options) {
     
     Then('the parsed response should equal the mock response.', function () {
         if (this.expectedMockResponseCode == 200) {
-            assert.equal(JSON.stringify(JSON.parse(expectedMockResponse)), JSON.stringify(this.actualMockResponse));
+            assert.strictEqual(JSON.stringify(JSON.parse(expectedMockResponse)), JSON.stringify(this.actualMockResponse));
         }
     });
     
     Then('expect error string to contain {string}', function (expectedErrorString) {
         if (expectedErrorString == 'nil') {
-            assert.equal("", globalErrForExamination);
+            assert.strictEqual("", globalErrForExamination);
             return;
         }
-        assert.equal(expectedErrorString, globalErrForExamination);
+        assert.strictEqual(expectedErrorString, globalErrForExamination);
     });
     
     Given('mock server recording request paths', function () {
@@ -1562,7 +1562,7 @@ module.exports = function getSteps(options) {
         } else if (indexerSeenRequests.length != 0) {
             actualRequestPath = indexerSeenRequests[0]['url'];
         }
-        assert.equal(expectedRequestPath, actualRequestPath);
+        assert.strictEqual(expectedRequestPath, actualRequestPath);
     });
     
     When('we make a Pending Transaction Information against txid {string} with max {int}', function (txid, max) {
@@ -1629,7 +1629,7 @@ module.exports = function getSteps(options) {
     
     Then('the parsed Pending Transaction Information response should have sender {string}', function (sender) {
         let actualSender = algosdk.encodeAddress(anyPendingTransactionInfoResponse['txn']['txn']['snd']);
-        assert.equal(sender, actualSender);
+        assert.strictEqual(sender, actualSender);
     });
     
     let anyPendingTransactionsInfoResponse;
@@ -1639,9 +1639,9 @@ module.exports = function getSteps(options) {
     });
     
     Then('the parsed Pending Transactions Information response should contain an array of len {int} and element number {int} should have sender {string}', function (len, idx, sender) {
-        assert.equal(len, anyPendingTransactionsInfoResponse['top-transactions'].length);
+        assert.strictEqual(len, anyPendingTransactionsInfoResponse['top-transactions'].length);
         if (len != 0) {
-            assert.equal(sender, algosdk.encodeAddress(anyPendingTransactionsInfoResponse['top-transactions'][idx]['txn']['snd']));
+            assert.strictEqual(sender, algosdk.encodeAddress(anyPendingTransactionsInfoResponse['top-transactions'][idx]['txn']['snd']));
         }
     });
     
@@ -1652,7 +1652,7 @@ module.exports = function getSteps(options) {
     });
     
     Then('the parsed Send Raw Transaction response should have txid {string}', function (txid) {
-        assert.equal(txid, anySendRawTransactionResponse['txId']);
+        assert.strictEqual(txid, anySendRawTransactionResponse['txId']);
     });
     
     let anyPendingTransactionsByAddressResponse;
@@ -1662,13 +1662,13 @@ module.exports = function getSteps(options) {
     });
     
     Then('the parsed Pending Transactions By Address response should contain an array of len {int} and element number {int} should have sender {string}', function (len, idx, sender) {
-        assert.equal(len, anyPendingTransactionsByAddressResponse['total-transactions']);
+        assert.strictEqual(len, anyPendingTransactionsByAddressResponse['total-transactions']);
         if (len == 0) {
             return
         }
         let actualSender = anyPendingTransactionsByAddressResponse['top-transactions'][idx]['txn']['snd']
         actualSender = algosdk.encodeAddress(actualSender);
-        assert.equal(sender, actualSender);
+        assert.strictEqual(sender, actualSender);
     });
     
     let anyNodeStatusResponse;
@@ -1678,7 +1678,7 @@ module.exports = function getSteps(options) {
     });
     
     Then('the parsed Node Status response should have a last round of {int}', function (lastRound) {
-        assert.equal(lastRound, anyNodeStatusResponse["last-round"]);
+        assert.strictEqual(lastRound, anyNodeStatusResponse["last-round"]);
     });
     
     let anyLedgerSupplyResponse;
@@ -1688,9 +1688,9 @@ module.exports = function getSteps(options) {
     });
     
     Then('the parsed Ledger Supply response should have totalMoney {int} onlineMoney {int} on round {int}', function (totalMoney, onlineMoney, round) {
-        assert.equal(totalMoney, anyLedgerSupplyResponse['total-money']);
-        assert.equal(onlineMoney, anyLedgerSupplyResponse['online-money']);
-        assert.equal(round, anyLedgerSupplyResponse['current_round']);
+        assert.strictEqual(totalMoney, anyLedgerSupplyResponse['total-money']);
+        assert.strictEqual(onlineMoney, anyLedgerSupplyResponse['online-money']);
+        assert.strictEqual(round, anyLedgerSupplyResponse['current_round']);
     });
     
     When('we make any Status After Block call', async function () {
@@ -1698,7 +1698,7 @@ module.exports = function getSteps(options) {
     });
     
     Then('the parsed Status After Block response should have a last round of {int}', function (lastRound) {
-        assert.equal(lastRound, anyNodeStatusResponse['last-round']);
+        assert.strictEqual(lastRound, anyNodeStatusResponse['last-round']);
     });
     
     let anyAccountInformationResponse;
@@ -1708,7 +1708,7 @@ module.exports = function getSteps(options) {
     });
     
     Then('the parsed Account Information response should have address {string}', function (address) {
-        assert.equal(address, anyAccountInformationResponse.address);
+        assert.strictEqual(address, anyAccountInformationResponse.address);
     });
     
     let anyBlockResponse;
@@ -1729,7 +1729,7 @@ module.exports = function getSteps(options) {
     });
     
     Then('the parsed Suggested Transaction Parameters response should have first round valid of {int}', function (firstRound) {
-        assert.equal(firstRound, anySuggestedTransactionsResponse.firstRound);
+        assert.strictEqual(firstRound, anySuggestedTransactionsResponse.firstRound);
     });
     
     When('we make a Lookup Asset Balances call against asset index {int} with limit {int} nextToken {string} round {int} currencyGreaterThan {int} currencyLessThan {int}', async function (index, limit, nextToken, round, currencyGreater, currencyLesser) {
@@ -1861,22 +1861,22 @@ module.exports = function getSteps(options) {
     When('we make any LookupAssetBalances call', async function () {
         anyLookupAssetBalancesResponse = await this.indexerClient
             .lookupAssetBalances()
-            .useBigInt()
+            .setIntDecoding('mixed')
             .do();
     });
     
     Then('the parsed LookupAssetBalances response should be valid on round {int}, and contain an array of len {int} and element number {int} should have address {string} amount {int} and frozen state {string}', function (round, length, idx, address, amount, frozenStateAsString) {
-        assert.equal(round, anyLookupAssetBalancesResponse['current-round']);
-        assert.equal(length, anyLookupAssetBalancesResponse['balances'].length);
-        if (length == 0) {
+        assert.strictEqual(round, anyLookupAssetBalancesResponse['current-round']);
+        assert.strictEqual(length, anyLookupAssetBalancesResponse['balances'].length);
+        if (length === 0) {
             return
         }
         let frozenState = false;
         if (frozenStateAsString === "true") {
             frozenState = true;
         }
-        assert.equal(amount, anyLookupAssetBalancesResponse['balances'][idx]['amount']);
-        assert.equal(frozenState, anyLookupAssetBalancesResponse['balances'][idx]['is-frozen']);
+        assert.strictEqual(amount, anyLookupAssetBalancesResponse['balances'][idx]['amount']);
+        assert.strictEqual(frozenState, anyLookupAssetBalancesResponse['balances'][idx]['is-frozen']);
     });
     
     let anyLookupAssetTransactionsResponse;
@@ -1884,17 +1884,17 @@ module.exports = function getSteps(options) {
     When('we make any LookupAssetTransactions call', async function () {
         anyLookupAssetTransactionsResponse = await this.indexerClient
             .lookupAssetTransactions()
-            .useBigInt()
+            .setIntDecoding('mixed')
             .do();
     });
     
     Then('the parsed LookupAssetTransactions response should be valid on round {int}, and contain an array of len {int} and element number {int} should have sender {string}', function (round, length, idx, sender) {
-        assert.equal(round, anyLookupAssetTransactionsResponse['current-round']);
-        assert.equal(length, anyLookupAssetTransactionsResponse['transactions'].length);
-        if (length == 0) {
+        assert.strictEqual(round, anyLookupAssetTransactionsResponse['current-round']);
+        assert.strictEqual(length, anyLookupAssetTransactionsResponse['transactions'].length);
+        if (length === 0) {
             return
         }
-        assert.equal(sender, anyLookupAssetTransactionsResponse['transactions'][idx]['sender']);
+        assert.strictEqual(sender, anyLookupAssetTransactionsResponse['transactions'][idx]['sender']);
     });
     
     let anyLookupAccountTransactionsResponse;
@@ -1904,12 +1904,12 @@ module.exports = function getSteps(options) {
     });
     
     Then('the parsed LookupAccountTransactions response should be valid on round {int}, and contain an array of len {int} and element number {int} should have sender {string}', function (round, length, idx, sender) {
-        assert.equal(round, anyLookupAccountTransactionsResponse['current-round']);
-        assert.equal(length, anyLookupAccountTransactionsResponse['transactions'].length);
+        assert.strictEqual(round, anyLookupAccountTransactionsResponse['current-round']);
+        assert.strictEqual(length, anyLookupAccountTransactionsResponse['transactions'].length);
         if (length == 0) {
             return
         }
-        assert.equal(sender, anyLookupAccountTransactionsResponse['transactions'][idx]['sender']);
+        assert.strictEqual(sender, anyLookupAccountTransactionsResponse['transactions'][idx]['sender']);
     });
     
     let anyLookupBlockResponse;
@@ -1919,7 +1919,7 @@ module.exports = function getSteps(options) {
     });
     
     Then('the parsed LookupBlock response should have previous block hash {string}', function (prevHash) {
-        assert.equal(prevHash, anyLookupBlockResponse['previous-block-hash']);
+        assert.strictEqual(prevHash, anyLookupBlockResponse['previous-block-hash']);
     });
     
     let anyLookupAccountByIDResponse;
@@ -1929,7 +1929,7 @@ module.exports = function getSteps(options) {
     });
     
     Then('the parsed LookupAccountByID response should have address {string}', function (address) {
-        assert.equal(address, anyLookupAccountByIDResponse['account']['address'])
+        assert.strictEqual(address, anyLookupAccountByIDResponse['account']['address'])
     });
     
     let anyLookupAssetByIDResponse;
@@ -1937,12 +1937,12 @@ module.exports = function getSteps(options) {
     When('we make any LookupAssetByID call', async function () {
         anyLookupAssetByIDResponse = await this.indexerClient
             .lookupAssetByID()
-            .useBigInt()
+            .setIntDecoding('mixed')
             .do();
     });
     
     Then('the parsed LookupAssetByID response should have index {int}', function (idx) {
-        assert.equal(idx, anyLookupAssetByIDResponse["asset"]["index"]);
+        assert.strictEqual(idx, anyLookupAssetByIDResponse["asset"]["index"]);
     });
     
     let anySearchAccountsResponse;
@@ -1952,21 +1952,21 @@ module.exports = function getSteps(options) {
     });
     
     Then('the parsed SearchAccounts response should be valid on round {int} and the array should be of len {int} and the element at index {int} should have address {string}', function (round, length, idx, address) {
-        assert.equal(round, anySearchAccountsResponse['current-round']);
-        assert.equal(length, anySearchAccountsResponse['accounts'].length);
+        assert.strictEqual(round, anySearchAccountsResponse['current-round']);
+        assert.strictEqual(length, anySearchAccountsResponse['accounts'].length);
         if (length == 0) {
             return;
         }
-        assert.equal(address, anySearchAccountsResponse['accounts'][idx]['address']);
+        assert.strictEqual(address, anySearchAccountsResponse['accounts'][idx]['address']);
     });
     
     Then('the parsed SearchAccounts response should be valid on round {int} and the array should be of len {int} and the element at index {int} should have authorizing address {string}', function (round, length, idx, authAddress) {
-        assert.equal(round, anySearchAccountsResponse['current-round']);
-        assert.equal(length, anySearchAccountsResponse['accounts'].length);
+        assert.strictEqual(round, anySearchAccountsResponse['current-round']);
+        assert.strictEqual(length, anySearchAccountsResponse['accounts'].length);
         if (length == 0) {
             return;
         }
-        assert.equal(authAddress, anySearchAccountsResponse['accounts'][idx]['auth-addr']);
+        assert.strictEqual(authAddress, anySearchAccountsResponse['accounts'][idx]['auth-addr']);
     });
     
     let anySearchForTransactionsResponse;
@@ -1976,21 +1976,21 @@ module.exports = function getSteps(options) {
     });
     
     Then('the parsed SearchForTransactions response should be valid on round {int} and the array should be of len {int} and the element at index {int} should have sender {string}', function (round, length, idx, sender) {
-        assert.equal(round, anySearchForTransactionsResponse['current-round']);
-        assert.equal(length, anySearchForTransactionsResponse['transactions'].length);
+        assert.strictEqual(round, anySearchForTransactionsResponse['current-round']);
+        assert.strictEqual(length, anySearchForTransactionsResponse['transactions'].length);
         if (length == 0) {
             return;
         }
-        assert.equal(sender, anySearchForTransactionsResponse['transactions'][idx]['sender']);
+        assert.strictEqual(sender, anySearchForTransactionsResponse['transactions'][idx]['sender']);
     });
     
     Then('the parsed SearchForTransactions response should be valid on round {int} and the array should be of len {int} and the element at index {int} should have rekey-to {string}', function (round, length, idx, rekeyTo) {
-        assert.equal(round, anySearchForTransactionsResponse['current-round']);
-        assert.equal(length, anySearchForTransactionsResponse['transactions'].length);
+        assert.strictEqual(round, anySearchForTransactionsResponse['current-round']);
+        assert.strictEqual(length, anySearchForTransactionsResponse['transactions'].length);
         if (length == 0) {
             return;
         }
-        assert.equal(rekeyTo, anySearchForTransactionsResponse['transactions'][idx]['rekey-to']);
+        assert.strictEqual(rekeyTo, anySearchForTransactionsResponse['transactions'][idx]['rekey-to']);
     });
     
     let anySearchForAssetsResponse;
@@ -2000,12 +2000,12 @@ module.exports = function getSteps(options) {
     });
     
     Then('the parsed SearchForAssets response should be valid on round {int} and the array should be of len {int} and the element at index {int} should have asset index {int}', function (round, length, idx, assetIndex) {
-        assert.equal(round, anySearchForAssetsResponse['current-round']);
-        assert.equal(length, anySearchForAssetsResponse['assets'].length);
+        assert.strictEqual(round, anySearchForAssetsResponse['current-round']);
+        assert.strictEqual(length, anySearchForAssetsResponse['assets'].length);
         if (length == 0) {
             return;
         }
-        assert.equal(assetIndex, anySearchForAssetsResponse['assets'][idx]['index']);
+        assert.strictEqual(assetIndex, anySearchForAssetsResponse['assets'][idx]['index']);
     });
     
     ////////////////////////////////////
@@ -2030,7 +2030,7 @@ module.exports = function getSteps(options) {
     
     Then('I receive status code {int}', async function(code) {
         // Currently only supports the good case. code != 200 should throw an exception.
-        assert.equal(code, 200)
+        assert.strictEqual(code, 200)
     });
     
     let integrationBlockResponse;
@@ -2041,9 +2041,9 @@ module.exports = function getSteps(options) {
     });
     
     Then('The block was confirmed at {int}, contains {int} transactions, has the previous block hash {string}', function (timestamp, numTransactions, prevHash) {
-        assert.equal(timestamp, integrationBlockResponse['timestamp']);
-        assert.equal(numTransactions, integrationBlockResponse['transactions'].length);
-        assert.equal(prevHash, integrationBlockResponse['previous-block-hash']);
+        assert.strictEqual(timestamp, integrationBlockResponse['timestamp']);
+        assert.strictEqual(numTransactions, integrationBlockResponse['transactions'].length);
+        assert.strictEqual(prevHash, integrationBlockResponse['previous-block-hash']);
     });
     
     let integrationLookupAccountResponse;
@@ -2055,38 +2055,38 @@ module.exports = function getSteps(options) {
     
     Then('The account has {int} assets, the first is asset {int} has a frozen status of {string} and amount {int}.', function (numAssets, firstAssetIndex, firstAssetFrozenStatus, firstAssetAmount) {
         let firstAssetFrozenBool = (firstAssetFrozenStatus == "true");
-        assert.equal(numAssets, integrationLookupAccountResponse['account']['assets'].length);
+        assert.strictEqual(numAssets, integrationLookupAccountResponse['account']['assets'].length);
         if (numAssets == 0) {
             return
         }
         let scrutinizedAsset = integrationLookupAccountResponse['account']['assets'][0];
-        assert.equal(firstAssetIndex, scrutinizedAsset['asset-id']);
-        assert.equal(firstAssetFrozenBool, scrutinizedAsset['is-frozen']);
-        assert.equal(firstAssetAmount, scrutinizedAsset['amount']);
+        assert.strictEqual(firstAssetIndex, scrutinizedAsset['asset-id']);
+        assert.strictEqual(firstAssetFrozenBool, scrutinizedAsset['is-frozen']);
+        assert.strictEqual(firstAssetAmount, scrutinizedAsset['amount']);
     });
     
     Then('The account created {int} assets, the first is asset {int} is named {string} with a total amount of {int} {string}', function (numCreatedAssets, firstCreatedAssetIndex, assetName, assetIssuance, assetUnit) {
-        assert.equal(numCreatedAssets, integrationLookupAccountResponse['account']['created-assets'].length);
+        assert.strictEqual(numCreatedAssets, integrationLookupAccountResponse['account']['created-assets'].length);
         let scrutinizedAsset = integrationLookupAccountResponse['account']['created-assets'][0];
-        assert.equal(firstCreatedAssetIndex, scrutinizedAsset['index']);
-        assert.equal(assetName, scrutinizedAsset['params']['name']);
-        assert.equal(assetIssuance, scrutinizedAsset['params']['total']);
-        assert.equal(assetUnit, scrutinizedAsset['params']['unit-name']);
+        assert.strictEqual(firstCreatedAssetIndex, scrutinizedAsset['index']);
+        assert.strictEqual(assetName, scrutinizedAsset['params']['name']);
+        assert.strictEqual(assetIssuance, scrutinizedAsset['params']['total']);
+        assert.strictEqual(assetUnit, scrutinizedAsset['params']['unit-name']);
     });
     
     Then('The account has {int} μalgos and {int} assets, {int} has {int}', function (microAlgos, numAssets, assetIndexToScrutinize, assetAmount) {
-        assert.equal(microAlgos, integrationLookupAccountResponse['account']['amount']);
+        assert.strictEqual(microAlgos, integrationLookupAccountResponse['account']['amount']);
         if (numAssets == 0) {
             return
         }
-        assert.equal(numAssets, integrationLookupAccountResponse['account']['assets'].length);
+        assert.strictEqual(numAssets, integrationLookupAccountResponse['account']['assets'].length);
         if (assetIndexToScrutinize == 0) {
             return
         }
         for (idx = 0; idx < integrationLookupAccountResponse['account']['assets'].length; idx++) {
             let scrutinizedAsset = integrationLookupAccountResponse['account']['assets'][idx];
             if (scrutinizedAsset['index'] == assetIndexToScrutinize) {
-                assert.equal(assetAmount, scrutinizedAsset['amount'])
+                assert.strictEqual(assetAmount, scrutinizedAsset['amount'])
             }
         }
     });
@@ -2100,14 +2100,14 @@ module.exports = function getSteps(options) {
     
     Then('The asset found has: {string}, {string}, {string}, {int}, {string}, {int}, {string}', function (name, units, creator, decimals, defaultFrozen, totalIssuance, clawback) {
         let assetParams = integrationLookupAssetResponse['asset']['params'];
-        assert.equal(name, assetParams['name']);
-        assert.equal(units, assetParams['unit-name']);
-        assert.equal(creator, assetParams['creator']);
-        assert.equal(decimals, assetParams['decimals']);
+        assert.strictEqual(name, assetParams['name']);
+        assert.strictEqual(units, assetParams['unit-name']);
+        assert.strictEqual(creator, assetParams['creator']);
+        assert.strictEqual(decimals, assetParams['decimals']);
         let defaultFrozenBool = (defaultFrozen == "true");
-        assert.equal(defaultFrozenBool, assetParams['default-frozen']);
-        assert.equal(totalIssuance, assetParams['total']);
-        assert.equal(clawback, assetParams['clawback']);
+        assert.strictEqual(defaultFrozenBool, assetParams['default-frozen']);
+        assert.strictEqual(totalIssuance, assetParams['total']);
+        assert.strictEqual(clawback, assetParams['clawback']);
     });
     
     let integrationLookupAssetBalancesResponse;
@@ -2124,15 +2124,15 @@ module.exports = function getSteps(options) {
     });
     
     Then('There are {int} with the asset, the first is {string} has {string} and {int}', function (numAccounts, firstAccountAddress, isFrozenString, accountAmount) {
-        assert.equal(numAccounts, integrationLookupAssetBalancesResponse['balances'].length)
+        assert.strictEqual(numAccounts, integrationLookupAssetBalancesResponse['balances'].length)
         if (numAccounts == 0) {
             return
         }
         let firstHolder = integrationLookupAssetBalancesResponse['balances'][0];
-        assert.equal(firstAccountAddress, firstHolder['address']);
+        assert.strictEqual(firstAccountAddress, firstHolder['address']);
         let isFrozenBool = (isFrozenString == "true");
-        assert.equal(isFrozenBool, firstHolder['is-frozen']);
-        assert.equal(accountAmount, firstHolder['amount']);
+        assert.strictEqual(isFrozenBool, firstHolder['is-frozen']);
+        assert.strictEqual(accountAmount, firstHolder['amount']);
     });
     
     let integrationSearchAccountsResponse;
@@ -2149,20 +2149,20 @@ module.exports = function getSteps(options) {
     });
     
     Then('There are {int}, the first has {int}, {int}, {int}, {int}, {string}, {int}, {string}, {string}', function (numAccounts, pendingRewards, rewardsBase, rewards, withoutRewards, address, amount, status, type) {
-        assert.equal(numAccounts, integrationSearchAccountsResponse['accounts'].length)
+        assert.strictEqual(numAccounts, integrationSearchAccountsResponse['accounts'].length)
         if (numAccounts == 0) {
             return;
         }
         let scrutinizedAccount = integrationSearchAccountsResponse['accounts'][0];
-        assert.equal(pendingRewards,scrutinizedAccount['pending-rewards'])
-        assert.equal(rewardsBase,scrutinizedAccount['reward-base'])
-        assert.equal(rewards,scrutinizedAccount['rewards'])
-        assert.equal(withoutRewards,scrutinizedAccount['amount-without-pending-rewards'])
-        assert.equal(address,scrutinizedAccount['address'])
-        assert.equal(amount,scrutinizedAccount['amount'])
-        assert.equal(status,scrutinizedAccount['status'])
+        assert.strictEqual(pendingRewards,scrutinizedAccount['pending-rewards'])
+        assert.strictEqual(rewardsBase,scrutinizedAccount['reward-base'])
+        assert.strictEqual(rewards,scrutinizedAccount['rewards'])
+        assert.strictEqual(withoutRewards,scrutinizedAccount['amount-without-pending-rewards'])
+        assert.strictEqual(address,scrutinizedAccount['address'])
+        assert.strictEqual(amount,scrutinizedAccount['amount'])
+        assert.strictEqual(status,scrutinizedAccount['status'])
         if (type) {
-            assert.equal(type,scrutinizedAccount['sig-type'])
+            assert.strictEqual(type,scrutinizedAccount['sig-type'])
         }
     });
     
@@ -2174,13 +2174,13 @@ module.exports = function getSteps(options) {
     
     Then('The first account is online and has {string}, {int}, {int}, {int}, {string}, {string}', function (address, keyDilution, firstValid, lastValid, voteKey, selKey) {
         let scrutinizedAccount = integrationSearchAccountsResponse['accounts'][0];
-        assert.equal("Online",scrutinizedAccount['status'])
-        assert.equal(address,scrutinizedAccount['address'])
-        assert.equal(keyDilution,scrutinizedAccount['participation']['vote-key-dilution'])
-        assert.equal(firstValid,scrutinizedAccount['participation']['vote-first-valid'])
-        assert.equal(lastValid,scrutinizedAccount['participation']['vote-last-valid'])
-        assert.equal(voteKey,scrutinizedAccount['participation']['vote-participation-key'])
-        assert.equal(selKey,scrutinizedAccount['participation']['selection-participation-key'])
+        assert.strictEqual("Online",scrutinizedAccount['status'])
+        assert.strictEqual(address,scrutinizedAccount['address'])
+        assert.strictEqual(keyDilution,scrutinizedAccount['participation']['vote-key-dilution'])
+        assert.strictEqual(firstValid,scrutinizedAccount['participation']['vote-first-valid'])
+        assert.strictEqual(lastValid,scrutinizedAccount['participation']['vote-last-valid'])
+        assert.strictEqual(voteKey,scrutinizedAccount['participation']['vote-participation-key'])
+        assert.strictEqual(selKey,scrutinizedAccount['participation']['selection-participation-key'])
     });
     
     let integrationSearchTransactionsResponse;
@@ -2245,17 +2245,17 @@ module.exports = function getSteps(options) {
     });
     
     Then('there are {int} transactions in the response, the first is {string}.', function (numTransactions, txid) {
-        assert.equal(numTransactions, integrationSearchTransactionsResponse['transactions'].length);
+        assert.strictEqual(numTransactions, integrationSearchTransactionsResponse['transactions'].length);
         if (numTransactions == 0) {
             return;
         }
-        assert.equal(txid, integrationSearchTransactionsResponse['transactions'][0]['id']);
+        assert.strictEqual(txid, integrationSearchTransactionsResponse['transactions'][0]['id']);
     });
     
     Then('Every transaction has tx-type {string}', function (txType) {
         for (idx = 0; idx < integrationSearchTransactionsResponse['transactions'].length; idx++) {
             let scrutinizedTxn = integrationSearchTransactionsResponse['transactions'][idx];
-            assert.equal(txType, scrutinizedTxn['tx-type']);
+            assert.strictEqual(txType, scrutinizedTxn['tx-type']);
         }
     });
     
@@ -2275,14 +2275,14 @@ module.exports = function getSteps(options) {
         }
         for (idx = 0; idx < integrationSearchTransactionsResponse['transactions'].length; idx++) {
             let scrutinizedTxn = integrationSearchTransactionsResponse['transactions'][idx];
-            assert.equal(sigType, getSigTypeFromTxnResponse(scrutinizedTxn))
+            assert.strictEqual(sigType, getSigTypeFromTxnResponse(scrutinizedTxn))
         }
     });
     
     Then('Every transaction has round {int}', function (round) {
         for (idx = 0; idx < integrationSearchTransactionsResponse['transactions'].length; idx++) {
             let scrutinizedTxn = integrationSearchTransactionsResponse['transactions'][idx];
-            assert.equal(round, scrutinizedTxn['confirmed-round']);
+            assert.strictEqual(round, scrutinizedTxn['confirmed-round']);
         }
     });
     
@@ -2319,7 +2319,7 @@ module.exports = function getSteps(options) {
         }
         for (idx = 0; idx < integrationSearchTransactionsResponse['transactions'].length; idx++) {
             let scrutinizedTxn = integrationSearchTransactionsResponse['transactions'][idx];
-            assert.equal(assetId, extractIdFromTransaction(scrutinizedTxn));
+            assert.strictEqual(assetId, extractIdFromTransaction(scrutinizedTxn));
         }
     });
     
@@ -2365,11 +2365,11 @@ module.exports = function getSteps(options) {
     });
     
     Then('there are {int} assets in the response, the first is {int}.', function (numAssets, firstAssetId) {
-        assert.equal(numAssets, integrationSearchAssetsResponse['assets'].length);
+        assert.strictEqual(numAssets, integrationSearchAssetsResponse['assets'].length);
         if (numAssets == 0) {
             return
         }
-        assert.equal(firstAssetId, integrationSearchAssetsResponse['assets'][0]['index']);
+        assert.strictEqual(firstAssetId, integrationSearchAssetsResponse['assets'][0]['index']);
     });
     
     ////////////////////////////////////
@@ -2398,8 +2398,8 @@ module.exports = function getSteps(options) {
     });
     
     Then('the parsed Dryrun Response should have global delta {string} with {int}', function (key, action) {
-        assert.equal(dryrunResponse.txns[0]["global-delta"][0].key, key);
-        assert.equal(dryrunResponse.txns[0]["global-delta"][0].value.action, action)
+        assert.strictEqual(dryrunResponse.txns[0]["global-delta"][0].key, key);
+        assert.strictEqual(dryrunResponse.txns[0]["global-delta"][0].value.action, action)
     });
     
     When('I dryrun a {string} program {string}', async function (kind, program) {
@@ -2449,7 +2449,7 @@ module.exports = function getSteps(options) {
             msgs = res["app-call-messages"]
         }
         assert.ok(msgs.length > 0);
-        assert.equal(msgs[0], result);
+        assert.strictEqual(msgs[0], result);
     });
     
     let compileStatusCode;
@@ -2470,9 +2470,9 @@ module.exports = function getSteps(options) {
     });
     
     Then('it is compiled with {int} and {string} and {string}', function (status, result, hash) {
-        assert.equal(status, compileStatusCode);
-        assert.equal(result, compileResponse.result);
-        assert.equal(hash, compileResponse.hash);
+        assert.strictEqual(status, compileStatusCode);
+        assert.strictEqual(result, compileResponse.result);
+        assert.strictEqual(hash, compileResponse.hash);
     });
     
     ////////////////////////////////////
@@ -2648,7 +2648,7 @@ module.exports = function getSteps(options) {
     
     Then('the base{int} encoded signed transaction should equal {string}', function (base, base64golden) {
         let actualBase64 = Buffer.from(this.stx).toString("base64");
-        assert.equal(base64golden, actualBase64)
+        assert.strictEqual(base64golden, actualBase64)
     });
     
     Given('an algod v{int} client connected to {string} port {int} with token {string}', function (clientVersion, host, port, token) {

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -1859,7 +1859,10 @@ module.exports = function getSteps(options) {
     let anyLookupAssetBalancesResponse;
     
     When('we make any LookupAssetBalances call', async function () {
-        anyLookupAssetBalancesResponse = await this.indexerClient.lookupAssetBalances().do();
+        anyLookupAssetBalancesResponse = await this.indexerClient
+            .lookupAssetBalances()
+            .useBigInt(true)
+            .do();
     });
     
     Then('the parsed LookupAssetBalances response should be valid on round {int}, and contain an array of len {int} and element number {int} should have address {string} amount {int} and frozen state {string}', function (round, length, idx, address, amount, frozenStateAsString) {
@@ -1879,7 +1882,10 @@ module.exports = function getSteps(options) {
     let anyLookupAssetTransactionsResponse;
     
     When('we make any LookupAssetTransactions call', async function () {
-        anyLookupAssetTransactionsResponse = await this.indexerClient.lookupAssetTransactions().do();
+        anyLookupAssetTransactionsResponse = await this.indexerClient
+            .lookupAssetTransactions()
+            .useBigInt(true)
+            .do();
     });
     
     Then('the parsed LookupAssetTransactions response should be valid on round {int}, and contain an array of len {int} and element number {int} should have sender {string}', function (round, length, idx, sender) {
@@ -1929,7 +1935,10 @@ module.exports = function getSteps(options) {
     let anyLookupAssetByIDResponse;
     
     When('we make any LookupAssetByID call', async function () {
-        anyLookupAssetByIDResponse = await this.indexerClient.lookupAssetByID().do();
+        anyLookupAssetByIDResponse = await this.indexerClient
+            .lookupAssetByID()
+            .useBigInt(true)
+            .do();
     });
     
     Then('the parsed LookupAssetByID response should have index {int}', function (idx) {

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -1861,7 +1861,7 @@ module.exports = function getSteps(options) {
     When('we make any LookupAssetBalances call', async function () {
         anyLookupAssetBalancesResponse = await this.indexerClient
             .lookupAssetBalances()
-            .useBigInt(true)
+            .useBigInt()
             .do();
     });
     
@@ -1884,7 +1884,7 @@ module.exports = function getSteps(options) {
     When('we make any LookupAssetTransactions call', async function () {
         anyLookupAssetTransactionsResponse = await this.indexerClient
             .lookupAssetTransactions()
-            .useBigInt(true)
+            .useBigInt()
             .do();
     });
     
@@ -1937,7 +1937,7 @@ module.exports = function getSteps(options) {
     When('we make any LookupAssetByID call', async function () {
         anyLookupAssetByIDResponse = await this.indexerClient
             .lookupAssetByID()
-            .useBigInt(true)
+            .useBigInt()
             .do();
     });
     


### PR DESCRIPTION
Several of the aglod REST APIs can return JSON responses with integer values greater than JavaScript's maximum safe integer value. To fix this problem, this PR uses the [json-bigint](https://www.npmjs.com/package/json-bigint) library to parse the JSON response from our endpoints. This PR introduces the following modes to parse integers:
* `"default"`: Integers will be decoded according to `JSON.parse`, meaning they will all be Numbers and any values greater than `Number.MAX_SAFE_INTEGER` will lose precision.
* `"safe"`: All integers will be decoded as Numbers, but if any values are greater than `Number.MAX_SAFE_INTEGER` an error will be thrown.
* `"mixed"`: Integers will be decoded as Numbers if they are less than or equal to `Number.MAX_SAFE_INTEGER`, otherwise they will be decoded as BigInts.
* `"bigint"`: All integers will be decoded as BigInts.

To specify which mode you want to use, call the `setIntDecoding` method on a JSON request object. For example:
```javascript
const accountInfo = await client.accountInformation(account.addr).setIntDecoding('mixed').do();
```

If `setIntDecoding` is not called for a request, by default the `"default"` mode will be used. To make this feature easy to adopt and to reduce repetitiveness, the default mode for a client can be changed by calling the `setIntDecoding` method on an Algodv2 or Indexer client. For example:

```javascript
const client = new algosdk.Algodv2(...);
client.setIntDecoding('mixed'); // now all requests from this client will use the 'mixed' mode unless overridden

// this will do the same thing as the previous example
const accountInfo = await client.accountInformation(account.addr).do();
```

Fixes #251.