### PR TITLE
Use JSON for dryrun request body

### DIFF
--- a/src/client/v2/algod/dryrun.ts
+++ b/src/client/v2/algod/dryrun.ts
@@ -1,15 +1,12 @@
 import JSONRequest from '../jsonrequest';
 import HTTPClient from '../../client';
-import * as modelsv2 from './models/types';
-import * as encoding from '../../../encoding/encoding';
+import { DryrunRequest } from './models/types';
 import { setHeaders } from './compile';
 
 export default class Dryrun extends JSONRequest {
-  private blob: Uint8Array;
-
-  constructor(c: HTTPClient, dr: modelsv2.DryrunRequest) {
+  constructor(c: HTTPClient, private dr: DryrunRequest) {
     super(c);
-    this.blob = encoding.encode(dr.get_obj_for_encoding());
+    this.dr = dr;
   }
 
   // eslint-disable-next-line class-methods-use-this
@@ -23,11 +20,9 @@ export default class Dryrun extends JSONRequest {
    */
   async do(headers = {}) {
     const txHeaders = setHeaders(headers);
-    const res = await this.c.post(
-      this.path(),
-      Buffer.from(this.blob),
-      txHeaders
-    );
+    const body = JSON.stringify(this.dr.get_obj_for_encoding());
+
+    const res = await this.c.post(this.path(), body, txHeaders);
     return res.body;
   }
 }


### PR DESCRIPTION
This PR changes the serialization from msgpack to JSON for dryrun requests. The advantages of this are:
* No more `Error: The object contains empty or 0 values` messages if a DryrunRequest object contains an empty value.
* TEAL programs are properly encoded if they are passed in as base64-encoded compiled program bytes.