### PR TITLE
Allow BigInts to be used in Transaction constructor

### DIFF
--- a/src/transaction.js
+++ b/src/transaction.js
@@ -58,7 +58,7 @@ class Transaction {
         if (!Number.isSafeInteger(fee) || fee < 0) throw Error("fee must be a positive number and smaller than 2^53-1");
         if (!Number.isSafeInteger(firstRound) || firstRound < 0) throw Error("firstRound must be a positive number");
         if (!Number.isSafeInteger(lastRound) || lastRound < 0) throw Error("lastRound must be a positive number");
-        if (assetTotal !== undefined && (!Number.isSafeInteger(assetTotal) || assetTotal < 0)) throw Error("Total asset issuance must be a positive number and smaller than 2^53-1");
+        if (assetTotal !== undefined && (!(Number.isSafeInteger(assetTotal) || (typeof(assetTotal) === 'bigint' && assetTotal <= 0xFFFFFFFFFFFFFFFFn)) || assetTotal < 0)) throw Error("Total asset issuance must be a positive number and smaller than 2^64-1");
         if (assetDecimals !== undefined && (!Number.isSafeInteger(assetDecimals) || assetDecimals < 0 || assetDecimals > ALGORAND_MAX_ASSET_DECIMALS)) throw Error("assetDecimals must be a positive number and smaller than " + ALGORAND_MAX_ASSET_DECIMALS.toString());
         if (assetIndex !== undefined && (!Number.isSafeInteger(assetIndex) || assetIndex < 0)) throw Error("Asset index must be a positive number and smaller than 2^53-1");
         if (appIndex !== undefined && (!Number.isSafeInteger(appIndex) || appIndex < 0)) throw Error("Application index must be a positive number and smaller than 2^53-1");

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -54,7 +54,7 @@ class Transaction {
 
         genesisHash = Buffer.from(genesisHash, 'base64');
 
-        if (amount !== undefined && (!Number.isSafeInteger(amount) || amount < 0)) throw Error("Amount must be a positive number and smaller than 2^53-1");
+        if (amount !== undefined && (!(Number.isSafeInteger(amount) || (typeof(amount) === 'bigint' && amount <= 0xFFFFFFFFFFFFFFFFn)) || amount < 0)) throw Error("Amount must be a positive number and smaller than 2^64-1");
         if (!Number.isSafeInteger(fee) || fee < 0) throw Error("fee must be a positive number and smaller than 2^53-1");
         if (!Number.isSafeInteger(firstRound) || firstRound < 0) throw Error("firstRound must be a positive number");
         if (!Number.isSafeInteger(lastRound) || lastRound < 0) throw Error("lastRound must be a positive number");

--- a/tests/5.Transaction.js
+++ b/tests/5.Transaction.js
@@ -382,6 +382,64 @@ describe('Sign', function () {
             assert.deepStrictEqual(expectedTxn, actualTxn);
         });
 
+        it('should be able to use helper to make a payment transaction with BigInt amount', function() {
+            let from = "XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU";
+            let to = "UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM";
+            let fee = 10;
+            let amount = 0xFFFFFFFFFFFFFFFFn;
+            let firstRound = 51;
+            let lastRound = 61;
+            let note = new Uint8Array([123, 12, 200]);
+            let genesisHash = "JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=";
+            let genesisID = "";
+            let rekeyTo = "GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM";
+            let closeRemainderTo = undefined;
+            let o = {
+                "from": from,
+                "to": to,
+                "fee": fee,
+                "amount": amount,
+                "closeRemainderTo": closeRemainderTo,
+                "firstRound": firstRound,
+                "lastRound": lastRound,
+                "note": note,
+                "genesisHash": genesisHash,
+                "genesisID": genesisID,
+                "rekeyTo": rekeyTo
+            };
+            let expectedTxn = new algosdk.Transaction(o);
+            let actualTxn = algosdk.makePaymentTxn(from, to, fee, amount, closeRemainderTo, firstRound, lastRound, note, genesisHash, genesisID, rekeyTo);
+            assert.deepStrictEqual(expectedTxn, actualTxn);
+        });
+
+        it('should throw if payment amount is too large', function() {
+            let from = "XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU";
+            let to = "UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM";
+            let fee = 10;
+            let amount = 0x10000000000000000n;
+            let firstRound = 51;
+            let lastRound = 61;
+            let note = new Uint8Array([123, 12, 200]);
+            let genesisHash = "JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=";
+            let genesisID = "";
+            let rekeyTo = "GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM";
+            let closeRemainderTo = undefined;
+            let o = {
+                "from": from,
+                "to": to,
+                "fee": fee,
+                "amount": amount,
+                "closeRemainderTo": closeRemainderTo,
+                "firstRound": firstRound,
+                "lastRound": lastRound,
+                "note": note,
+                "genesisHash": genesisHash,
+                "genesisID": genesisID,
+                "rekeyTo": rekeyTo
+            };
+            assert.throws(() => new algosdk.Transaction(o), new Error('Amount must be a positive number and smaller than 2^64-1'));
+        });
+
         it('should be able to use helper to make a keyreg transaction', function() {
             let from = "XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU";
             let fee = 10;

--- a/tests/5.Transaction.js
+++ b/tests/5.Transaction.js
@@ -465,6 +465,97 @@ describe('Sign', function () {
             assert.deepStrictEqual(expectedTxn, actualTxn);
         });
 
+        it('should be able to use helper to make an asset create transaction with BigInt total', function() {
+            let addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4";
+            let fee = 10;
+            let defaultFrozen = false;
+            let genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=";
+            let total = 0xFFFFFFFFFFFFFFFFn;
+            let decimals = 0;
+            let reserve = addr;
+            let freeze = addr;
+            let clawback = addr;
+            let unitName = "tst";
+            let assetName = "testcoin";
+            let assetURL = "testURL";
+            let assetMetadataHash = new Uint8Array(Buffer.from("dGVzdGhhc2gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", "base64"));
+            let genesisID = "";
+            let firstRound = 322575;
+            let lastRound = 322575;
+            let note = new Uint8Array([123, 12, 200]);
+            let rekeyTo = "GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM";
+            let o = {
+                "from": addr,
+                "fee": fee,
+                "firstRound": firstRound,
+                "lastRound": lastRound,
+                "note": note,
+                "genesisHash": genesisHash,
+                "assetTotal": total,
+                "assetDecimals": decimals,
+                "assetDefaultFrozen": defaultFrozen,
+                "assetUnitName": unitName,
+                "assetName": assetName,
+                "assetURL": assetURL,
+                "assetMetadataHash": assetMetadataHash,
+                "assetManager": addr,
+                "assetReserve": reserve,
+                "assetFreeze": freeze,
+                "assetClawback": clawback,
+                "genesisID": genesisID,
+                "rekeyTo": rekeyTo,
+                "type": "acfg"
+            };
+            let expectedTxn = new algosdk.Transaction(o);
+            let actualTxn = algosdk.makeAssetCreateTxn(addr, fee, firstRound, lastRound, note, genesisHash, genesisID,
+                total, decimals, defaultFrozen, addr, reserve, freeze, clawback, unitName, assetName, assetURL, assetMetadataHash, rekeyTo);
+            assert.deepStrictEqual(expectedTxn, actualTxn);
+        });
+
+        it('should throw if asset creation total is too large', function() {
+            let addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4";
+            let fee = 10;
+            let defaultFrozen = false;
+            let genesisHash = "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=";
+            let total = 0x10000000000000000n;
+            let decimals = 0;
+            let reserve = addr;
+            let freeze = addr;
+            let clawback = addr;
+            let unitName = "tst";
+            let assetName = "testcoin";
+            let assetURL = "testURL";
+            let assetMetadataHash = new Uint8Array(Buffer.from("dGVzdGhhc2gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", "base64"));
+            let genesisID = "";
+            let firstRound = 322575;
+            let lastRound = 322575;
+            let note = new Uint8Array([123, 12, 200]);
+            let rekeyTo = "GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM";
+            let o = {
+                "from": addr,
+                "fee": fee,
+                "firstRound": firstRound,
+                "lastRound": lastRound,
+                "note": note,
+                "genesisHash": genesisHash,
+                "assetTotal": total,
+                "assetDecimals": decimals,
+                "assetDefaultFrozen": defaultFrozen,
+                "assetUnitName": unitName,
+                "assetName": assetName,
+                "assetURL": assetURL,
+                "assetMetadataHash": assetMetadataHash,
+                "assetManager": addr,
+                "assetReserve": reserve,
+                "assetFreeze": freeze,
+                "assetClawback": clawback,
+                "genesisID": genesisID,
+                "rekeyTo": rekeyTo,
+                "type": "acfg"
+            };
+            assert.throws(() => new algosdk.Transaction(o), new Error('Total asset issuance must be a positive number and smaller than 2^64-1'));
+        });
+
         it('should fail to make an asset create transaction with an invalid assetMetadataHash', function() {
             let addr = "BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4";
             let fee = 10;


### PR DESCRIPTION
Currently's it's not possible to construct an asset creation transaction that has a total issuance larger than 2^53-1, or transfer asset amounts that exceed 2^53-1. This PR fixes this by allowing the Transaction constructor to accept BigInts for the asset total parameter and amount parameter. Since our msgpack fork already supports encoding and decoding BigInts, this just updates the gatekeeping logic we perform on `amount` and `assetTotal`.