### PR TITLE
Support new features from indexer 2.3.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 unit:
-	node_modules/.bin/cucumber-js --tags "@unit.offline or @unit.algod or @unit.indexer or @unit.rekey or @unit.tealsign or @unit.dryrun or @unit.applications or @unit.responses or @unit.transactions" tests/cucumber/features --require tests/cucumber/steps/index.js
+	node_modules/.bin/cucumber-js --tags "@unit.offline or @unit.algod or @unit.indexer or @unit.rekey or @unit.tealsign or @unit.dryrun or @unit.applications or @unit.responses or @unit.transactions or @unit.responses.231" tests/cucumber/features --require tests/cucumber/steps/index.js
 integration:
-	node_modules/.bin/cucumber-js --tags "@algod or @assets or @auction or @kmd or @send or @template or @indexer or @rekey or @dryrun or @compile or @applications or @indexer.applications or @applications.verified" tests/cucumber/features --require tests/cucumber/steps/index.js
+	node_modules/.bin/cucumber-js --tags "@algod or @assets or @auction or @kmd or @send or @template or @indexer or @rekey or @dryrun or @compile or @applications or @indexer.applications or @applications.verified or @indexer.231" tests/cucumber/features --require tests/cucumber/steps/index.js
 
 docker-test:
 	./tests/cucumber/docker/run_docker.sh

