### PR TITLE
Implemented WaitForConfirmation function

### DIFF
--- a/src/client/v2/algod/waitForConfirmation.ts
+++ b/src/client/v2/algod/waitForConfirmation.ts
@@ -6,14 +6,14 @@ import HTTPClient from '../../client';
  * confirmed by the network
  */
 export default class WaitForConfirmation extends JSONRequest {
-  constructor(c: HTTPClient, private txid: string, private timeout: number) {
+  constructor(c: HTTPClient, private txid: string, private waitRounds: number) {
     super(c);
     this.txid = txid;
-    this.timeout = timeout;
+    this.waitRounds = waitRounds;
   }
 
   async do(headers = {}) {
-    // Wait until the transaction is confirmed or rejected, or until 'timeout'
+    // Wait until the transaction is confirmed or rejected, or until 'waitRounds'
     // number of rounds have passed.
     const status = await this.c.status().do(headers);
     if (typeof status === 'undefined') {
@@ -23,7 +23,7 @@ export default class WaitForConfirmation extends JSONRequest {
     let currentRound = startRound;
 
     /* eslint-disable no-await-in-loop */
-    while (currentRound < startRound + this.timeout) {
+    while (currentRound < startRound + this.waitRounds) {
       const pendingInfo = await this.c
         .pendingTransactionInformation(this.txid)
         .do(headers);
@@ -50,6 +50,8 @@ export default class WaitForConfirmation extends JSONRequest {
       currentRound += 1;
     }
     /* eslint-enable no-await-in-loop */
-    throw new Error(`Transaction not confirmed after ${this.timeout} rounds!`);
+    throw new Error(
+      `Transaction not confirmed after ${this.waitRounds} rounds!`
+    );
   }
 }

--- a/src/client/v2/algod/waitForConfirmation.ts
+++ b/src/client/v2/algod/waitForConfirmation.ts
@@ -1,0 +1,55 @@
+import JSONRequest from '../jsonrequest';
+import HTTPClient from '../../client';
+
+/**
+ * WaitForConfirmation waits for a pending transaction to be
+ * confirmed by the network
+ */
+export default class WaitForConfirmation extends JSONRequest {
+  constructor(c: HTTPClient, private txid: string, private timeout: number) {
+    super(c);
+    this.txid = txid;
+    this.timeout = timeout;
+  }
+
+  async do(headers = {}) {
+    // Wait until the transaction is confirmed or rejected, or until 'timeout'
+    // number of rounds have passed.
+    const status = await this.c.status().do(headers);
+    if (typeof status === 'undefined') {
+      throw new Error('Unable to get node status');
+    }
+    const startRound = status['last-round'] + 1;
+    let currentRound = startRound;
+
+    /* eslint-disable no-await-in-loop */
+    while (currentRound < startRound + this.timeout) {
+      const pendingInfo = await this.c
+        .pendingTransactionInformation(this.txid)
+        .do(headers);
+      if (pendingInfo !== undefined) {
+        if (
+          pendingInfo['confirmed-round'] !== null &&
+          pendingInfo['confirmed-round'] > 0
+        ) {
+          // Got the completed Transaction
+          return pendingInfo;
+        }
+
+        if (
+          pendingInfo['pool-error'] != null &&
+          pendingInfo['pool-error'].length > 0
+        ) {
+          // If there was a pool error, then the transaction has been rejected!
+          throw new Error(
+            `Transaction Rejected pool error${pendingInfo['pool-error']}`
+          );
+        }
+      }
+      await this.c.statusAfterBlock(currentRound).do(headers);
+      currentRound += 1;
+    }
+    /* eslint-enable no-await-in-loop */
+    throw new Error(`Transaction not confirmed after ${this.timeout} rounds!`);
+  }
+}


### PR DESCRIPTION
When using the JS SDK, I oftentimes find myself copying the same code to WaitForConfirmation() of a pending transaction.

The WaitForConfirmation() waits for a pending transaction to be accepted and confirmed by the network. Until then, it blocks. I have implemented this function with a timeout feature as well that will error if the timeout is achieved.

I am unsure what to do about the CHANGELOG

This code was taken from the utils.js in the `examples` directory and moved into the actual v2 code of this SDK.