### PR TITLE
Initialize errors when they occur for improved error traces

### DIFF
--- a/src/convert.js
+++ b/src/convert.js
@@ -1,5 +1,5 @@
 const MICROALGOS_TO_ALGOS_RATIO = 1e6;
-const ERROR_INVALID_MICROALGOS = new Error("Microalgos should be positive and less than 2^53 - 1.");
+const INVALID_MICROALGOS_ERROR_MSG = "Microalgos should be positive and less than 2^53 - 1.";
 
 /**
  * microalgosToAlgos converts microalgos to algos
@@ -8,7 +8,7 @@ const ERROR_INVALID_MICROALGOS = new Error("Microalgos should be positive and le
  */
 function microalgosToAlgos(microalgos) {
     if (microalgos < 0 || !Number.isSafeInteger(microalgos)){
-        throw ERROR_INVALID_MICROALGOS;
+        throw new Error(INVALID_MICROALGOS_ERROR_MSG);
     }
     return microalgos/MICROALGOS_TO_ALGOS_RATIO
 }
@@ -26,5 +26,5 @@ function algosToMicroalgos(algos) {
 module.exports = {
     microalgosToAlgos,
     algosToMicroalgos,
-    ERROR_INVALID_MICROALGOS,
+    INVALID_MICROALGOS_ERROR_MSG,
 };

--- a/src/main.js
+++ b/src/main.js
@@ -28,7 +28,7 @@ let Indexer = indexer.IndexerClient
 const SIGN_BYTES_PREFIX = Buffer.from([77, 88]); // "MX"
 
 // Errors
-const ERROR_MULTISIG_BAD_SENDER = new Error("The transaction sender address and multisig preimage do not match.");
+const MULTISIG_BAD_SENDER_ERROR_MSG = "The transaction sender address and multisig preimage do not match.";
 
 /**
  * signTransaction takes an object with either payment or key registration fields and 
@@ -115,7 +115,7 @@ function signMultisigTransaction(txn, {version, threshold, addrs}, sk) {
     let expectedFromRaw = address.fromMultisigPreImgAddrs({version, threshold, addrs});
     if (txn.hasOwnProperty('from')) {
         if ((txn.from !== expectedFromRaw) && (address.encodeAddress(txn.from.publicKey) !== expectedFromRaw)) {
-            throw ERROR_MULTISIG_BAD_SENDER;
+            throw new Error(MULTISIG_BAD_SENDER_ERROR_MSG);
         }
     } else {
         txn.from = expectedFromRaw;
@@ -230,8 +230,10 @@ module.exports = {
     mergeMultisigTransactions,
     signMultisigTransaction,
     multisigAddress,
-    ERROR_MULTISIG_BAD_SENDER,
-    ERROR_INVALID_MICROALGOS: convert.ERROR_INVALID_MICROALGOS,
+    MULTISIG_BAD_SENDER_ERROR_MSG,
+    ERROR_MULTISIG_BAD_SENDER: new Error(MULTISIG_BAD_SENDER_ERROR_MSG),
+    INVALID_MICROALGOS_ERROR_MSG: convert.ERROR_INVALID_MICROALGOS,
+    ERROR_INVALID_MICROALGOS: new Error(convert.ERROR_INVALID_MICROALGOS),
     microalgosToAlgos: convert.microalgosToAlgos,
     algosToMicroalgos: convert.algosToMicroalgos,
     computeGroupID: group.computeGroupID,

--- a/src/mnemonic/mnemonic.js
+++ b/src/mnemonic/mnemonic.js
@@ -2,8 +2,8 @@ const english = require("./wordlists/english");
 const nacl = require("../nacl/naclWrappers");
 const address = require("../encoding/address");
 
-const ERROR_FAIL_TO_DECODE_MNEMONIC = Error('failed to decode mnemonic');
-const ERROR_NOT_IN_WORDS_LIST = Error('the mnemonic contains a word that is not in the wordlist');
+const FAIL_TO_DECODE_MNEMONIC_ERROR_MSG = 'failed to decode mnemonic';
+const NOT_IN_WORDS_LIST_ERROR_MSG = 'the mnemonic contains a word that is not in the wordlist';
 
 /**
  * mnemonicFromSeed converts a 32-byte key into a 25 word mnemonic. The generated mnemonic includes a checksum.
@@ -36,7 +36,7 @@ function seedFromMnemonic(mnemonic) {
 
     //Check that all words are in list
     for (let w of key) {
-        if (english.indexOf(w) === -1) throw ERROR_NOT_IN_WORDS_LIST;
+        if (english.indexOf(w) === -1) throw new Error(NOT_IN_WORDS_LIST_ERROR_MSG);
     }
 
     const checksum = words[words.length - 1];
@@ -52,10 +52,10 @@ function seedFromMnemonic(mnemonic) {
     // While converting back to byte array, our new 264 bits array is divisible by 8 but the last byte is just the padding.
 
     // check that we have 33 bytes long array as expected
-    if (uint8Array.length !== 33) throw ERROR_FAIL_TO_DECODE_MNEMONIC;
+    if (uint8Array.length !== 33) throw new Error(FAIL_TO_DECODE_MNEMONIC_ERROR_MSG);
 
     // check that the last byte is actually 0x0
-    if (uint8Array[uint8Array.length - 1] !== 0x0) throw ERROR_FAIL_TO_DECODE_MNEMONIC;
+    if (uint8Array[uint8Array.length - 1] !== 0x0) throw new Error(FAIL_TO_DECODE_MNEMONIC_ERROR_MSG);
 
     // chop it !
     uint8Array = uint8Array.slice(0, uint8Array.length - 1);
@@ -67,7 +67,7 @@ function seedFromMnemonic(mnemonic) {
     // success!
     if (cs === checksum) return uint8Array;
 
-    throw ERROR_FAIL_TO_DECODE_MNEMONIC;
+    throw new Error(FAIL_TO_DECODE_MNEMONIC_ERROR_MSG);
 }
 
 function computeChecksum(seed) {
@@ -180,8 +180,8 @@ function masterDerivationKeyToMnemonic(mdk) {
 module.exports = {
     mnemonicFromSeed,
     seedFromMnemonic,
-    ERROR_FAIL_TO_DECODE_MNEMONIC,
-    ERROR_NOT_IN_WORDS_LIST,
+    FAIL_TO_DECODE_MNEMONIC_ERROR_MSG,
+    NOT_IN_WORDS_LIST_ERROR_MSG,
     mnemonicToSecretKey,
     secretKeyToMnemonic,
     mnemonicToMasterDerivationKey,

--- a/tests/1.Mnemonics_test.js
+++ b/tests/1.Mnemonics_test.js
@@ -36,21 +36,21 @@ describe('#mnemonic', function () {
         mn = mn.substring(0, mn.length - 2) + lastChar;
         assert.throws(() => {
             passphrase.seedFromMnemonic(mn)
-        }, (err) => err === passphrase.ERROR_FAIL_TO_DECODE_MNEMONIC);
+        }, (err) => err.message === passphrase.FAIL_TO_DECODE_MNEMONIC_ERROR_MSG);
     });
 
     it('should fail to verify an invalid mnemonic', function () {
         let mn = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon venue abandon abandon abandon abandon abandon abandon abandon abandon abandon invest"
         assert.throws(() => {
             passphrase.seedFromMnemonic(mn);
-        }, (err) => err === passphrase.ERROR_FAIL_TO_DECODE_MNEMONIC);
+        }, (err) => err.message === passphrase.FAIL_TO_DECODE_MNEMONIC_ERROR_MSG);
 
     });
     it('should fail to verify an mnemonic with a word that is not in the list ', function () {
         let mn = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon venues abandon abandon abandon abandon abandon abandon abandon abandon abandon invest"
         assert.throws(() => {
             passphrase.seedFromMnemonic(mn);
-        }, (err) => err === passphrase.ERROR_NOT_IN_WORDS_LIST);
+        }, (err) => err.message === passphrase.NOT_IN_WORDS_LIST_ERROR_MSG);
 
     });
 });

--- a/tests/3.Address.js
+++ b/tests/3.Address.js
@@ -24,14 +24,14 @@ describe('address', function () {
         });
 
         it('should fail to verify a malformed Algorand address', function () {
-            assert.throws(() => { algosdk.decodeAddress(malformed_address1) }, (err) => err === address.MALFORMED_ADDRESS_ERROR);
-            assert.throws(() => { algosdk.decodeAddress(malformed_address2) }, (err) => err === address.MALFORMED_ADDRESS_ERROR);
+            assert.throws(() => { algosdk.decodeAddress(malformed_address1) }, (err) => err.message === address.MALFORMED_ADDRESS_ERROR_MSG);
+            assert.throws(() => { algosdk.decodeAddress(malformed_address2) }, (err) => err.message === address.MALFORMED_ADDRESS_ERROR_MSG);
             // Catch an exception possibly thrown by base32 decoding function
             assert.throws(() => { algosdk.decodeAddress(malformed_address3) }, (err) => err.message === "Invalid base32 characters");
         });
 
         it('should fail to verify a checksum for an invalid Algorand address', function () {
-            assert.throws(() => { algosdk.decodeAddress(wrong_checksum_address) }, (err) => err === address.CHECKSUM_ADDRESS_ERROR);
+            assert.throws(() => { algosdk.decodeAddress(wrong_checksum_address) }, (err) => err.message === address.CHECKSUM_ADDRESS_ERROR_MSG);
        });
 
         // Check helper functions


### PR DESCRIPTION
Fixes #286 by setting error *messages* instead of initialized Error instances. This allows for error traces to be more informative to the user. Please refer to #286 for additional details.