### PR TITLE
Add base64 serialization/deserialization functions

### DIFF
--- a/src/client/v2/algod/algod.ts
+++ b/src/client/v2/algod/algod.ts
@@ -20,6 +20,10 @@ import Versions from './versions';
 import Genesis from './genesis';
 import Proof from './proof';
 
+function isString(str: any): str is string {
+  return typeof str === 'string';
+}
+
 export default class AlgodClient extends ServiceClient {
   constructor(
     token: string | AlgodTokenHeader | CustomTokenHeader,
@@ -40,6 +44,28 @@ export default class AlgodClient extends ServiceClient {
 
   sendRawTransaction(stxOrStxs: Uint8Array | Uint8Array[]) {
     return new SendRawTransaction(this.c, stxOrStxs);
+  }
+
+  // sendBase64RawTransaction is similar to sendRawTransaction
+  // except that it takes as input a base64 string
+  // or an array of base64 strings instead of a byte array
+  // or an array of byte array
+  sendBase64RawTransaction(base64StxOrStxs: string | string[]) {
+    let base64Stxs;
+    if (Array.isArray(base64StxOrStxs)) {
+      if (!base64StxOrStxs.every(isString)) {
+        throw new TypeError('Array elements must be strings');
+      }
+      base64Stxs = base64StxOrStxs;
+    } else if (!isString(base64StxOrStxs)) {
+      throw new TypeError('Argument must be a string');
+    } else {
+      base64Stxs = [base64StxOrStxs];
+    }
+    const stxs = base64Stxs.map((base64Stx) =>
+      Buffer.from(base64Stx, 'base64')
+    );
+    return new SendRawTransaction(this.c, stxs);
   }
 
   /**

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -896,6 +896,11 @@ export class Transaction implements TransactionStorageStructure {
     return encoding.encode(this.get_obj_for_encoding());
   }
 
+  // returns the base64 encoding of the canonical msgpack encoding
+  toBase64() {
+    return Buffer.from(this.toByte()).toString('base64');
+  }
+
   // returns the raw signature
   rawSignTxn(sk: Uint8Array) {
     const toBeSigned = this.bytesToSign();
@@ -1043,6 +1048,18 @@ export function encodeUnsignedTransaction(transactionObject: Transaction) {
 }
 
 /**
+ * encodeBase64UnsignedTransaction takes a completed txnBuilder.Transaction object, such as from the makeFoo
+ * family of transactions, and converts it to a base64 string
+ * equal to the base64 encoding of encodeUnsignedTransaction output
+ * @param transactionObject - the completed Transaction object
+ */
+export function encodeBase64UnsignedTransaction(
+  transactionObject: Transaction
+) {
+  return transactionObject.toBase64();
+}
+
+/**
  * decodeUnsignedTransaction takes a Buffer (as if from encodeUnsignedTransaction) and converts it to a txnBuilder.Transaction object
  * @param transactionBuffer - the Uint8Array containing a transaction
  */
@@ -1053,6 +1070,15 @@ export function decodeUnsignedTransaction(
     transactionBuffer
   ) as EncodedTransaction;
   return Transaction.from_obj_for_encoding(partlyDecodedObject);
+}
+
+/**
+ * decodeBase64UnsignedTransaction takes a base64 string (as if from encodeBase64UnsignedTransaction)
+ * and converts it to a txnBuilder.Transaction object
+ * @param transactionBase64 - the base64 string containing a transaction
+ */
+export function decodeBase64UnsignedTransaction(transactionBase64: string) {
+  return decodeUnsignedTransaction(Buffer.from(transactionBase64, 'base64'));
 }
 
 /**

--- a/tests/5.Transaction.js
+++ b/tests/5.Transaction.js
@@ -514,6 +514,63 @@ describe('Sign', () => {
     });
   });
 
+  describe('should correctly serialize and deserialize from base64 msgpack representation', () => {
+    it('should correctly serialize and deserialize from base64 msgpack representation', () => {
+      const o = {
+        from: 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU',
+        to: 'UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM',
+        fee: 10,
+        amount: 847,
+        firstRound: 51,
+        lastRound: 61,
+        note: new Uint8Array([123, 12, 200]),
+        genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
+        genesisID: '',
+      };
+      const expectedTxn = new algosdk.Transaction(o);
+      const encRep = expectedTxn.get_obj_for_encoding();
+      const encBase64Txn1 = algosdk.encodeBase64UnsignedTransaction(
+        expectedTxn
+      );
+      const encBase64Txn2 = algosdk.encodeBase64UnsignedTransaction(
+        expectedTxn
+      );
+      assert.strictEqual(encBase64Txn2, encBase64Txn1);
+      const decTxn = algosdk.decodeBase64UnsignedTransaction(encBase64Txn1);
+      const reencRep = decTxn.get_obj_for_encoding();
+      assert.deepStrictEqual(reencRep, encRep);
+    });
+
+    it('should correctly serialize to base64 msgpack representation', () => {
+      const o = {
+        from: 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU',
+        to: 'UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM',
+        fee: 10,
+        amount: 847,
+        firstRound: 51,
+        lastRound: 61,
+        note: new Uint8Array([123, 12, 200]),
+        genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
+        genesisID: '',
+      };
+      const expectedTxn = new algosdk.Transaction(o);
+      const encRep = expectedTxn.get_obj_for_encoding();
+      const encTxn = algosdk.encodeObj(encRep);
+      const encBase64Txn1 = algosdk.encodeBase64UnsignedTransaction(
+        expectedTxn
+      );
+      const encBase64Txn2 = algosdk.encodeBase64UnsignedTransaction(
+        expectedTxn
+      );
+      assert.strictEqual(encBase64Txn2, encBase64Txn1);
+      assert.strictEqual(
+        Buffer.from(encBase64Txn1, 'base64').toString('hex'),
+        Buffer.from(encTxn).toString('hex')
+      );
+      assert.strictEqual(encBase64Txn1, Buffer.from(encTxn).toString('base64'));
+    });
+  });
+
   describe('transaction making functions', () => {
     it('should be able to use helper to make a payment transaction', () => {
       const from = 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU';


### PR DESCRIPTION
This commit adds:
* base64 serialization/deserialization functions for unsigned transactions
* algodclient.sendBase64RawTransaction that allows sending directly
  base64-encoded signed transactions

This is very useful for wallets such as AlgoSigner
that takes as inputs and outputs base64 encoding of
canonical msgpack encodings.

See https://github.com/PureStake/algosigner/blob/369785fa305b2f08850e64e1b56a1e8cb7254860/docs/dApp-integration.md#working-with-transactions

Currently, unsigned transactions need to be converted
in two steps:
```js
let binaryTxs = [tx1.toByte(), tx2.toByte()];
let base64Txs = binaryTxs.map((binary) => AlgoSigner.encoding.msgpackToBase64(binary));
```

This commit simplifies this into:
```
let base64Txs = [tx1.toBase64(), tx2.toBase64()];
```

Similarly, returned signed transactions need to be converted
to array of byte arrays before being sent:
```js
let binarySignedTxs = signedTxs.map((tx) => AlgoSigner.encoding.base64ToMsgpack(tx.blob));
await client.sendRawTransaction(binarySignedTxs).do();
```

This commit simplifies this into:
```
await client.sendBase64RawTransaction(signedTxs);
```

Unit testing hacwsve been added for `Transaction.base64`,
`algosdk.encodeBase64UnsignedTransaction`,
`algosdk.decodeBase64UnsignedTransaction`.

I was not sure how to run cucumber testings.
Instead I manually tested `algodclient.sendBase64RawTrabsaction` with the following code:

```js
const algosdk = require("algosdk");

(async () => {
    const passphrase = "my passphrase";

    const myAccount = algosdk.mnemonicToSecretKey(passphrase)
    console.log("My address: %s", myAccount.addr);

    const algodToken = "";
    const algodServer = "https://testnet.algoexplorerapi.io";
    const algodPort = "";

    const algodClient = new algosdk.Algodv2(algodToken, algodServer, algodPort);

    const params = await algodClient.getTransactionParams().do();
    const note = algosdk.encodeObj("hello");

    // test with single tx
    const txn = algosdk.makePaymentTxnWithSuggestedParams(myAccount.addr, myAccount.addr, 1100000, undefined, note, params);

    const stx = txn.signTxn(myAccount.sk);
    const stxBase64 = Buffer.from(stx).toString("base64");

    await algodClient.sendBase64RawTransaction(stxBase64).do();

    // test with group of two txs
    const txn1 = algosdk.makePaymentTxnWithSuggestedParams(myAccount.addr, myAccount.addr, 100000, undefined, note, params);
    const txn2 = algosdk.makePaymentTxnWithSuggestedParams(myAccount.addr, myAccount.addr, 200000, undefined, note, params);

    algosdk.assignGroupID([txn1, txn2]);

    const stx1 = txn1.signTxn(myAccount.sk);
    const stx2 = txn2.signTxn(myAccount.sk);
    const stx1Base64 = Buffer.from(stx1).toString("base64");
    const stx2Base64 = Buffer.from(stx2).toString("base64");

    await algodClient.sendBase64RawTransaction([stx1Base64, stx2Base64]).do();
})();
```