### PR TITLE
Update examples on getting `suggestedParams`

### DIFF
--- a/examples/asset_accept_example.js
+++ b/examples/asset_accept_example.js
@@ -15,6 +15,7 @@ async function main() {
   const assetIndex = 1234; // identifying index of the asset
 
   // set suggested parameters
+  // usually these parameters are fetched using the `algosdk.getTransactionParams()` method
   const suggestedParams = {
     fee: feePerByte,
     firstRound: firstValidRound,

--- a/examples/asset_create_example.js
+++ b/examples/asset_create_example.js
@@ -33,6 +33,7 @@ async function main() {
   const defaultFrozen = false; // whether accounts should be frozen by default
 
   // create suggested parameters
+  // usually these parameters are fetched using the `algosdk.getTransactionParams()` method
   const suggestedParams = {
     flatFee: false,
     fee: feePerByte,

--- a/examples/asset_destroy_example.js
+++ b/examples/asset_destroy_example.js
@@ -16,6 +16,7 @@ async function main() {
   const assetIndex = 1234; // identifying index of the asset
 
   // set suggested parameters
+  // usually these parameters are fetched using the `algosdk.getTransactionParams()` method
   const suggestedParams = {
     fee: feePerByte,
     firstRound: firstValidRound,

--- a/examples/asset_freeze_example.js
+++ b/examples/asset_freeze_example.js
@@ -18,6 +18,7 @@ async function main() {
   const assetIndex = 1234; // identifying index of the asset
 
   // set suggested parameters
+  // usually these parameters are fetched using the `algosdk.getTransactionParams()` method
   const suggestedParams = {
     fee: feePerByte,
     firstRound: firstValidRound,

--- a/examples/asset_revoke_example.js
+++ b/examples/asset_revoke_example.js
@@ -19,6 +19,7 @@ async function main() {
   const assetIndex = 1234; // identifying index of the asset
 
   // set suggested parameters
+  // usually these parameters are fetched using the `algosdk.getTransactionParams()` method
   const suggestedParams = {
     fee: feePerByte,
     firstRound: firstValidRound,

--- a/examples/asset_send_example.js
+++ b/examples/asset_send_example.js
@@ -19,6 +19,7 @@ async function main() {
   const assetIndex = 1234; // identifying index of the asset
 
   // set suggested parameters
+  // usually these parameters are fetched using the `algosdk.getTransactionParams()` method
   const suggestedParams = {
     fee: feePerByte,
     firstRound: firstValidRound,

--- a/examples/asset_update_example.js
+++ b/examples/asset_update_example.js
@@ -20,6 +20,7 @@ async function main() {
   const assetIndex = 1234; // identifying index of the asset
 
   // set suggested parameters
+  // usually these parameters are fetched using the `algosdk.getTransactionParams()` method
   const suggestedParams = {
     fee: feePerByte,
     firstRound: firstValidRound,


### PR DESCRIPTION
Show how to let the SDK fetch suggested parameters as an alternative to setting them manually.