### PR TITLE
Use `UMD` library type instead of `window` so React environments can also use the browser bundle

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
     filename: 'algosdk.min.js',
     path: path.resolve(__dirname, 'dist/browser'),
     library: {
-      type: 'window',
+      type: 'umd',
       name: 'algosdk',
     },
   },


### PR DESCRIPTION
Fixes #352 