### PR TITLE
Allow byte arrays in algod compile

### DIFF
--- a/src/client/v2/algod/algod.ts
+++ b/src/client/v2/algod/algod.ts
@@ -110,7 +110,7 @@ export default class AlgodClient extends ServiceClient {
     return new Supply(this.c, this.intDecoding);
   }
 
-  compile(source: string) {
+  compile(source: string | Uint8Array) {
     return new Compile(this.c, source);
   }
 

--- a/src/client/v2/algod/compile.ts
+++ b/src/client/v2/algod/compile.ts
@@ -18,7 +18,7 @@ export function setHeaders(headers = {}) {
  * Executes compile
  */
 export default class Compile extends JSONRequest {
-  constructor(c: HTTPClient, private source: string) {
+  constructor(c: HTTPClient, private source: string | Uint8Array) {
     super(c);
     this.source = source;
   }


### PR DESCRIPTION
This small change allows `Uint8Arrays` to be passed into the algod `compile` method.