--- a/src/client/v2/algod/algod.js
+++ b/src/client/v2/algod/algod.js
@@ -169,8 +169,8 @@ class AlgodClient {
 
   /**
    * Get the proof for a given transaction in a round.
-   * @param {number} round The round that the transaction occurred in.
-   * @param {string} txID The ID of the transaction.
+   * @param {number} round The round in which the transaction appears.
+   * @param {string} txID The transaction ID for which to generate a proof.
    */
   getProof(round, txID) {
     return new proof.Proof(this.c, this.intDecoding, round, txID);

--- a/src/client/v2/algod/algod.js
+++ b/src/client/v2/algod/algod.js
@@ -15,6 +15,8 @@ const sab = require('./statusAfterBlock');
 const sp = require('./suggestedParams');
 const supply = require('./supply');
 const versions = require('./versions');
+const genesis = require('./genesis');
+const proof = require('./proof');
 
 class AlgodClient {
   constructor(
@@ -156,6 +158,22 @@ class AlgodClient {
    */
   getApplicationByID(index) {
     return new gapbid.GetApplicationByID(this.c, this.intDecoding, index);
+  }
+
+  /**
+   * Returns the entire genesis file.
+   */
+  genesis() {
+    return new genesis.Genesis(this.c, this.intDecoding);
+  }
+
+  /**
+   * Get the proof for a given transaction in a round.
+   * @param {number} round The round that the transaction occurred in.
+   * @param {string} txID The ID of the transaction.
+   */
+  getProof(round, txID) {
+    return new proof.Proof(this.c, this.intDecoding, round, txID);
   }
 }
 

--- a/src/client/v2/algod/genesis.js
+++ b/src/client/v2/algod/genesis.js
@@ -3,7 +3,7 @@ const { JSONRequest } = require('../jsonrequest');
 class Genesis extends JSONRequest {
   // eslint-disable-next-line no-underscore-dangle,class-methods-use-this
   _path() {
-    return '/v2/genesis';
+    return '/genesis';
   }
 }
 

--- a/src/client/v2/algod/genesis.js
+++ b/src/client/v2/algod/genesis.js
@@ -1,0 +1,10 @@
+const { JSONRequest } = require('../jsonrequest');
+
+class Genesis extends JSONRequest {
+  // eslint-disable-next-line no-underscore-dangle,class-methods-use-this
+  _path() {
+    return '/v2/genesis';
+  }
+}
+
+module.exports = { Genesis };

--- a/src/client/v2/algod/proof.js
+++ b/src/client/v2/algod/proof.js
@@ -1,0 +1,16 @@
+const { JSONRequest } = require('../jsonrequest');
+
+class Proof extends JSONRequest {
+  constructor(c, intDecoding, round, txID) {
+    super(c, intDecoding);
+    this.round = round;
+    this.txID = txID;
+  }
+
+  // eslint-disable-next-line no-underscore-dangle
+  _path() {
+    return `/v2/blocks/${this.round}/transactions/${this.txID}/proof`;
+  }
+}
+
+module.exports = { Proof };

--- a/src/client/v2/indexer/indexer.js
+++ b/src/client/v2/indexer/indexer.js
@@ -7,6 +7,7 @@ const lasb = require('./lookupAssetBalances');
 const lasbid = require('./lookupAssetByID');
 const last = require('./lookupAssetTransactions');
 const lb = require('./lookupBlock');
+const ltbid = require('./lookupTransactionByID');
 const sfas = require('./searchForAssets');
 const sfapp = require('./searchForApplications');
 const sft = require('./searchForTransactions');
@@ -88,6 +89,14 @@ class IndexerClient {
    */
   lookupBlock(round) {
     return new lb.LookupBlock(this.c, this.intDecoding, round);
+  }
+
+  /**
+   * Returns information about the given transaction.
+   * @param {string} txID The ID of the transaction to look up.
+   */
+  lookupTransactionByID(txID) {
+    return new ltbid.LookupTransactionByID(this.c, this.intDecoding, txID);
   }
 
   /**

--- a/src/client/v2/indexer/lookupAccountByID.js
+++ b/src/client/v2/indexer/lookupAccountByID.js
@@ -11,8 +11,15 @@ class LookupAccountByID extends JSONRequest {
     return `/v2/accounts/${this.account}`;
   }
 
+  // specific round to search
   round(round) {
     this.query.round = round;
+    return this;
+  }
+
+  // include all items including closed accounts, deleted applications, destroyed assets, opted-out asset holdings, and closed-out application localstates
+  includeAll(value = true) {
+    this.query['include-all'] = value;
     return this;
   }
 }

--- a/src/client/v2/indexer/lookupApplications.js
+++ b/src/client/v2/indexer/lookupApplications.js
@@ -11,9 +11,9 @@ class LookupApplications extends JSONRequest {
     return `/v2/applications/${this.index}`;
   }
 
-  // specific round to search
-  round(round) {
-    this.query.round = round;
+  // include all items including closed accounts, deleted applications, destroyed assets, opted-out asset holdings, and closed-out application localstates
+  includeAll(value = true) {
+    this.query['include-all'] = value;
     return this;
   }
 }

--- a/src/client/v2/indexer/lookupAssetBalances.js
+++ b/src/client/v2/indexer/lookupAssetBalances.js
@@ -40,6 +40,12 @@ class LookupAssetBalances extends JSONRequest {
     this.query.next = nextToken;
     return this;
   }
+
+  // include all items including closed accounts, deleted applications, destroyed assets, opted-out asset holdings, and closed-out application localstates
+  includeAll(value = true) {
+    this.query['include-all'] = value;
+    return this;
+  }
 }
 
 module.exports = { LookupAssetBalances };

--- a/src/client/v2/indexer/lookupAssetByID.js
+++ b/src/client/v2/indexer/lookupAssetByID.js
@@ -10,6 +10,12 @@ class LookupAssetByID extends JSONRequest {
   _path() {
     return `/v2/assets/${this.index}`;
   }
+
+  // include all items including closed accounts, deleted applications, destroyed assets, opted-out asset holdings, and closed-out application localstates
+  includeAll(value = true) {
+    this.query['include-all'] = value;
+    return this;
+  }
 }
 
 module.exports = { LookupAssetByID };

--- a/src/client/v2/indexer/lookupTransactionByID.js
+++ b/src/client/v2/indexer/lookupTransactionByID.js
@@ -1,0 +1,15 @@
+const { JSONRequest } = require('../jsonrequest');
+
+class LookupTransactionByID extends JSONRequest {
+  constructor(c, intDecoding, txID) {
+    super(c, intDecoding);
+    this.txID = txID;
+  }
+
+  // eslint-disable-next-line no-underscore-dangle
+  _path() {
+    return `/v2/transactions/${this.txID}`;
+  }
+}
+
+module.exports = { LookupTransactionByID };

--- a/src/client/v2/indexer/searchAccounts.js
+++ b/src/client/v2/indexer/searchAccounts.js
@@ -53,6 +53,12 @@ class SearchAccounts extends JSONRequest {
     this.query['application-id'] = applicationID;
     return this;
   }
+
+  // include all items including closed accounts, deleted applications, destroyed assets, opted-out asset holdings, and closed-out application localstates
+  includeAll(value = true) {
+    this.query['include-all'] = value;
+    return this;
+  }
 }
 
 module.exports = { SearchAccounts };

--- a/src/client/v2/indexer/searchForApplications.js
+++ b/src/client/v2/indexer/searchForApplications.js
@@ -12,12 +12,6 @@ class SearchForApplications extends JSONRequest {
     return this;
   }
 
-  // specific round to search
-  round(round) {
-    this.query.round = round;
-    return this;
-  }
-
   // token for pagination
   nextToken(next) {
     this.query.next = next;
@@ -27,6 +21,12 @@ class SearchForApplications extends JSONRequest {
   // limit results for pagination
   limit(limit) {
     this.query.limit = limit;
+    return this;
+  }
+
+  // include all items including closed accounts, deleted applications, destroyed assets, opted-out asset holdings, and closed-out application localstates
+  includeAll(value = true) {
+    this.query['include-all'] = value;
     return this;
   }
 }

--- a/src/client/v2/indexer/searchForAssets.js
+++ b/src/client/v2/indexer/searchForAssets.js
@@ -41,6 +41,12 @@ class SearchForAssets extends JSONRequest {
     this.query.next = nextToken;
     return this;
   }
+
+  // include all items including closed accounts, deleted applications, destroyed assets, opted-out asset holdings, and closed-out application localstates
+  includeAll(value = true) {
+    this.query['include-all'] = value;
+    return this;
+  }
 }
 
 module.exports = { SearchForAssets };

--- a/tests/cucumber/browser/test.js
+++ b/tests/cucumber/browser/test.js
@@ -46,3 +46,11 @@ window.makeUint8Array = function makeUint8Array(arg) {
 window.makeEmptyObject = function makeEmptyObject() {
   return {};
 };
+
+window.formatIncludeAll = function formatIncludeAll(includeAll) {
+  if (!['true', 'false'].includes(includeAll)) {
+    throw new Error(`Unknown value for includeAll: ${includeAll}`);
+  }
+
+  return includeAll === 'true';
+};

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -52,6 +52,14 @@ function makeEmptyObject() {
   return {};
 }
 
+function formatIncludeAll(includeAll) {
+  if (!['true', 'false'].includes(includeAll)) {
+    throw new Error(`Unknown value for includeAll: ${includeAll}`);
+  }
+
+  return includeAll === 'true';
+}
+
 const steps = {
   given: {},
   when: {},
@@ -3232,10 +3240,6 @@ module.exports = function getSteps(options) {
       includeAll,
       nextToken
     ) {
-      if (includeAll !== 'true' && includeAll !== 'false') {
-        throw new Error(`Unknown value for includeAll: ${includeAll}`);
-      }
-
       const ic = indexerIntegrationClients[clientNum];
       integrationSearchAccountsResponse = await ic
         .searchAccounts()
@@ -3245,7 +3249,7 @@ module.exports = function getSteps(options) {
         .limit(limit)
         .authAddr(authAddr)
         .applicationID(appID)
-        .includeAll(includeAll === 'true')
+        .includeAll(formatIncludeAll(includeAll))
         .nextToken(nextToken)
         .do();
       this.responseForDirectJsonComparison = integrationSearchAccountsResponse;
@@ -3471,16 +3475,12 @@ module.exports = function getSteps(options) {
   When(
     'I use {int} to search for applications with {int}, {int}, {string} and token {string}',
     async function (clientNum, limit, appID, includeAll, token) {
-      if (includeAll !== 'true' && includeAll !== 'false') {
-        throw new Error(`Unknown value for includeAll: ${includeAll}`);
-      }
-
       const ic = indexerIntegrationClients[clientNum];
       this.responseForDirectJsonComparison = await ic
         .searchForApplications()
         .limit(limit)
         .index(appID)
-        .includeAll(includeAll === 'true')
+        .includeAll(formatIncludeAll(includeAll))
         .nextToken(token)
         .do();
     }
@@ -3499,15 +3499,11 @@ module.exports = function getSteps(options) {
   When(
     'I use {int} to lookup application with {int} and {string}',
     async function (clientNum, appID, includeAll) {
-      if (includeAll !== 'true' && includeAll !== 'false') {
-        throw new Error(`Unknown value for includeAll: ${includeAll}`);
-      }
-
       const ic = indexerIntegrationClients[clientNum];
       try {
         this.responseForDirectJsonComparison = await ic
           .lookupApplications(appID)
-          .includeAll(includeAll === 'true')
+          .includeAll(formatIncludeAll(includeAll))
           .do();
       } catch (err) {
         if (err.status !== 404) {

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -3219,6 +3219,39 @@ module.exports = function getSteps(options) {
     }
   );
 
+  When(
+    'I use {int} to search for an account with {int}, {int}, {int}, {int}, {string}, {int}, {string} and token {string}',
+    async function (
+      clientNum,
+      assetIndex,
+      limit,
+      currencyGreater,
+      currencyLesser,
+      authAddr,
+      appID,
+      includeAll,
+      nextToken
+    ) {
+      if (includeAll !== 'true' && includeAll !== 'false') {
+        throw new Error(`Unknown value for includeAll: ${includeAll}`);
+      }
+
+      const ic = indexerIntegrationClients[clientNum];
+      integrationSearchAccountsResponse = await ic
+        .searchAccounts()
+        .assetID(assetIndex)
+        .currencyGreaterThan(currencyGreater)
+        .currencyLessThan(currencyLesser)
+        .limit(limit)
+        .authAddr(authAddr)
+        .applicationID(appID)
+        .includeAll(includeAll === 'true')
+        .nextToken(nextToken)
+        .do();
+      this.responseForDirectJsonComparison = integrationSearchAccountsResponse;
+    }
+  );
+
   Then(
     'There are {int}, the first has {int}, {int}, {int}, {int}, {string}, {int}, {string}, {string}',
     (
@@ -3436,12 +3469,52 @@ module.exports = function getSteps(options) {
   );
 
   When(
+    'I use {int} to search for applications with {int}, {int}, {string} and token {string}',
+    async function (clientNum, limit, appID, includeAll, token) {
+      if (includeAll !== 'true' && includeAll !== 'false') {
+        throw new Error(`Unknown value for includeAll: ${includeAll}`);
+      }
+
+      const ic = indexerIntegrationClients[clientNum];
+      this.responseForDirectJsonComparison = await ic
+        .searchForApplications()
+        .limit(limit)
+        .index(appID)
+        .includeAll(includeAll === 'true')
+        .nextToken(token)
+        .do();
+    }
+  );
+
+  When(
     'I use {int} to lookup application with {int}',
     async function (clientNum, appID) {
       const ic = indexerIntegrationClients[clientNum];
       this.responseForDirectJsonComparison = await ic
         .lookupApplications(appID)
         .do();
+    }
+  );
+
+  When(
+    'I use {int} to lookup application with {int} and {string}',
+    async function (clientNum, appID, includeAll) {
+      if (includeAll !== 'true' && includeAll !== 'false') {
+        throw new Error(`Unknown value for includeAll: ${includeAll}`);
+      }
+
+      const ic = indexerIntegrationClients[clientNum];
+      try {
+        this.responseForDirectJsonComparison = await ic
+          .lookupApplications(appID)
+          .includeAll(includeAll === 'true')
+          .do();
+      } catch (err) {
+        if (err.status !== 404) {
+          throw err;
+        }
+        this.responseForDirectJsonComparison = err.response.body;
+      }
     }
   );
 


### PR DESCRIPTION
Add support for the new `include-all` query param on some indexer endpoints, and add support for relevant cucumber tests.

Also, I removed the `round` query param from the request builders for `/v2/applications` and `/v2/applications/<app-id>` since this param does not apply to those endpoints.

Closes #282.