### PR TITLE
Fixing rekeyTo makeTxnWithSuggestedParams bug

### DIFF
--- a/src/makeTxn.js
+++ b/src/makeTxn.js
@@ -56,7 +56,7 @@ function makePaymentTxnWithSuggestedParams(from, to, amount, closeRemainderTo, n
         "note": note,
         "suggestedParams": suggestedParams,
         "type": "pay",
-        "rekeyTo": rekeyTo
+        "reKeyTo": rekeyTo
     };
     return new txnBuilder.Transaction(o);
 }
@@ -134,7 +134,7 @@ function makeKeyRegistrationTxnWithSuggestedParams(from, note, voteKey, selectio
         "voteKeyDilution": voteKeyDilution,
         "suggestedParams": suggestedParams,
         "type": "keyreg",
-        "rekeyTo": rekeyTo
+        "reKeyTo": rekeyTo
     };
     return new txnBuilder.Transaction(o);
 }
@@ -230,7 +230,7 @@ function makeAssetCreateTxnWithSuggestedParams(from, note, total, decimals, defa
         "assetFreeze": freeze,
         "assetClawback": clawback,
         "type": "acfg",
-        "rekeyTo": rekeyTo
+        "reKeyTo": rekeyTo
     };
     return new txnBuilder.Transaction(o);
 }
@@ -314,7 +314,7 @@ function makeAssetConfigTxnWithSuggestedParams(from, note, assetIndex,
         "assetClawback": clawback,
         "type": "acfg",
         "note": note,
-        "rekeyTo": rekeyTo
+        "reKeyTo": rekeyTo
     };
     return new txnBuilder.Transaction(o);
 }
@@ -376,7 +376,7 @@ function makeAssetDestroyTxnWithSuggestedParams(from, note, assetIndex, suggeste
         "assetIndex": assetIndex,
         "type": "acfg",
         "note": note,
-        "rekeyTo": rekeyTo
+        "reKeyTo": rekeyTo
     };
     return new txnBuilder.Transaction(o);
 }
@@ -444,7 +444,7 @@ function makeAssetFreezeTxnWithSuggestedParams(from, note, assetIndex, freezeTar
         "freezeState" : freezeState,
         "note": note,
         "suggestedParams": suggestedParams,
-        "rekeyTo": rekeyTo
+        "reKeyTo": rekeyTo
     };
     return new txnBuilder.Transaction(o);
 }
@@ -524,7 +524,7 @@ function makeAssetTransferTxnWithSuggestedParams(from, to, closeRemainderTo, rev
         "note": note,
         "assetRevocationTarget": revocationTarget,
         "closeRemainderTo": closeRemainderTo,
-        "rekeyTo": rekeyTo
+        "reKeyTo": rekeyTo
     };
     return new txnBuilder.Transaction(o);
 }

--- a/src/makeTxn.js
+++ b/src/makeTxn.js
@@ -610,7 +610,7 @@ function makeApplicationCreateTxn(from, suggestedParams, onComplete, approvalPro
         "appForeignAssets": foreignAssets,
         "note": note,
         "lease": lease,
-        "rekeyTo": rekeyTo
+        "reKeyTo": rekeyTo
     }
     return new txnBuilder.Transaction(o);
 }
@@ -662,7 +662,7 @@ function makeApplicationUpdateTxn(from, suggestedParams, appIndex, approvalProgr
         "appForeignAssets": foreignAssets,
         "note": note,
         "lease": lease,
-        "rekeyTo": rekeyTo
+        "reKeyTo": rekeyTo
     }
     return new txnBuilder.Transaction(o);
 }
@@ -709,7 +709,7 @@ function makeApplicationDeleteTxn(from, suggestedParams, appIndex,
         "appForeignAssets": foreignAssets,
         "note": note,
         "lease": lease,
-        "rekeyTo": rekeyTo
+        "reKeyTo": rekeyTo
     }
     return new txnBuilder.Transaction(o);
 }
