### PR TITLE
Final TypeScript changes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
-  "editor.formatOnPaste": true,
-  "eslint.validate": ["typescript"]
+  "editor.formatOnPaste": true
 }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -122,7 +122,7 @@ export default class HTTPClient {
     port?: string | number,
     private defaultHeaders: Record<string, any> = {}
   ) {
-    const baseServerURL = new Url(baseServer);
+    const baseServerURL = new Url(baseServer, {});
     if (typeof port !== 'undefined') {
       baseServerURL.set('port', port.toString());
     }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -126,6 +126,11 @@ export default class HTTPClient {
     if (typeof port !== 'undefined') {
       baseServerURL.set('port', port.toString());
     }
+
+    if (baseServerURL.protocol.length === 0) {
+      throw new Error('Invalid base server URL, protocol must be defined.');
+    }
+
     this.baseURL = baseServerURL;
     this.defaultHeaders = defaultHeaders;
     this.tokenHeader = tokenHeader;

--- a/src/client/v2/algod/suggestedParams.ts
+++ b/src/client/v2/algod/suggestedParams.ts
@@ -1,15 +1,16 @@
 import JSONRequest from '../jsonrequest';
+import { SuggestedParams } from '../../../types/transactions/base';
 
 /**
  * Returns the common needed parameters for a new transaction, in a format the transaction builder expects
  */
-export default class SuggestedParams extends JSONRequest {
+export default class SuggestedParamsRequest extends JSONRequest<SuggestedParams> {
   /* eslint-disable class-methods-use-this */
   path() {
     return '/v2/transactions/params';
   }
 
-  prepare(body: Record<string, any>) {
+  prepare(body: Record<string, any>): SuggestedParams {
     return {
       flatFee: false,
       fee: body.fee,

--- a/src/client/v2/jsonrequest.ts
+++ b/src/client/v2/jsonrequest.ts
@@ -9,8 +9,8 @@ import IntDecoding from '../../types/intDecoding';
  * Body: The structure of the response's body
  */
 export default abstract class JSONRequest<
-  Data = Record<string, any> | Uint8Array,
-  Body = Data
+  Data = Record<string, any>,
+  Body = Data | Uint8Array
 > {
   c: HTTPClient;
   query: Record<string, any>;

--- a/src/group.ts
+++ b/src/group.ts
@@ -83,7 +83,7 @@ export function assignGroupID(
   from?: string
 ) {
   const gid = computeGroupID(txns);
-  const result = [];
+  const result: txnBuilder.Transaction[] = [];
   for (const txn of txns) {
     const tx = txnBuilder.instantiateTxnIfNeeded(txn);
     if (!from || address.encodeAddress(tx.from.publicKey) === from) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -240,6 +240,7 @@ export * from './types/transactions';
 export { default as Algodv2 } from './client/v2/algod/algod';
 export { default as Kmd } from './client/kmd';
 export { default as IntDecoding } from './types/intDecoding';
+export { default as Account } from './types/account';
 export { default as Indexer } from './client/v2/indexer/indexer';
 export {
   isValidAddress,

--- a/src/makeTxn.ts
+++ b/src/makeTxn.ts
@@ -336,7 +336,7 @@ export function makeKeyRegistrationTxnWithSuggestedParamsFromObject(
     >,
     'from' | 'note' | 'suggestedParams' | 'rekeyTo'
   > & {
-    nonParticipation?: true;
+    nonParticipation: true;
   }
 ): txnBuilder.Transaction;
 export function makeKeyRegistrationTxnWithSuggestedParamsFromObject(o: any) {

--- a/src/makeTxn.ts
+++ b/src/makeTxn.ts
@@ -158,6 +158,7 @@ export function makePaymentTxnWithSuggestedParamsFromObject(
  * @param nonParticipation - configure whether the address wants to stop participating. If true,
  *   voteKey, selectionKey, voteFirst, voteLast, and voteKeyDilution must be undefined.
  */
+/* eslint-disable no-unused-vars,no-redeclare */
 export function makeKeyRegistrationTxnWithSuggestedParams(
   from: KeyRegistrationTxn['from'],
   note: KeyRegistrationTxn['note'],
@@ -168,8 +169,33 @@ export function makeKeyRegistrationTxnWithSuggestedParams(
   voteKeyDilution: KeyRegistrationTxn['voteKeyDilution'],
   suggestedParams: MustHaveSuggestedParams<KeyRegistrationTxn>['suggestedParams'],
   rekeyTo?: KeyRegistrationTxn['reKeyTo'],
-  nonParticipation: KeyRegistrationTxn['nonParticipation'] = false
+  nonParticipation?: false
+): txnBuilder.Transaction;
+export function makeKeyRegistrationTxnWithSuggestedParams(
+  from: KeyRegistrationTxn['from'],
+  note: KeyRegistrationTxn['note'],
+  voteKey: undefined,
+  selectionKey: undefined,
+  voteFirst: undefined,
+  voteLast: undefined,
+  voteKeyDilution: undefined,
+  suggestedParams: MustHaveSuggestedParams<KeyRegistrationTxn>['suggestedParams'],
+  rekeyTo?: KeyRegistrationTxn['reKeyTo'],
+  nonParticipation?: true
+): txnBuilder.Transaction;
+export function makeKeyRegistrationTxnWithSuggestedParams(
+  from: any,
+  note: any,
+  voteKey: any,
+  selectionKey: any,
+  voteFirst: any,
+  voteLast: any,
+  voteKeyDilution: any,
+  suggestedParams: any,
+  rekeyTo?: any,
+  nonParticipation = false
 ) {
+  /* eslint-enable no-unused-vars,no-redeclare */
   const o: KeyRegistrationTxn = {
     from,
     note,
@@ -208,6 +234,7 @@ export function makeKeyRegistrationTxnWithSuggestedParams(
  *   voteKey, selectionKey, voteFirst, voteLast, and voteKeyDilution must be undefined.
  * @Deprecated in version 2.0 this will change to use the "WithSuggestedParams" signature.
  */
+/* eslint-disable no-unused-vars,no-redeclare */
 export function makeKeyRegistrationTxn(
   from: KeyRegistrationTxn['from'],
   fee: MustHaveSuggestedParamsInline<KeyRegistrationTxn>['fee'],
@@ -222,8 +249,41 @@ export function makeKeyRegistrationTxn(
   voteLast: KeyRegistrationTxn['voteLast'],
   voteKeyDilution: KeyRegistrationTxn['voteKeyDilution'],
   rekeyTo?: KeyRegistrationTxn['reKeyTo'],
-  nonParticipation: KeyRegistrationTxn['nonParticipation'] = false
+  nonParticipation?: false
+): txnBuilder.Transaction;
+export function makeKeyRegistrationTxn(
+  from: KeyRegistrationTxn['from'],
+  fee: MustHaveSuggestedParamsInline<KeyRegistrationTxn>['fee'],
+  firstRound: MustHaveSuggestedParamsInline<KeyRegistrationTxn>['firstRound'],
+  lastRound: MustHaveSuggestedParamsInline<KeyRegistrationTxn>['lastRound'],
+  note: KeyRegistrationTxn['note'],
+  genesisHash: MustHaveSuggestedParamsInline<KeyRegistrationTxn>['genesisHash'],
+  genesisID: MustHaveSuggestedParamsInline<KeyRegistrationTxn>['genesisID'],
+  voteKey: undefined,
+  selectionKey: undefined,
+  voteFirst: undefined,
+  voteLast: undefined,
+  voteKeyDilution: undefined,
+  rekeyTo?: KeyRegistrationTxn['reKeyTo'],
+  nonParticipation?: true
+): txnBuilder.Transaction;
+export function makeKeyRegistrationTxn(
+  from: any,
+  fee: any,
+  firstRound: any,
+  lastRound: any,
+  note: any,
+  genesisHash: any,
+  genesisID: any,
+  voteKey: any,
+  selectionKey: any,
+  voteFirst: any,
+  voteLast: any,
+  voteKeyDilution: any,
+  rekeyTo?: any,
+  nonParticipation: any = false
 ) {
+  /* eslint-enable no-unused-vars,no-redeclare */
   const suggestedParams: SuggestedParams = {
     genesisHash,
     genesisID,
@@ -246,6 +306,7 @@ export function makeKeyRegistrationTxn(
 }
 
 // helper for above makeKeyRegistrationTxnWithSuggestedParams, instead accepting an arguments object
+/* eslint-disable no-unused-vars,no-redeclare */
 export function makeKeyRegistrationTxnWithSuggestedParamsFromObject(
   o: Pick<
     RenameProperty<
@@ -262,9 +323,24 @@ export function makeKeyRegistrationTxnWithSuggestedParamsFromObject(
     | 'voteKeyDilution'
     | 'suggestedParams'
     | 'rekeyTo'
-    | 'nonParticipation'
-  >
-) {
+  > & {
+    nonParticipation?: false;
+  }
+): txnBuilder.Transaction;
+export function makeKeyRegistrationTxnWithSuggestedParamsFromObject(
+  o: Pick<
+    RenameProperty<
+      MustHaveSuggestedParams<KeyRegistrationTxn>,
+      'reKeyTo',
+      'rekeyTo'
+    >,
+    'from' | 'note' | 'suggestedParams' | 'rekeyTo'
+  > & {
+    nonParticipation?: true;
+  }
+): txnBuilder.Transaction;
+export function makeKeyRegistrationTxnWithSuggestedParamsFromObject(o: any) {
+  /* eslint-enable no-unused-vars,no-redeclare */
   return makeKeyRegistrationTxnWithSuggestedParams(
     o.from,
     o.note,

--- a/tests/9.Client.ts
+++ b/tests/9.Client.ts
@@ -53,6 +53,12 @@ describe('client', () => {
         }
       }
     });
+
+    it('should throw an error if protocol is the empty', () => {
+      const baseServer = 'localhost'; // should be http://localhost
+
+      assert.throws(() => new HTTPClient({}, baseServer));
+    });
     /* eslint-enable dot-notation */
   });
 });


### PR DESCRIPTION
* Remove deprecated ESLint setting

* Specify `SuggestedParams` type for the SuggestedParams client request

* Fix default generic types of the `JSONRequest` class

* Provide better return type for the `assignGroupID` method

* Export `Account` type

Closes #336. 