### PR TITLE
adding link to js fiddle with example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ const client = new algosdk.Algod(token, server, port);
 });
 ```
 
+Try it yourself here:
+https://jsfiddle.net/24bhztpq/
+
 ## Documentation
 
 Documentation for this SDK is available here: https://algorand.github.io/js-algorand-sdk/. Additional resources are available on https://developer.algorand.org.


### PR DESCRIPTION
Just adding a link to the code in the example with `testnet.algoexplorer.io` API configured. 

Wont be a tiny bit offended if you decline this one