### PR TITLE
- Convert functions for IPFS CID v0 to 32 byte hex string and back

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,11 @@
   "packages": {
     "": {
       "name": "algosdk",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "license": "MIT",
       "dependencies": {
         "algo-msgpack-with-bigint": "^2.1.1",
+        "bs58": "^4.0.1",
         "buffer": "^6.0.2",
         "hi-base32": "^0.5.1",
         "js-sha256": "^0.9.0",
@@ -1171,6 +1172,14 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base-x": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+      "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -1328,6 +1337,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
+      }
+    },
+    "node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+      "dependencies": {
+        "base-x": "^3.0.2"
       }
     },
     "node_modules/buffer": {
@@ -9347,6 +9364,14 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "base-x": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+      "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -9469,6 +9494,14 @@
         "electron-to-chromium": "^1.3.723",
         "escalade": "^3.1.1",
         "node-releases": "^1.1.71"
+      }
+    },
+    "bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+      "requires": {
+        "base-x": "^3.0.2"
       }
     },
     "buffer": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "json-bigint": "^1.0.0",
     "superagent": "^6.1.0",
     "tweetnacl": "^1.0.3",
-    "url-parse": "^1.5.1"
+    "url-parse": "^1.5.1",
+    "bs58": "^4.0.1"
   },
   "devDependencies": {
     "@types/json-bigint": "^1.0.0",

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -1,3 +1,5 @@
+import { encode, decode } from 'bs58';
+
 const MICROALGOS_TO_ALGOS_RATIO = 1e6;
 export const INVALID_MICROALGOS_ERROR_MSG =
   'Microalgos should be positive and less than 2^53 - 1.';
@@ -22,4 +24,30 @@ export function microalgosToAlgos(microalgos: number) {
 export function algosToMicroalgos(algos: number) {
   const microalgos = algos * MICROALGOS_TO_ALGOS_RATIO;
   return Math.round(microalgos);
+}
+
+/**
+ * Converts IPFS CID version 0 (Base58) to a 32 bytes hex string and adds initial 0x.
+ * @param cid - The 46 character long IPFS CID V0 string (starts with Qm).
+ * @returns string
+ */
+export function ipfsCidV0ToB32(cid: string) {
+  if (cid.length !== 46 || cid.indexOf('Qm') !== 0) {
+    throw new Error(
+      `The CID: ${cid} is not an IPFS CID version 0 valid address. Version 1 is 46 characters long and starts with Qm.`
+    );
+  }
+  return `0x${decode(cid).slice(2).toString('hex')}`;
+}
+
+/**
+ * Converts 32 byte hex string (initial 0x is removed) to Base58 IPFS content identifier version 0 address string (starts with Qm)
+ * @param str - The 32 byte long hex string to encode to IPFS CID V0 (without initial 0x).
+ * @returns string 
+ */
+export function b32ToIpfsCidV0(str: string) {
+  if (str.indexOf('0x') === 0) {
+    str = str.slice(2)
+  }
+  return encode(Buffer.from(`1220${str}`, 'hex'));
 }

--- a/tests/4.Utils.ts
+++ b/tests/4.Utils.ts
@@ -1,7 +1,8 @@
 import assert from 'assert';
 import * as utils from '../src/utils/utils';
+import * as convert from '../src/convert';
 
-describe('utils', () => {
+describe('utils & converts', () => {
   describe('concatArrays', () => {
     it('should concat two Uint8Arrays', () => {
       const a = new Uint8Array([1, 2, 3]);
@@ -30,6 +31,22 @@ describe('utils', () => {
       const expected = new Uint8Array([1, 2, 3, 4, 5, 6]);
       const actual = utils.concatArrays(a, b, c);
       assert.deepStrictEqual(expected, actual);
+    });
+  });
+  describe('convertCidByte32', () => {
+    it('should convert IPFS CID V0 to 32 byte hex array and back', () => {
+      const expected = 'QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR';
+      const a = convert.ipfsCidV0ToB32(expected);
+      const actual = convert.b32ToIpfsCidV0(a);
+      assert.strictEqual(expected, actual);
+    });
+  });
+  describe('convertAlgoMicroAlgo', () => {
+    it('should convert MicroAlgo and Algo and back', () => {
+      const expected = 1e9;
+      const a = convert.microalgosToAlgos(expected);
+      const actual = convert.algosToMicroalgos(a);
+      assert.strictEqual(expected, actual);
     });
   });
 });

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -518,7 +518,7 @@ module.exports = function getSteps(options) {
     assert.deepStrictEqual(
       true,
       Object.entries(transactions).length === 0 ||
-        'transactions' in transactions
+      'transactions' in transactions
     );
   });
 
@@ -527,7 +527,7 @@ module.exports = function getSteps(options) {
     assert.deepStrictEqual(
       true,
       Object.entries(transactions).length === 0 ||
-        'transactions' in transactions
+      'transactions' in transactions
     );
   });
 
@@ -538,7 +538,7 @@ module.exports = function getSteps(options) {
     assert.deepStrictEqual(
       true,
       Object.entries(transactions).length === 0 ||
-        'transactions' in transactions
+      'transactions' in transactions
     );
   });
 
@@ -547,7 +547,7 @@ module.exports = function getSteps(options) {
     assert.deepStrictEqual(
       true,
       Object.entries(transactions).length === 0 ||
-        'truncatedTxns' in transactions
+      'truncatedTxns' in transactions
     );
   });
 
@@ -689,6 +689,19 @@ module.exports = function getSteps(options) {
     'it should still be the same amount of microalgos {int}',
     function (microalgos) {
       assert.deepStrictEqual(this.microalgos, microalgos.toString());
+    }
+  );
+
+  When('I convert {string} ipfs cid v0 to 32 byte hex array and back', function (cid) {
+    this.cid = algosdk
+      .b32ToIpfsCidV0(algosdk.ipfsCidV0ToB32(cid))
+      .toString();
+  });
+
+  Then(
+    'it should still be the same cid {string}',
+    function (cid) {
+      assert.strictEqual(this.cid, cid.toString());
     }
   );
 
@@ -1150,9 +1163,9 @@ module.exports = function getSteps(options) {
       assert.strictEqual(
         true,
         this.assetTestFixture.expectedParams[key] ===
-          this.assetTestFixture.queriedParams[key] ||
-          typeof this.assetTestFixture.expectedParams[key] === 'undefined' ||
-          typeof this.assetTestFixture.queriedParams[key] === 'undefined'
+        this.assetTestFixture.queriedParams[key] ||
+        typeof this.assetTestFixture.expectedParams[key] === 'undefined' ||
+        typeof this.assetTestFixture.queriedParams[key] === 'undefined'
       );
     });
   });
@@ -1692,7 +1705,7 @@ module.exports = function getSteps(options) {
     const assetAmount =
       Math.floor(
         (microAlgoAmount * this.contractTestFixture.limitOrderN) /
-          this.contractTestFixture.limitOrderD
+        this.contractTestFixture.limitOrderD
       ) + 1;
     this.params = await this.acl.getTransactionParams();
     this.fee = this.params.fee;
@@ -4358,7 +4371,7 @@ module.exports = function getSteps(options) {
 
   Then(
     'The transient account should have the created app {string} and total schema byte-slices {int} and uints {int},' +
-      ' the application {string} state contains key {string} with value {string}',
+    ' the application {string} state contains key {string} with value {string}',
     async function (
       appCreatedBoolAsString,
       numByteSlices,


### PR DESCRIPTION
This PR adds two functions to convert.ts module to convert between IPFS CID v0 strings to 32 bytes hex strings that fits Algorand Standard Asset's `metadatahash` field. 

This very simple contribution (NO BOUNTY) tries to solve integration of IPFS content identifiers to ASA fields which is a better way in comparison to method already in practice (ASA transactions `NOTE` field to include IPFS CID).