### PR TITLE
Add SRI for security and misc changes for browser

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -9,3 +9,13 @@ In prior versions, the browser bundles were made available in the `dist` directo
 ## Can I host the browser bundle myself?
 
 Yes! If you would instead prefer to host the package yourself, a minified browser bundle can be found in the `dist/browser/` folder of the published npm package starting with version 1.9.0.
+
+## How do I generate the SRI hash of `algosdk.min.js`?
+
+The SRI hash of `algosdk.min.js` is the base64 string after `sha384-` in the `integrity` attribute of the `<script>` tag used to import `algosdk.min.js`.
+See the [instructions to import algosdk in browser](./README.md#Browser).
+It can be computed as follows after [building the project](./README.md#building):
+
+```bash
+cat dist/browser/algosdk.min.js | openssl dgst -sha384 -binary | openssl base64 -A
+```

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Include a minified browser bundle directly in your HTML like so:
 
 ```html
 <script
-  src="https://unpkg.com/algosdk@1.9.1/dist/browser/algosdk.min.js"
-  integrity="sha384-86wAe++qzt+1nVVQLHtTAHl47rKvdyZCFJtuT3DHqk91EHZt+z63n4+dVnIMmjgV"
+  src="https://unpkg.com/algosdk@1.11.1/dist/browser/algosdk.min.js"
+  integrity="sha384-jEOO0cMWxmBm4WiSKj+1Pb2nEddu4UoHzyEue2iY/ssigMu58ao9cojkN+WTsNMm"
   crossorigin="anonymous"
 ></script>
 ```
@@ -30,8 +30,8 @@ or
 
 ```html
 <script
-  src="https://cdn.jsdelivr.net/npm/algosdk@1.9.1/dist/browser/algosdk.min.js"
-  integrity="sha384-86wAe++qzt+1nVVQLHtTAHl47rKvdyZCFJtuT3DHqk91EHZt+z63n4+dVnIMmjgV"
+  src="https://cdn.jsdelivr.net/npm/algosdk@1.11.1/dist/browser/algosdk.min.js"
+  integrity="sha384-jEOO0cMWxmBm4WiSKj+1Pb2nEddu4UoHzyEue2iY/ssigMu58ao9cojkN+WTsNMm"
   crossorigin="anonymous"
 ></script>
 ```

--- a/README.md
+++ b/README.md
@@ -19,13 +19,24 @@ $ npm install algosdk
 Include a minified browser bundle directly in your HTML like so:
 
 ```html
-<script src="https://unpkg.com/algosdk@latest" />
-<!-- or https://cdn.jsdelivr.net/npm/algosdk@latest -->
+<script
+  src="https://unpkg.com/algosdk@1.9.1/dist/browser/algosdk.min.js"
+  integrity="sha384-86wAe++qzt+1nVVQLHtTAHl47rKvdyZCFJtuT3DHqk91EHZt+z63n4+dVnIMmjgV"
+  crossorigin="anonymous"
+></script>
 ```
 
-> In production, it's recommended to pin a specific version instead of using `latest`.
+or
 
-Information about hosting the package for yourself or finding the browser bundles of previous versions is [available here](FAQ.md).
+```html
+<script
+  src="https://cdn.jsdelivr.net/npm/algosdk@1.9.1/dist/browser/algosdk.min.js"
+  integrity="sha384-86wAe++qzt+1nVVQLHtTAHl47rKvdyZCFJtuT3DHqk91EHZt+z63n4+dVnIMmjgV"
+  crossorigin="anonymous"
+></script>
+```
+
+Information about hosting the package for yourself, finding the browser bundles of previous versions, and computing the SRI hash is [available here](FAQ.md).
 
 ## Quick Start
 


### PR DESCRIPTION
* SRI (subresource integrity) ensures that the CDN cannot serve a
  malicious script. This is quite important for the Algorand SDK
  as the Algorand SDK can be used in quite sensitive websites.
  See https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
* Use the full URL for algosdk.min.js in the CDN so that the
  source map is properly found by the browser which facilitates
  debugging
* Close the `<script>` tag using `</script>` for better compatibility
* Specify explicitely the cross-origin to be `anonymous`