### PR TITLE
fix: add support for deserializing nonparticipating transaction

### DIFF
--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -790,9 +790,11 @@ export class Transaction implements TransactionStorageStructure {
           address.encodeAddress(txnForEnc.close)
         );
     } else if (txnForEnc.type === 'keyreg') {
-      txn.voteKey = Buffer.from(txnForEnc.votekey);
-      txn.selectionKey = Buffer.from(txnForEnc.selkey);
-      txn.voteKeyDilution = txnForEnc.votekd;
+      if (!txnForEnc.nonpart) {
+        txn.voteKey = Buffer.from(txnForEnc.votekey);
+        txn.selectionKey = Buffer.from(txnForEnc.selkey);
+        txn.voteKeyDilution = txnForEnc.votekd;
+      }
       txn.voteFirst = txnForEnc.votefst;
       txn.voteLast = txnForEnc.votelst;
       txn.nonParticipation = txnForEnc.nonpart;

--- a/tests/5.Transaction.js
+++ b/tests/5.Transaction.js
@@ -366,6 +366,27 @@ describe('Sign', () => {
       assert.deepStrictEqual(reencRep, encRep);
     });
 
+    it('should correctly serialize and deserialize a nonparticipating key registration transaction from msgpack representation', () => {
+      const o = {
+        from: 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU',
+        fee: 10,
+        firstRound: 51,
+        lastRound: 61,
+        note: new Uint8Array([123, 12, 200]),
+        genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
+        nonParticipation: true,
+        genesisID: '',
+        type: 'keyreg',
+      };
+      const expectedTxn = new algosdk.Transaction(o);
+      const encRep = expectedTxn.get_obj_for_encoding();
+      const encTxn = algosdk.encodeObj(encRep);
+      const decEncRep = algosdk.decodeObj(encTxn);
+      const decTxn = algosdk.Transaction.from_obj_for_encoding(decEncRep);
+      const reencRep = decTxn.get_obj_for_encoding();
+      assert.deepStrictEqual(reencRep, encRep);
+    });
+
     it('should correctly serialize and deserialize an asset configuration transaction from msgpack representation', () => {
       const address =
         'BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4';


### PR DESCRIPTION
`Transaction.from_obj_for_encoding` fails to process nonparticipating transactions without `voteKey`, `selectionKey` or `voteKeyDilution` fields which are not required for nonparticipating transactions.

This PR fixes the issue and voteKey`, `selectionKey` or `voteKeyDilution` are not required for nonparticipating transactions.