### PR TITLE
Use DryrunRequest instead of DryrunSource in constructor

### DIFF
--- a/src/client/v2/algod/dryrun.ts
+++ b/src/client/v2/algod/dryrun.ts
@@ -7,7 +7,7 @@ import { setHeaders } from './compile';
 export default class Dryrun extends JSONRequest {
   private blob: Uint8Array;
 
-  constructor(c: HTTPClient, dr: modelsv2.DryrunSource) {
+  constructor(c: HTTPClient, dr: modelsv2.DryrunRequest) {
     super(c);
     this.blob = encoding.encode(dr.get_obj_for_encoding());
   }


### PR DESCRIPTION
This change addresses Issue algorand#366, which points out that the constructor for the `Dryrun` class should be of type `DryrunRequest`, instead of `DryrunSource`.