### PR TITLE
Add `prepare` script to support npm installing with the git URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   },
   "scripts": {
     "test": "node -r ts-node/register tests/mocha.js",
+    "prepare": "npm run build",
     "prepare-browser-tests": "npm run build && mkdir -p tests/cucumber/browser/build && cp dist/browser/algosdk.min.* tests/cucumber/browser/build/ && webpack --config tests/cucumber/browser/webpack.config.js",
     "build": "concurrently \"webpack --config webpack.config.js\" \"tsc -p tsconfig-esm.json\" \"tsc -p tsconfig-cjs.json\"",
     "docs": "typedoc src/main.ts",


### PR DESCRIPTION
This PR adds a `prepare` script to the `package.json` to support npm installing this repository with the git URL like so:

```sh
$ npm install --save https://github.com/algorand/js-algorand-sdk
```

The above command worked previously when the `dist` directory was stored in version control but, since it has been removed, the convention [starting in NPM v4](https://stackoverflow.com/questions/48287776/automatically-build-npm-module-on-install-from-github/57503862#57503862) is to add any necessary build scripts to the `prepare` script in `package.json`, so that npm knows how to build your cloned repository.