### PR TITLE
Add disclaimer to `examples/README.md` about when the `ts-node` package is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For detailed information about the different API calls in `client`, visit https:
 
 Running examples requires access to a running node. Follow the instructions in Algorand's [developer resources](https://developer.algorand.org/docs/run-a-node/setup/install/) to install a node on your computer.
 
-**As portions of the codebase are written in TypeScript, examples cannot be run directly using `node`**. Please refer to the instructions described in the [examples/README.md](examples/README.md) file for more information regarding running the examples.
+**As portions of the codebase are written in TypeScript, example files cannot be run directly using `node`**. Please refer to the instructions described in the [examples/README.md](examples/README.md) file for more information regarding running the examples.
 
 ## SDK Development
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,8 @@ Portions of the codebase are written in TypeScript, so running examples requires
 $ npm run example examples/generate_sender_receiver.js
 ```
 
+> **Disclaimer:** `ts-node` is **not** required when importing this module from NPM. Code imported from the `algosdk` NPM module will be pre-compiled to plain JavaScript.
+
 ## Configuration
 
 Many of the examples in this folder require configuration information such as:


### PR DESCRIPTION
Closes #320.