@@ -756,7 +756,7 @@ function makeApplicationOptInTxn(from, suggestedParams, appIndex,
         "appForeignAssets": foreignAssets,
         "note": note,
         "lease": lease,
-        "rekeyTo": rekeyTo
+        "reKeyTo": rekeyTo
     }
     return new txnBuilder.Transaction(o);
 }
@@ -803,7 +803,7 @@ function makeApplicationCloseOutTxn(from, suggestedParams, appIndex,
         "appForeignAssets": foreignAssets,
         "note": note,
         "lease": lease,
-        "rekeyTo": rekeyTo
+        "reKeyTo": rekeyTo
     }
     return new txnBuilder.Transaction(o);
 }
@@ -851,7 +851,7 @@ function makeApplicationClearStateTxn(from, suggestedParams, appIndex,
         "appForeignAssets": foreignAssets,
         "note": note,
         "lease": lease,
-        "rekeyTo": rekeyTo
+        "reKeyTo": rekeyTo
     }
     return new txnBuilder.Transaction(o);
 }
@@ -899,7 +899,7 @@ function makeApplicationNoOpTxn(from, suggestedParams, appIndex,
         "appForeignAssets": foreignAssets,
         "note": note,
         "lease": lease,
-        "rekeyTo": rekeyTo
+        "reKeyTo": rekeyTo
     }
     return new txnBuilder.Transaction(o);
 }

--- a/src/makeTxn.js
+++ b/src/makeTxn.js
@@ -610,7 +610,7 @@ function makeApplicationCreateTxn(from, suggestedParams, onComplete, approvalPro
         "appForeignAssets": foreignAssets,
         "note": note,
         "lease": lease,
-        "reKeyTo": rekeyTo
+        "rekeyTo": rekeyTo
     }
     return new txnBuilder.Transaction(o);
 }
@@ -662,7 +662,7 @@ function makeApplicationUpdateTxn(from, suggestedParams, appIndex, approvalProgr
         "appForeignAssets": foreignAssets,
         "note": note,
         "lease": lease,
-        "reKeyTo": rekeyTo
+        "rekeyTo": rekeyTo
     }
     return new txnBuilder.Transaction(o);
 }
@@ -709,7 +709,7 @@ function makeApplicationDeleteTxn(from, suggestedParams, appIndex,
         "appForeignAssets": foreignAssets,
         "note": note,
         "lease": lease,
-        "reKeyTo": rekeyTo
+        "rekeyTo": rekeyTo
     }
     return new txnBuilder.Transaction(o);
 }
@@ -756,7 +756,7 @@ function makeApplicationOptInTxn(from, suggestedParams, appIndex,
         "appForeignAssets": foreignAssets,
         "note": note,
         "lease": lease,
-        "reKeyTo": rekeyTo
+        "rekeyTo": rekeyTo
     }
     return new txnBuilder.Transaction(o);
 }
@@ -803,7 +803,7 @@ function makeApplicationCloseOutTxn(from, suggestedParams, appIndex,
         "appForeignAssets": foreignAssets,
         "note": note,
         "lease": lease,
-        "reKeyTo": rekeyTo
+        "rekeyTo": rekeyTo
     }
     return new txnBuilder.Transaction(o);
 }
@@ -851,7 +851,7 @@ function makeApplicationClearStateTxn(from, suggestedParams, appIndex,
         "appForeignAssets": foreignAssets,
         "note": note,
         "lease": lease,
-        "reKeyTo": rekeyTo
+        "rekeyTo": rekeyTo
     }
     return new txnBuilder.Transaction(o);
 }
