### PR TITLE
Include link to `dist` directory in the README’s installation section

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,11 @@
+# Frequently Asked Questions
+
+## Where did the `dist` folder go?
+
+Starting with version 1.9.0, a minified browser bundle can be obtained from npm CDNs such as [unpkg](https://unpkg.com/) or [jsDelivr](https://www.jsdelivr.com/). The link can be found in the [README.md](README.md).
+
+In prior versions, the browser bundles were made available in the `dist` directory. In order to access those, look in the `dist` folder on the version's GitHub tag, e.g. https://github.com/algorand/js-algorand-sdk/tree/v1.8.1/dist.
+
+## Can I host the browser bundle myself?
+
+Yes! If you would instead prefer to host the package yourself, a minified browser bundle can be found in the `dist/browser/` folder of the published npm package starting with version 1.9.0.

--- a/README.md
+++ b/README.md
@@ -14,15 +14,16 @@ $ npm install algosdk
 
 ### Browser
 
-Starting with version 1.9.0, a minified browser bundle can be obtained from npm CDNs such as [unpkg](https://unpkg.com/) or [jsDelivr](https://www.jsdelivr.com/). These bundles can be included directly in your HTML like so:
+Include a minified browser bundle directly in your HTML like so:
 
 ```html
-<script src="https://unpkg.com/algosdk@latest" /> <!-- or https://cdn.jsdelivr.net/npm/algosdk@latest -->
+<script src="https://unpkg.com/algosdk@latest" />
+<!-- or https://cdn.jsdelivr.net/npm/algosdk@latest -->
 ```
 
 > In production, it's recommended to pin a specific version instead of using `latest`.
 
-If you would instead prefer to host the package yourself, a minified browser bundle can be found in the `dist/browser/` folder of the published npm package starting with version 1.9.0. Prior versions do not include the browser bundle in the npm package. In order to access those, look in the `dist` folder on the version's GitHub tag, e.g. https://github.com/algorand/js-algorand-sdk/tree/v1.8.1/dist.
+Information about hosting the package for yourself or finding the browser bundles of previous versions is [available here](FAQ.md).
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -14,14 +14,15 @@ $ npm install algosdk
 
 ### Browser
 
-The [`dist` directory](https://github.com/algorand/js-algorand-sdk/tree/v1.8.1/dist) contains a minified version of the library - `algosdk.min.js`.
-Include this line in your HTML.
+Starting with version 1.9.0, a minified browser bundle can be obtained from npm CDNs such as [unpkg](https://unpkg.com/) or [jsDelivr](https://www.jsdelivr.com/). These bundles can be included directly in your HTML like so:
 
 ```html
-<script src="algosdk.min.js" />
+<script src="https://unpkg.com/algosdk@latest" /> <!-- or https://cdn.jsdelivr.net/npm/algosdk@latest -->
 ```
 
-> The `dist` directory has been removed from version control in releases after v1.8.1. In the future, users will be encouraged to use an npm CDN such as [unpkg](https://unpkg.com/) or [jsDelivr](https://www.jsdelivr.com/).
+> In production, it's recommended to pin a specific version instead of using `latest`.
+
+If you would instead prefer to host the package yourself, a minified browser bundle can be found in the `dist/browser/` folder of the published npm package starting with version 1.9.0. Prior versions do not include the browser bundle in the npm package. In order to access those, look in the `dist` folder on the version's GitHub tag, e.g. https://github.com/algorand/js-algorand-sdk/tree/v1.8.1/dist.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,14 @@ $ npm install algosdk
 
 ### Browser
 
-The `dist` directory contains a minified version of the library - `algosdk.min.js`.
+The [`dist` directory](https://github.com/algorand/js-algorand-sdk/tree/v1.8.1/dist) contains a minified version of the library - `algosdk.min.js`.
 Include this line in your HTML.
 
 ```html
 <script src="algosdk.min.js" />
 ```
+
+> The `dist` directory has been removed from version control in releases after v1.8.1. In the future, users will be encouraged to use an npm CDN such as [unpkg](https://unpkg.com/) or [jsDelivr](https://www.jsdelivr.com/).
 
 ## Quick Start
 
@@ -55,8 +57,6 @@ To build a new version of the library, run:
 ```bash
 npm run build
 ```
-
-> The `dist` directory has been removed from version control in releases after v1.8.1. Browser bundles for previous versions can be found by going to that version's tag and looking in the `dist` folder.
 
 ### Generating Documentation
 


### PR DESCRIPTION
* Move `dist` directory disclaimer from the build section of the README to an FAQ file.

Closes #341.