### PR TITLE
replacing truthy check with undefined

### DIFF
--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -594,7 +594,7 @@ export class Transaction implements TransactionStorageStructure {
         delete txn.apar;
       } else {
         if (!txn.apar.t) delete txn.apar.t;
-        if (!txn.apar.dc) delete txn.apar.dc;
+        if (txn.apar.dc === undefined) delete txn.apar.dc; // 0 is a valid value
         if (!txn.apar.un) delete txn.apar.un;
         if (!txn.apar.an) delete txn.apar.an;
         if (!txn.apar.df) delete txn.apar.df;


### PR DESCRIPTION
I'm not sure if this is something that needs to be changed here or in AlgoSigner to set the decimal to an optional value.  Setting it to 0 currently fails validation on AlgoSigner because it is deleted here.