@@ -899,7 +899,7 @@ function makeApplicationNoOpTxn(from, suggestedParams, appIndex,
         "appForeignAssets": foreignAssets,
         "note": note,
         "lease": lease,
-        "reKeyTo": rekeyTo
+        "rekeyTo": rekeyTo
     }
     return new txnBuilder.Transaction(o);
 }

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -27,7 +27,7 @@ class Transaction {
                  appGlobalInts, appGlobalByteSlices, appApprovalProgram, appClearProgram,
                  appArgs, appAccounts, appForeignApps, appForeignAssets,
                  type="pay", flatFee=false, suggestedParams=undefined,
-                 rekeyTo=undefined}) {
+                 reKeyTo=undefined}) {
         this.name = "Transaction";
         this.tag = Buffer.from("TX");
 
@@ -49,7 +49,7 @@ class Transaction {
         if (assetClawback !== undefined) assetClawback = address.decodeAddress(assetClawback);
         if (assetRevocationTarget !== undefined) assetRevocationTarget = address.decodeAddress(assetRevocationTarget);
         if (freezeAccount !== undefined) freezeAccount = address.decodeAddress(freezeAccount);
-        if (rekeyTo !== undefined) rekeyTo = address.decodeAddress(rekeyTo);
+        if (reKeyTo !== undefined) reKeyTo = address.decodeAddress(reKeyTo);
         if (genesisHash === undefined) throw Error("genesis hash must be specified and in a base64 string.");
 
         genesisHash = Buffer.from(genesisHash, 'base64');
@@ -135,7 +135,7 @@ class Transaction {
             freezeAccount, freezeState, assetRevocationTarget,
             appIndex, appOnComplete, appLocalInts, appLocalByteSlices, appGlobalInts, appGlobalByteSlices,
             appApprovalProgram, appClearProgram, appArgs, appAccounts, appForeignApps, appForeignAssets,
-            type, rekeyTo
+            type, reKeyTo
         });
 
         // Modify Fee
@@ -171,8 +171,8 @@ class Transaction {
             if ((this.closeRemainderTo !== undefined) && (address.encodeAddress(this.closeRemainderTo.publicKey) !== address.ALGORAND_ZERO_ADDRESS_STRING)) {
                 txn.close = Buffer.from(this.closeRemainderTo.publicKey);
             }
-            if ((this.rekeyTo !== undefined)) {
-                txn.rekey = Buffer.from(this.rekeyTo.publicKey)
+            if ((this.reKeyTo !== undefined)) {
+                txn.rekey = Buffer.from(this.reKeyTo.publicKey)
             }
             // allowed zero values
             if (this.to !== undefined) txn.rcv = Buffer.from(this.to.publicKey);
@@ -209,8 +209,8 @@ class Transaction {
             if (!txn.fee) delete txn.fee;
             if (!txn.gen) delete txn.gen;
             if (txn.grp === undefined) delete txn.grp;
-            if ((this.rekeyTo !== undefined)) {
-                txn.rekey = Buffer.from(this.rekeyTo.publicKey)
+            if ((this.reKeyTo !== undefined)) {
+                txn.rekey = Buffer.from(this.reKeyTo.publicKey)
             }
             return txn;
         }
@@ -249,8 +249,8 @@ class Transaction {
             if (!txn.amt) delete txn.amt;
             if (!txn.fee) delete txn.fee;
             if (!txn.gen) delete txn.gen;
-            if ((this.rekeyTo !== undefined)) {
-                txn.rekey = Buffer.from(this.rekeyTo.publicKey)
+            if ((this.reKeyTo !== undefined)) {
+                txn.rekey = Buffer.from(this.reKeyTo.publicKey)
             }
 
             if (!txn.caid) delete txn.caid;
@@ -314,8 +314,8 @@ class Transaction {
             if (!txn.aclose) delete txn.aclose;
             if (!txn.asnd) delete txn.asnd;
             if (!txn.rekey) delete txn.rekey;
-            if ((this.rekeyTo !== undefined)) {
-                txn.rekey = Buffer.from(this.rekeyTo.publicKey)
+            if ((this.reKeyTo !== undefined)) {
+                txn.rekey = Buffer.from(this.reKeyTo.publicKey)
             }
             return txn;
         }
@@ -344,8 +344,8 @@ class Transaction {
             if (!txn.gen) delete txn.gen;
             if (!txn.afrz) delete txn.afrz;
             if (txn.grp === undefined) delete txn.grp;
-            if ((this.rekeyTo !== undefined)) {
-                txn.rekey = Buffer.from(this.rekeyTo.publicKey)
+            if ((this.reKeyTo !== undefined)) {
+                txn.rekey = Buffer.from(this.reKeyTo.publicKey)
             }
             return txn;
         }
@@ -375,8 +375,8 @@ class Transaction {
                 "apfa": this.appForeignApps,
                 "apas": this.appForeignAssets,
             };
-            if ((this.rekeyTo !== undefined)) {
-                txn.rekey = Buffer.from(this.rekeyTo.publicKey)
+            if ((this.reKeyTo !== undefined)) {
+                txn.rekey = Buffer.from(this.reKeyTo.publicKey)
             }
             if (this.appApprovalProgram !== undefined) {
                 txn.apap = Buffer.from(this.appApprovalProgram);
@@ -435,7 +435,7 @@ class Transaction {
         txn.lease = new Uint8Array(txnForEnc.lx);
         txn.from = address.decodeAddress(address.encodeAddress(new Uint8Array(txnForEnc.snd)));
         if (txnForEnc.grp !== undefined) txn.group = Buffer.from(txnForEnc.grp);
-        if (txnForEnc.rekey !== undefined) txn.rekeyTo = address.decodeAddress(address.encodeAddress(new Uint8Array(txnForEnc.rekey)));
+        if (txnForEnc.rekey !== undefined) txn.reKeyTo = address.decodeAddress(address.encodeAddress(new Uint8Array(txnForEnc.rekey)));
 
         if (txnForEnc.type === "pay") {
             txn.amount = txnForEnc.amt;
@@ -597,9 +597,9 @@ class Transaction {
 
     // add the rekey-to field to a transaction not yet having it
     // supply feePerByte to increment fee accordingly
-    addRekey(rekeyTo, feePerByte=0) {
-        if (rekeyTo !== undefined) {
-            this.rekeyTo = address.decodeAddress(rekeyTo);
+    addRekey(reKeyTo, feePerByte=0) {
+        if (reKeyTo !== undefined) {
+            this.reKeyTo = address.decodeAddress(reKeyTo);
         }
         if (feePerByte !== 0) {
             this.fee += (ALGORAND_TRANSACTION_REKEY_LABEL_LENGTH + ALGORAND_TRANSACTION_ADDRESS_LENGTH) * feePerByte;
@@ -621,7 +621,7 @@ class Transaction {
         if (forPrinting.assetFreeze !== undefined) forPrinting.assetFreeze = address.encodeAddress(forPrinting.assetFreeze.publicKey);
         if (forPrinting.assetClawback !== undefined) forPrinting.assetClawback = address.encodeAddress(forPrinting.assetClawback.publicKey);
         if (forPrinting.assetRevocationTarget !== undefined) forPrinting.assetRevocationTarget = address.encodeAddress(forPrinting.assetRevocationTarget.publicKey);
-        if (forPrinting.rekeyTo !== undefined) forPrinting.rekeyTo = address.encodeAddress(forPrinting.rekeyTo.publicKey);
+        if (forPrinting.reKeyTo !== undefined) forPrinting.reKeyTo = address.encodeAddress(forPrinting.reKeyTo.publicKey);
         forPrinting.genesisHash = forPrinting.genesisHash.toString('base64');
         return forPrinting;
     }

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -27,7 +27,7 @@ class Transaction {
                  appGlobalInts, appGlobalByteSlices, appApprovalProgram, appClearProgram,
                  appArgs, appAccounts, appForeignApps, appForeignAssets,
                  type="pay", flatFee=false, suggestedParams=undefined,
-                 reKeyTo=undefined}) {
+                 rekeyTo=undefined}) {
         this.name = "Transaction";
         this.tag = Buffer.from("TX");
 
@@ -49,7 +49,7 @@ class Transaction {
         if (assetClawback !== undefined) assetClawback = address.decodeAddress(assetClawback);
         if (assetRevocationTarget !== undefined) assetRevocationTarget = address.decodeAddress(assetRevocationTarget);
         if (freezeAccount !== undefined) freezeAccount = address.decodeAddress(freezeAccount);
-        if (reKeyTo !== undefined) reKeyTo = address.decodeAddress(reKeyTo);
+        if (rekeyTo !== undefined) rekeyTo = address.decodeAddress(rekeyTo);
         if (genesisHash === undefined) throw Error("genesis hash must be specified and in a base64 string.");
 
         genesisHash = Buffer.from(genesisHash, 'base64');
@@ -135,7 +135,7 @@ class Transaction {
             freezeAccount, freezeState, assetRevocationTarget,
             appIndex, appOnComplete, appLocalInts, appLocalByteSlices, appGlobalInts, appGlobalByteSlices,
             appApprovalProgram, appClearProgram, appArgs, appAccounts, appForeignApps, appForeignAssets,
-            type, reKeyTo
+            type, rekeyTo
         });
 
         // Modify Fee
@@ -171,8 +171,8 @@ class Transaction {
             if ((this.closeRemainderTo !== undefined) && (address.encodeAddress(this.closeRemainderTo.publicKey) !== address.ALGORAND_ZERO_ADDRESS_STRING)) {
                 txn.close = Buffer.from(this.closeRemainderTo.publicKey);
             }
-            if ((this.reKeyTo !== undefined)) {
-                txn.rekey = Buffer.from(this.reKeyTo.publicKey)
+            if ((this.rekeyTo !== undefined)) {
+                txn.rekey = Buffer.from(this.rekeyTo.publicKey)
             }
             // allowed zero values
             if (this.to !== undefined) txn.rcv = Buffer.from(this.to.publicKey);
@@ -209,8 +209,8 @@ class Transaction {
             if (!txn.fee) delete txn.fee;
             if (!txn.gen) delete txn.gen;
             if (txn.grp === undefined) delete txn.grp;
-            if ((this.reKeyTo !== undefined)) {
-                txn.rekey = Buffer.from(this.reKeyTo.publicKey)
+            if ((this.rekeyTo !== undefined)) {
+                txn.rekey = Buffer.from(this.rekeyTo.publicKey)
             }
             return txn;
         }
@@ -249,8 +249,8 @@ class Transaction {
             if (!txn.amt) delete txn.amt;
             if (!txn.fee) delete txn.fee;
             if (!txn.gen) delete txn.gen;
-            if ((this.reKeyTo !== undefined)) {
-                txn.rekey = Buffer.from(this.reKeyTo.publicKey)
+            if ((this.rekeyTo !== undefined)) {
+                txn.rekey = Buffer.from(this.rekeyTo.publicKey)
             }
 
             if (!txn.caid) delete txn.caid;
@@ -314,8 +314,8 @@ class Transaction {
             if (!txn.aclose) delete txn.aclose;
             if (!txn.asnd) delete txn.asnd;
             if (!txn.rekey) delete txn.rekey;
-            if ((this.reKeyTo !== undefined)) {
-                txn.rekey = Buffer.from(this.reKeyTo.publicKey)
+            if ((this.rekeyTo !== undefined)) {
+                txn.rekey = Buffer.from(this.rekeyTo.publicKey)
             }
             return txn;
         }
@@ -344,8 +344,8 @@ class Transaction {
             if (!txn.gen) delete txn.gen;
             if (!txn.afrz) delete txn.afrz;
             if (txn.grp === undefined) delete txn.grp;
-            if ((this.reKeyTo !== undefined)) {
-                txn.rekey = Buffer.from(this.reKeyTo.publicKey)
+            if ((this.rekeyTo !== undefined)) {
+                txn.rekey = Buffer.from(this.rekeyTo.publicKey)
             }
             return txn;
         }
@@ -375,8 +375,8 @@ class Transaction {
                 "apfa": this.appForeignApps,
                 "apas": this.appForeignAssets,
             };
-            if ((this.reKeyTo !== undefined)) {
-                txn.rekey = Buffer.from(this.reKeyTo.publicKey)
+            if ((this.rekeyTo !== undefined)) {
+                txn.rekey = Buffer.from(this.rekeyTo.publicKey)
             }
             if (this.appApprovalProgram !== undefined) {
                 txn.apap = Buffer.from(this.appApprovalProgram);
@@ -435,7 +435,7 @@ class Transaction {
         txn.lease = new Uint8Array(txnForEnc.lx);
         txn.from = address.decodeAddress(address.encodeAddress(new Uint8Array(txnForEnc.snd)));
         if (txnForEnc.grp !== undefined) txn.group = Buffer.from(txnForEnc.grp);
-        if (txnForEnc.rekey !== undefined) txn.reKeyTo = address.decodeAddress(address.encodeAddress(new Uint8Array(txnForEnc.rekey)));
+        if (txnForEnc.rekey !== undefined) txn.rekeyTo = address.decodeAddress(address.encodeAddress(new Uint8Array(txnForEnc.rekey)));
 
         if (txnForEnc.type === "pay") {
             txn.amount = txnForEnc.amt;
@@ -597,9 +597,9 @@ class Transaction {
 
     // add the rekey-to field to a transaction not yet having it
     // supply feePerByte to increment fee accordingly
-    addRekey(reKeyTo, feePerByte=0) {
-        if (reKeyTo !== undefined) {
-            this.reKeyTo = address.decodeAddress(reKeyTo);
+    addRekey(rekeyTo, feePerByte=0) {
+        if (rekeyTo !== undefined) {
+            this.rekeyTo = address.decodeAddress(rekeyTo);
         }
         if (feePerByte !== 0) {
             this.fee += (ALGORAND_TRANSACTION_REKEY_LABEL_LENGTH + ALGORAND_TRANSACTION_ADDRESS_LENGTH) * feePerByte;
@@ -621,7 +621,7 @@ class Transaction {
         if (forPrinting.assetFreeze !== undefined) forPrinting.assetFreeze = address.encodeAddress(forPrinting.assetFreeze.publicKey);
         if (forPrinting.assetClawback !== undefined) forPrinting.assetClawback = address.encodeAddress(forPrinting.assetClawback.publicKey);
         if (forPrinting.assetRevocationTarget !== undefined) forPrinting.assetRevocationTarget = address.encodeAddress(forPrinting.assetRevocationTarget.publicKey);
-        if (forPrinting.reKeyTo !== undefined) forPrinting.reKeyTo = address.encodeAddress(forPrinting.reKeyTo.publicKey);
+        if (forPrinting.rekeyTo !== undefined) forPrinting.rekeyTo = address.encodeAddress(forPrinting.rekeyTo.publicKey);
         forPrinting.genesisHash = forPrinting.genesisHash.toString('base64');
         return forPrinting;
     }

--- a/tests/5.Transaction.js
+++ b/tests/5.Transaction.js
@@ -375,7 +375,7 @@ describe('Sign', function () {
                 "note": note,
                 "genesisHash": genesisHash,
                 "genesisID": genesisID,
-                "rekeyTo": rekeyTo
+                "reKeyTo": rekeyTo
             };
             let expectedTxn = new algosdk.Transaction(o);
             let actualTxn = algosdk.makePaymentTxn(from, to, fee, amount, closeRemainderTo, firstRound, lastRound, note, genesisHash, genesisID, rekeyTo);
@@ -405,7 +405,7 @@ describe('Sign', function () {
                 "note": note,
                 "genesisHash": genesisHash,
                 "genesisID": genesisID,
-                "rekeyTo": rekeyTo
+                "reKeyTo": rekeyTo
             };
             let expectedTxn = new algosdk.Transaction(o);
             let actualTxn = algosdk.makePaymentTxn(from, to, fee, amount, closeRemainderTo, firstRound, lastRound, note, genesisHash, genesisID, rekeyTo);
@@ -435,7 +435,7 @@ describe('Sign', function () {
                 "note": note,
                 "genesisHash": genesisHash,
                 "genesisID": genesisID,
-                "rekeyTo": rekeyTo
+                "reKeyTo": rekeyTo
             };
             assert.throws(() => new algosdk.Transaction(o), new Error('Amount must be a positive number and smaller than 2^64-1'));
         });
@@ -467,7 +467,7 @@ describe('Sign', function () {
                 "voteLast": voteLast,
                 "voteKeyDilution": voteKeyDilution,
                 "genesisID": genesisID,
-                "rekeyTo": rekeyTo,
+                "reKeyTo": rekeyTo,
                 "type": "keyreg"
             };
             let expectedTxn = new algosdk.Transaction(o);
@@ -514,7 +514,7 @@ describe('Sign', function () {
                 "assetFreeze": freeze,
                 "assetClawback": clawback,
                 "genesisID": genesisID,
-                "rekeyTo": rekeyTo,
+                "reKeyTo": rekeyTo,
                 "type": "acfg"
             };
             let expectedTxn = new algosdk.Transaction(o);
@@ -561,7 +561,7 @@ describe('Sign', function () {
                 "assetFreeze": freeze,
                 "assetClawback": clawback,
                 "genesisID": genesisID,
-                "rekeyTo": rekeyTo,
+                "reKeyTo": rekeyTo,
                 "type": "acfg"
             };
             let expectedTxn = new algosdk.Transaction(o);
@@ -608,7 +608,7 @@ describe('Sign', function () {
                 "assetFreeze": freeze,
                 "assetClawback": clawback,
                 "genesisID": genesisID,
-                "rekeyTo": rekeyTo,
+                "reKeyTo": rekeyTo,
                 "type": "acfg"
             };
             assert.throws(() => new algosdk.Transaction(o), new Error('Total asset issuance must be a positive number and smaller than 2^64-1'));
@@ -650,7 +650,7 @@ describe('Sign', function () {
                 "assetFreeze": freeze,
                 "assetClawback": clawback,
                 "genesisID": genesisID,
-                "rekeyTo": rekeyTo,
+                "reKeyTo": rekeyTo,
                 "type": "acfg"
             };
             assert.doesNotThrow(() => {
@@ -739,7 +739,7 @@ describe('Sign', function () {
                 "assetClawback": clawback,
                 "type": "acfg",
                 "note": note,
-                "rekeyTo": rekeyTo
+                "reKeyTo": rekeyTo
             };
             let expectedTxn = new algosdk.Transaction(o);
             let actualTxn = algosdk.makeAssetConfigTxn(addr, fee, firstRound, lastRound, note, genesisHash, genesisID,
@@ -790,7 +790,7 @@ describe('Sign', function () {
                 "assetIndex": assetIndex,
                 "type": "acfg",
                 "note": note,
-                "rekeyTo": rekeyTo
+                "reKeyTo": rekeyTo
             };
             let expectedTxn = new algosdk.Transaction(o);
             let actualTxn = algosdk.makeAssetDestroyTxn(addr, fee, firstRound, lastRound, note, genesisHash, genesisID,
@@ -828,7 +828,7 @@ describe('Sign', function () {
                 "note": note,
                 "assetRevocationTarget": revocationTarget,
                 "closeRemainderTo": closeRemainderTo,
-                "rekeyTo": rekeyTo
+                "reKeyTo": rekeyTo
             };
             let expectedTxn = new algosdk.Transaction(o);
             let actualTxn = algosdk.makeAssetTransferTxn(sender, recipient, closeRemainderTo, revocationTarget,
@@ -862,7 +862,7 @@ describe('Sign', function () {
                 "freezeState" : freezeState,
                 "note": note,
                 "genesisID": genesisID,
-                "rekeyTo": rekeyTo
+                "reKeyTo": rekeyTo
             };
             let expectedTxn = new algosdk.Transaction(o);
             let actualTxn = algosdk.makeAssetFreezeTxn(addr, fee, firstRound, lastRound, note, genesisHash, genesisID,


### PR DESCRIPTION
The current implementation of these functions initializes the object with the field rekeyTo  (lowercase letter K) causing the build of the rekey transaction to fail because the expected field name is reKeyTo (uppercase letter K).

- makePaymentTxnWithSuggestedParams
- makeKeyRegistrationTxnWithSuggestedParams
- makeAssetCreateTxnWithSuggestedParams
- makeAssetConfigTxnWithSuggestedParams
- makeAssetDestroyTxnWithSuggestedParams
- makeAssetFreezeTxnWithSuggestedParams
- makeAssetTransferTxnWithSuggestedParams

To avoid this problem in the future, reKeyTo has been changed by rekeyTo in src/makeTxn.js and src/transaction.js (As it is in the node go-algorand)