### PR TITLE
Fix: Cast hexadecimal literals to BigInt to be compatible with React Native applications on android

### DIFF
--- a/src/encoding/uint64.ts
+++ b/src/encoding/uint64.ts
@@ -8,7 +8,7 @@
 export function encodeUint64(num: number | bigint) {
   const isInteger = typeof num === 'bigint' || Number.isInteger(num);
 
-  if (!isInteger || num < 0 || num > 0xffffffffffffffffn) {
+  if (!isInteger || num < 0 || num > BigInt(0xffffffffffffffffn)) {
     throw new Error('Input is not a 64-bit unsigned integer');
   }
 

--- a/src/encoding/uint64.ts
+++ b/src/encoding/uint64.ts
@@ -8,7 +8,7 @@
 export function encodeUint64(num: number | bigint) {
   const isInteger = typeof num === 'bigint' || Number.isInteger(num);
 
-  if (!isInteger || num < 0 || num > BigInt(0xffffffffffffffffn)) {
+  if (!isInteger || num < 0 || num > BigInt('0xffffffffffffffff')) {
     throw new Error('Input is not a 64-bit unsigned integer');
   }
 

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -244,7 +244,8 @@ export class Transaction implements TransactionStorageStructure {
       txn.amount !== undefined &&
       (!(
         Number.isSafeInteger(txn.amount) ||
-        (typeof txn.amount === 'bigint' && txn.amount <= 0xffffffffffffffffn)
+        (typeof txn.amount === 'bigint' &&
+          txn.amount <= BigInt(0xffffffffffffffffn))
       ) ||
         txn.amount < 0)
     )
@@ -267,7 +268,7 @@ export class Transaction implements TransactionStorageStructure {
       (!(
         Number.isSafeInteger(txn.assetTotal) ||
         (typeof txn.assetTotal === 'bigint' &&
-          txn.assetTotal <= 0xffffffffffffffffn)
+          txn.assetTotal <= BigInt(0xffffffffffffffffn))
       ) ||
         txn.assetTotal < 0)
     )

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -245,7 +245,7 @@ export class Transaction implements TransactionStorageStructure {
       (!(
         Number.isSafeInteger(txn.amount) ||
         (typeof txn.amount === 'bigint' &&
-          txn.amount <= BigInt(0xffffffffffffffffn))
+          txn.amount <= BigInt('0xffffffffffffffff'))
       ) ||
         txn.amount < 0)
     )
@@ -268,7 +268,7 @@ export class Transaction implements TransactionStorageStructure {
       (!(
         Number.isSafeInteger(txn.assetTotal) ||
         (typeof txn.assetTotal === 'bigint' &&
-          txn.assetTotal <= BigInt(0xffffffffffffffffn))
+          txn.assetTotal <= BigInt('0xffffffffffffffff'))
       ) ||
         txn.assetTotal < 0)
     )


### PR DESCRIPTION
Hey guys! I'm part of Rand Labs team and we are creating an algo-wallet for React Native.
The sdk works well on iOS but on Android throws the next error:
![image](https://user-images.githubusercontent.com/6260966/123471147-bd8ace00-d5cb-11eb-97a7-2100aa0254f1.png)

Doing a debug, this is because of the way of comparing a big int directly with hexadecimal

I make a quick fix on this PR jus casting the hexadecimal to a BigInt