### PR TITLE
Enabling a custom client for Algod and Indexer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ tests/browser/bundle.*
 # Builds
 dist/
 docs/
+built/
 
 # Caches
 .eslintcache

--- a/src/client/baseHTTPClient.ts
+++ b/src/client/baseHTTPClient.ts
@@ -1,0 +1,194 @@
+import Url from 'url-parse';
+import path from 'path';
+import * as request from 'superagent';
+
+export type Query<F> = {
+  format?: F;
+  [key: string]: any;
+};
+
+export interface AlgodTokenHeader {
+  'X-Algo-API-Token': string;
+}
+
+export interface IndexerTokenHeader {
+  'X-Indexer-API-Token': string;
+}
+
+export interface KMDTokenHeader {
+  'X-KMD-API-Token': string;
+}
+
+export interface CustomTokenHeader {
+  [headerName: string]: string;
+}
+
+export type TokenHeader =
+  | AlgodTokenHeader
+  | IndexerTokenHeader
+  | KMDTokenHeader
+  | CustomTokenHeader;
+
+export interface BaseHTTPClientResponse {
+  body: Uint8Array;
+  status: number; // status must always be 200 except when the response is inside an error
+  headers: Record<string, string>;
+}
+
+/**
+ * BaseHTTPClientError is the interface that errors thrown
+ * by methods of BaseHTTPClient should be using
+ */
+export interface BaseHTTPClientError {
+  response: BaseHTTPClientResponse;
+}
+
+/**
+ * BaseHTTPClient is an interface abstracting the queries that can be
+ * made to an algod/indexer endpoint.
+ * The SDK normally uses the URLTokenBaseHTTPClient implementation.
+ * But when used via wallets, the wallet may provide a different object
+ * satisfying the HTTPClient interface. This is useful to allow
+ * wallets to provide access to paid API services without leaking
+ * the secret tokens/URLs.
+ *
+ * Note that post and delete also have an optional query parameter
+ * This is to allow future extension where post and delete may have queries
+ * Currently however HTTPClient does not make use of it
+ *
+ * Compared to HTTPClient, BaseHTTPClient does not deal with serialization/deserialization
+ * Everything is already string/Uint8Array
+ * and all the headers (including Accept/Content-Type) are assumed to be provided
+ *
+ * In case of non-200 status, all methods must throw an error of type
+ * BaseHTTPClientError
+ */
+export interface BaseHTTPClient {
+  get: (
+    relativePath: string,
+    query?: Query<string>,
+    requestHeaders?: Record<string, string>
+  ) => Promise<BaseHTTPClientResponse>;
+  post: (
+    relativePath: string,
+    data: Uint8Array,
+    query?: Query<string>,
+    requestHeaders?: Record<string, string>
+  ) => Promise<BaseHTTPClientResponse>;
+  delete: (
+    relativePath: string,
+    data: Uint8Array,
+    query?: Query<string>,
+    requestHeaders?: Record<string, string>
+  ) => Promise<BaseHTTPClientResponse>;
+}
+
+export class URLTokenBaseHTTPClient implements BaseHTTPClient {
+  private readonly baseURL: Url;
+  private readonly tokenHeader: TokenHeader;
+
+  constructor(
+    tokenHeader: TokenHeader,
+    baseServer: string,
+    port?: string | number,
+    private defaultHeaders: Record<string, any> = {}
+  ) {
+    const baseServerURL = new Url(baseServer, {});
+    if (typeof port !== 'undefined') {
+      baseServerURL.set('port', port.toString());
+    }
+
+    if (baseServerURL.protocol.length === 0) {
+      throw new Error('Invalid base server URL, protocol must be defined.');
+    }
+
+    this.baseURL = baseServerURL;
+    this.tokenHeader = tokenHeader;
+  }
+
+  /**
+   * Compute the URL for a path relative to the instance's address
+   * @param relativePath - A path string
+   * @returns A URL string
+   */
+  private addressWithPath(relativePath: string) {
+    const address = new Url(
+      path.posix.join(this.baseURL.pathname, relativePath),
+      this.baseURL
+    );
+    return address.toString();
+  }
+
+  /**
+   * Convert a superagent response to a valid BaseHTTPClientResponse
+   * Modify the superagent response
+   * @param res
+   * @private
+   */
+  private static superagentToHTTPClientResponse(
+    res: request.Response
+  ): BaseHTTPClientResponse {
+    if (res.body instanceof ArrayBuffer) {
+      // Handle the case where the body is an arraybuffer which happens in the browser
+      res.body = new Uint8Array(res.body);
+    }
+    return res;
+  }
+
+  async get(
+    relativePath: string,
+    query?: Query<string>,
+    requestHeaders: Record<string, string> = {}
+  ): Promise<BaseHTTPClientResponse> {
+    const r = request
+      .get(this.addressWithPath(relativePath))
+      .set(this.tokenHeader)
+      .set(this.defaultHeaders)
+      .set(requestHeaders)
+      .responseType('arraybuffer')
+      .query(query);
+
+    const res = await r;
+    return URLTokenBaseHTTPClient.superagentToHTTPClientResponse(res);
+  }
+
+  async post(
+    relativePath: string,
+    data: Uint8Array,
+    query?: Query<string>,
+    requestHeaders: Record<string, string> = {}
+  ): Promise<BaseHTTPClientResponse> {
+    const r = request
+      .post(this.addressWithPath(relativePath))
+      .set(this.tokenHeader)
+      .set(this.defaultHeaders)
+      .set(requestHeaders)
+      .query(query)
+      .serialize((o) => o) // disable serialization from superagent
+      .responseType('arraybuffer')
+      .send(Buffer.from(data)); // Buffer.from necessary for superagent
+
+    const res = await r;
+    return URLTokenBaseHTTPClient.superagentToHTTPClientResponse(res);
+  }
+
+  async delete(
+    relativePath: string,
+    data: Uint8Array,
+    query?: Query<string>,
+    requestHeaders: Record<string, string> = {}
+  ): Promise<BaseHTTPClientResponse> {
+    const r = request
+      .delete(this.addressWithPath(relativePath))
+      .set(this.tokenHeader)
+      .set(this.defaultHeaders)
+      .set(requestHeaders)
+      .query(query)
+      .serialize((o) => o) // disable serialization from superagent
+      .responseType('arraybuffer')
+      .send(Buffer.from(data)); // Buffer.from necessary for superagent
+
+    const res = await r;
+    return URLTokenBaseHTTPClient.superagentToHTTPClientResponse(res);
+  }
+}

--- a/src/client/baseHTTPClient.ts
+++ b/src/client/baseHTTPClient.ts
@@ -1,33 +1,7 @@
-import Url from 'url-parse';
-import path from 'path';
-import * as request from 'superagent';
-
 export type Query<F> = {
   format?: F;
   [key: string]: any;
 };
-
-export interface AlgodTokenHeader {
-  'X-Algo-API-Token': string;
-}
-
-export interface IndexerTokenHeader {
-  'X-Indexer-API-Token': string;
-}
-
-export interface KMDTokenHeader {
-  'X-KMD-API-Token': string;
-}
-
-export interface CustomTokenHeader {
-  [headerName: string]: string;
-}
-
-export type TokenHeader =
-  | AlgodTokenHeader
-  | IndexerTokenHeader
-  | KMDTokenHeader
-  | CustomTokenHeader;
 
 export interface BaseHTTPClientResponse {
   body: Uint8Array;
@@ -64,131 +38,21 @@ export interface BaseHTTPClientError {
  * BaseHTTPClientError
  */
 export interface BaseHTTPClient {
-  get: (
+  get(
     relativePath: string,
     query?: Query<string>,
     requestHeaders?: Record<string, string>
-  ) => Promise<BaseHTTPClientResponse>;
-  post: (
-    relativePath: string,
-    data: Uint8Array,
-    query?: Query<string>,
-    requestHeaders?: Record<string, string>
-  ) => Promise<BaseHTTPClientResponse>;
-  delete: (
+  ): Promise<BaseHTTPClientResponse>;
+  post(
     relativePath: string,
     data: Uint8Array,
     query?: Query<string>,
     requestHeaders?: Record<string, string>
-  ) => Promise<BaseHTTPClientResponse>;
-}
-
-export class URLTokenBaseHTTPClient implements BaseHTTPClient {
-  private readonly baseURL: Url;
-  private readonly tokenHeader: TokenHeader;
-
-  constructor(
-    tokenHeader: TokenHeader,
-    baseServer: string,
-    port?: string | number,
-    private defaultHeaders: Record<string, any> = {}
-  ) {
-    const baseServerURL = new Url(baseServer, {});
-    if (typeof port !== 'undefined') {
-      baseServerURL.set('port', port.toString());
-    }
-
-    if (baseServerURL.protocol.length === 0) {
-      throw new Error('Invalid base server URL, protocol must be defined.');
-    }
-
-    this.baseURL = baseServerURL;
-    this.tokenHeader = tokenHeader;
-  }
-
-  /**
-   * Compute the URL for a path relative to the instance's address
-   * @param relativePath - A path string
-   * @returns A URL string
-   */
-  private addressWithPath(relativePath: string) {
-    const address = new Url(
-      path.posix.join(this.baseURL.pathname, relativePath),
-      this.baseURL
-    );
-    return address.toString();
-  }
-
-  /**
-   * Convert a superagent response to a valid BaseHTTPClientResponse
-   * Modify the superagent response
-   * @param res
-   * @private
-   */
-  private static superagentToHTTPClientResponse(
-    res: request.Response
-  ): BaseHTTPClientResponse {
-    if (res.body instanceof ArrayBuffer) {
-      // Handle the case where the body is an arraybuffer which happens in the browser
-      res.body = new Uint8Array(res.body);
-    }
-    return res;
-  }
-
-  async get(
-    relativePath: string,
-    query?: Query<string>,
-    requestHeaders: Record<string, string> = {}
-  ): Promise<BaseHTTPClientResponse> {
-    const r = request
-      .get(this.addressWithPath(relativePath))
-      .set(this.tokenHeader)
-      .set(this.defaultHeaders)
-      .set(requestHeaders)
-      .responseType('arraybuffer')
-      .query(query);
-
-    const res = await r;
-    return URLTokenBaseHTTPClient.superagentToHTTPClientResponse(res);
-  }
-
-  async post(
+  ): Promise<BaseHTTPClientResponse>;
+  delete(
     relativePath: string,
     data: Uint8Array,
     query?: Query<string>,
-    requestHeaders: Record<string, string> = {}
-  ): Promise<BaseHTTPClientResponse> {
-    const r = request
-      .post(this.addressWithPath(relativePath))
-      .set(this.tokenHeader)
-      .set(this.defaultHeaders)
-      .set(requestHeaders)
-      .query(query)
-      .serialize((o) => o) // disable serialization from superagent
-      .responseType('arraybuffer')
-      .send(Buffer.from(data)); // Buffer.from necessary for superagent
-
-    const res = await r;
-    return URLTokenBaseHTTPClient.superagentToHTTPClientResponse(res);
-  }
-
-  async delete(
-    relativePath: string,
-    data: Uint8Array,
-    query?: Query<string>,
-    requestHeaders: Record<string, string> = {}
-  ): Promise<BaseHTTPClientResponse> {
-    const r = request
-      .delete(this.addressWithPath(relativePath))
-      .set(this.tokenHeader)
-      .set(this.defaultHeaders)
-      .set(requestHeaders)
-      .query(query)
-      .serialize((o) => o) // disable serialization from superagent
-      .responseType('arraybuffer')
-      .send(Buffer.from(data)); // Buffer.from necessary for superagent
-
-    const res = await r;
-    return URLTokenBaseHTTPClient.superagentToHTTPClientResponse(res);
-  }
+    requestHeaders?: Record<string, string>
+  ): Promise<BaseHTTPClientResponse>;
 }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -3,9 +3,8 @@ import {
   BaseHTTPClient,
   BaseHTTPClientResponse,
   Query,
-  TokenHeader,
-  URLTokenBaseHTTPClient,
 } from './baseHTTPClient';
+import { TokenHeader, URLTokenBaseHTTPClient } from './urlTokenBaseHTTPClient';
 
 interface ErrorWithAdditionalInfo extends Error {
   rawResponse: string | null;
@@ -76,6 +75,9 @@ function isResponseJSON(res: BaseHTTPClientResponse): boolean {
     contentType = contentType.split(';')[0];
     /* eslint-enable prefer-destructuring */
   }
+  // regex should match /json or +json
+  // but not /json-seq
+  // from https://github.com/visionmedia/superagent/blob/048cf185d954028b1dccde0717d2488b2284c297/src/client.js#L276
   return /[/+]json($|[^-\w])/i.test(contentType);
 }
 
@@ -176,10 +178,10 @@ export default class HTTPClient {
       return new Uint8Array(0); // empty Uint8Array
     }
     if (requestHeaders['content-type'] === 'application/json') {
-      return new TextEncoder().encode(JSON.stringify(data));
+      return new Uint8Array(Buffer.from(JSON.stringify(data)));
     }
     if (typeof data === 'string') {
-      return new TextEncoder().encode(data);
+      return new Uint8Array(Buffer.from(data));
     }
     if (data instanceof Uint8Array) {
       return data;

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,54 +1,27 @@
-import path from 'path';
-import * as request from 'superagent';
-import Url from 'url-parse';
 import * as utils from '../utils/utils';
-import IntDecoding from '../types/intDecoding';
+import {
+  BaseHTTPClient,
+  BaseHTTPClientResponse,
+  Query,
+  TokenHeader,
+  URLTokenBaseHTTPClient,
+} from './baseHTTPClient';
 
 interface ErrorWithAdditionalInfo extends Error {
   rawResponse: string | null;
   statusCode: number;
 }
 
-function createJSONParser(options: utils.JSONOptions) {
-  return (
-    res: request.Response,
-    // eslint-disable-next-line no-unused-vars
-    fnOrStr: string | ((err: Error, obj: any) => void)
-    // eslint-disable-next-line consistent-return
-  ) => {
-    if (typeof fnOrStr === 'string') {
-      // in browser
-      return fnOrStr && utils.parseJSON(fnOrStr, options);
-    }
-
-    // in node
-    // based off https://github.com/visionmedia/superagent/blob/1277a880c32191e300b229e352e0633e421046c8/src/node/parsers/json.js
-    res.text = '';
-    res.setEncoding('utf8');
-    res.on('data', (chunk) => {
-      res.text += chunk;
-    });
-    res.on('end', () => {
-      let body: any;
-      let err: ErrorWithAdditionalInfo | null;
-      try {
-        body = res.text && utils.parseJSON(res.text, options);
-      } catch (err_) {
-        err = err_;
-        // issue #675: return the raw response if the response parsing fails
-        err.rawResponse = res.text || null;
-        // issue #876: return the http status code if the response parsing fails
-        err.statusCode = res.status;
-      } finally {
-        fnOrStr(err, body);
-      }
-    });
-  };
+export interface HTTPClientResponse {
+  body: Uint8Array | any; // when content-type=JSON, body is a JSON object, otherwise it's a Uint8Array
+  text?: string;
+  headers: Record<string, string>;
+  status: number;
+  ok: boolean;
 }
 
 /**
  * Remove falsy values or values with a length of 0 from an object.
- * @param obj
  */
 function removeFalsyOrEmpty(obj: Record<string, any>) {
   for (const key in obj) {
@@ -60,15 +33,20 @@ function removeFalsyOrEmpty(obj: Record<string, any>) {
   return obj;
 }
 
-type Query<F> = {
-  format?: F;
-  [key: string]: any;
-};
+/**
+ * Create a new object with lower-case keys
+ * See https://codereview.stackexchange.com/a/162418
+ * Used to ensure all headers are lower-case and to work more easily with them
+ */
+function tolowerCaseKeys(o: object): object {
+  /* eslint-disable no-param-reassign,no-return-assign,no-sequences */
+  return Object.keys(o).reduce((c, k) => ((c[k.toLowerCase()] = o[k]), c), {});
+  /* eslint-enable no-param-reassign,no-return-assign,no-sequences */
+}
 
 /**
  * getAcceptFormat returns the correct Accept header depending on the
  * requested format.
- * @param query
  */
 function getAcceptFormat(
   query?: Query<'msgpack' | 'json'>
@@ -87,64 +65,170 @@ function getAcceptFormat(
   } else return 'application/json';
 }
 
-export interface AlgodTokenHeader {
-  'X-Algo-API-Token': string;
+/**
+ * Check is a response is JSON or not
+ * Inspired from superagent code
+ */
+function isResponseJSON(res: BaseHTTPClientResponse): boolean {
+  let contentType = tolowerCaseKeys(res.headers)['content-type'];
+  if (contentType) {
+    /* eslint-disable prefer-destructuring */
+    contentType = contentType.split(';')[0];
+    /* eslint-enable prefer-destructuring */
+  }
+  return /[/+]json($|[^-\w])/i.test(contentType);
 }
 
-export interface IndexerTokenHeader {
-  'X-Indexer-API-Token': string;
+/**
+ * Check is a response is text
+ * Inspired from superagent code
+ */
+function isResponseText(res: BaseHTTPClientResponse): boolean {
+  const contentType =
+    tolowerCaseKeys(res.headers)['content-type'] || 'text/plain';
+  return /^\w*text\//i.test(contentType);
 }
 
-export interface KMDTokenHeader {
-  'X-KMD-API-Token': string;
-}
-
-export interface CustomTokenHeader {
-  [headerName: string]: string;
-}
-
-export type TokenHeader =
-  | AlgodTokenHeader
-  | IndexerTokenHeader
-  | KMDTokenHeader
-  | CustomTokenHeader;
-
+/**
+ * HTTPClient is a wrapper around a BaseHTTPClient
+ * It takes care of setting the proper "Accept" header and of
+ * decoding the JSON outputs.
+ */
 export default class HTTPClient {
-  private baseURL: Url;
-  private tokenHeader: TokenHeader;
-  public intDecoding: IntDecoding = IntDecoding.DEFAULT;
+  private bc: BaseHTTPClient;
 
+  /**
+   * Construct an HTTPClient from a BaseHTTPClient
+   * @param bc - the BaseHTTPClient used
+   */
+  constructor(bc: BaseHTTPClient);
+  /**
+   * Construct an HTTPClient from a URL (baseServer+port) and a token
+   */
   constructor(
     tokenHeader: TokenHeader,
     baseServer: string,
     port?: string | number,
-    private defaultHeaders: Record<string, any> = {}
+    defaultHeaders?: Record<string, string>
+  );
+
+  constructor(
+    bcOrTokenHeader: BaseHTTPClient | TokenHeader,
+    baseServer?: string,
+    port?: string | number,
+    defaultHeaders: Record<string, string> = {}
   ) {
-    const baseServerURL = new Url(baseServer, {});
-    if (typeof port !== 'undefined') {
-      baseServerURL.set('port', port.toString());
+    if (baseServer !== undefined) {
+      this.bc = new URLTokenBaseHTTPClient(
+        bcOrTokenHeader as TokenHeader,
+        baseServer,
+        port,
+        defaultHeaders
+      );
+    } else {
+      this.bc = bcOrTokenHeader as BaseHTTPClient;
     }
-
-    if (baseServerURL.protocol.length === 0) {
-      throw new Error('Invalid base server URL, protocol must be defined.');
-    }
-
-    this.baseURL = baseServerURL;
-    this.defaultHeaders = defaultHeaders;
-    this.tokenHeader = tokenHeader;
   }
 
   /**
-   * Compute the URL for a path relative to the instance's address
-   * @param relativePath - A path string
-   * @returns A URL string
+   * Parse JSON using either the built-in JSON.parse or utils.parseJSON
+   * depending on whether jsonOptions are provided or not
+   *
+   * @param text JSON data
+   * @param status Status of the response (used in case parseJSON fails)
+   * @param jsonOptions Options object to use to decode JSON responses. See
+   *   utils.parseJSON for the options available.
+   * @private
    */
-  private addressWithPath(relativePath: string) {
-    const address = new Url(
-      path.posix.join(this.baseURL.pathname, relativePath),
-      this.baseURL
+  private static parseJSON(
+    text: string,
+    status: number,
+    jsonOptions: utils.JSONOptions = {}
+  ) {
+    try {
+      if (Object.keys(jsonOptions).length !== 0) {
+        return text && JSON.parse(text);
+      }
+      return text && utils.parseJSON(text, jsonOptions);
+    } catch (err_) {
+      const err: ErrorWithAdditionalInfo = err_;
+      // return the raw response if the response parsing fails
+      err.rawResponse = text || null;
+      // return the http status code if the response parsing fails
+      err.statusCode = status;
+      throw err;
+    }
+  }
+
+  /**
+   * Serialize the data according to the requestHeaders
+   * Assumes that requestHeaders contain a key "content-type"
+   * If the content-type is "application/json", data is JSON serialized
+   * Otherwise, data needs to be either an UTF-8 string that is converted to an Uint8Array
+   * or an Uint8Array
+   * @private
+   */
+  private static serializeData(
+    data: object,
+    requestHeaders: Record<string, string>
+  ): Uint8Array {
+    if (!data) {
+      return new Uint8Array(0); // empty Uint8Array
+    }
+    if (requestHeaders['content-type'] === 'application/json') {
+      return new TextEncoder().encode(JSON.stringify(data));
+    }
+    if (typeof data === 'string') {
+      return new TextEncoder().encode(data);
+    }
+    if (data instanceof Uint8Array) {
+      return data;
+    }
+    throw new Error(
+      'provided data is neither a string nor a Uint8Array and content-type is not application/json'
     );
-    return address.toString();
+  }
+
+  /**
+   * Convert a BaseHTTPClientResponse into a full HTTPClientResponse
+   * Parse the body in
+   * Modifies in place res and return the result
+   */
+  private static prepareResponse(
+    res: BaseHTTPClientResponse,
+    jsonOptions: utils.JSONOptions = {}
+  ): HTTPClientResponse {
+    let { body } = res;
+    let text;
+    if (isResponseJSON(res)) {
+      text = (body && new TextDecoder().decode(body)) || '';
+      body = HTTPClient.parseJSON(text, res.status, jsonOptions);
+    } else if (isResponseText(res)) {
+      text = (body && new TextDecoder().decode(body)) || '';
+    }
+
+    return {
+      ...res,
+      body,
+      text,
+      ok: Math.trunc(res.status / 100) === 2,
+    };
+  }
+
+  /**
+   * Prepare an error with a response
+   * (the type of errors BaseHTTPClient are supposed to throw)
+   * by adding the status and preparing the internal response
+   * @private
+   */
+  private static prepareResponseError(err) {
+    if (err.response) {
+      // eslint-disable-next-line no-param-reassign
+      err.response = HTTPClient.prepareResponse(err.response);
+      // eslint-disable-next-line no-param-reassign
+      err.status = err.response.status;
+    }
+    return err;
   }
 
   /**
@@ -159,66 +243,76 @@ export default class HTTPClient {
   async get(
     relativePath: string,
     query?: Query<any>,
-    requestHeaders: Record<string, any> = {},
+    requestHeaders: Record<string, string> = {},
     jsonOptions: utils.JSONOptions = {}
-  ) {
+  ): Promise<HTTPClientResponse> {
     const format = getAcceptFormat(query);
-    let r = request
-      .get(this.addressWithPath(relativePath))
-      .set(this.tokenHeader)
-      .set(this.defaultHeaders)
-      .set(requestHeaders)
-      .set('Accept', format)
-      .query(removeFalsyOrEmpty(query));
+    const fullHeaders = { ...requestHeaders, accept: format };
 
-    if (format === 'application/msgpack') {
-      r = r.responseType('arraybuffer');
-    } else if (
-      format === 'application/json' &&
-      Object.keys(jsonOptions).length !== 0
-    ) {
-      if (utils.isNode()) {
-        // in node, need to set buffer
-        r = r.buffer(true);
-      }
-      r = r.parse(createJSONParser(jsonOptions));
-    }
+    try {
+      const res = await this.bc.get(
+        relativePath,
+        removeFalsyOrEmpty(query),
+        fullHeaders
+      );
 
-    const res = await r;
-    if (Buffer.isBuffer(res.body)) {
-      // In node res.body will be a Buffer, but in the browser it will be an ArrayBuffer
-      // (thanks superagent...), so convert it to an ArrayBuffer for consistency.
-      const underlyingArrayBuffer = res.body.buffer;
-      const start = res.body.byteOffset;
-      const end = start + res.body.byteLength;
-      res.body = underlyingArrayBuffer.slice(start, end);
+      return HTTPClient.prepareResponse(res, jsonOptions);
+    } catch (err) {
+      throw HTTPClient.prepareResponseError(err);
     }
-    return res;
   }
 
+  /**
+   * Send a POST request.
+   * If no content-type present, adds the header "content-type: application/json"
+   * and data is serialized in JSON (if not empty)
+   */
   async post(
     relativePath: string,
-    data: string | object,
-    requestHeaders: Record<string, any> = {}
-  ) {
-    return request
-      .post(this.addressWithPath(relativePath))
-      .set(this.tokenHeader)
-      .set(this.defaultHeaders)
-      .set(requestHeaders)
-      .send(data);
+    data: any,
+    requestHeaders: Record<string, string> = {}
+  ): Promise<HTTPClientResponse> {
+    const fullHeaders = {
+      'content-type': 'application/json',
+      ...tolowerCaseKeys(requestHeaders),
+    };
+
+    try {
+      const res = await this.bc.post(
+        relativePath,
+        HTTPClient.serializeData(data, fullHeaders),
+        undefined,
+        fullHeaders
+      );
+
+      return HTTPClient.prepareResponse(res);
+    } catch (err) {
+      throw HTTPClient.prepareResponseError(err);
+    }
   }
 
+  /**
+   * Send a DELETE request.
+   * If no content-type present, adds the header "content-type: application/json"
+   * and data is serialized in JSON (if not empty)
+   */
   async delete(
     relativePath: string,
-    data: string | object,
-    requestHeaders: Record<string, any> = {}
+    data: any,
+    requestHeaders: Record<string, string> = {}
   ) {
-    return request
-      .delete(this.addressWithPath(relativePath))
-      .set(this.tokenHeader)
-      .set(this.defaultHeaders)
-      .set(requestHeaders)
-      .send(data);
+    const fullHeaders = {
+      'content-type': 'application/json',
+      ...tolowerCaseKeys(requestHeaders),
+    };
+
+    const res = await this.bc.delete(
+      relativePath,
+      HTTPClient.serializeData(data, fullHeaders),
+      undefined,
+      fullHeaders
+    );
+
+    return HTTPClient.prepareResponse(res);
   }
 }

--- a/src/client/kmd.ts
+++ b/src/client/kmd.ts
@@ -1,6 +1,6 @@
 import ServiceClient from './v2/serviceClient';
 import * as txn from '../transaction';
-import { CustomTokenHeader, KMDTokenHeader } from './client';
+import { CustomTokenHeader, KMDTokenHeader } from './baseHTTPClient';
 
 export default class Kmd extends ServiceClient {
   constructor(

--- a/src/client/kmd.ts
+++ b/src/client/kmd.ts
@@ -1,6 +1,6 @@
 import ServiceClient from './v2/serviceClient';
 import * as txn from '../transaction';
-import { CustomTokenHeader, KMDTokenHeader } from './baseHTTPClient';
+import { CustomTokenHeader, KMDTokenHeader } from './urlTokenBaseHTTPClient';
 
 export default class Kmd extends ServiceClient {
   constructor(

--- a/src/client/urlTokenBaseHTTPClient.ts
+++ b/src/client/urlTokenBaseHTTPClient.ts
@@ -1,0 +1,144 @@
+import Url from 'url-parse';
+import path from 'path';
+import * as request from 'superagent';
+import {
+  BaseHTTPClient,
+  BaseHTTPClientResponse,
+  Query,
+} from './baseHTTPClient';
+
+export interface AlgodTokenHeader {
+  'X-Algo-API-Token': string;
+}
+
+export interface IndexerTokenHeader {
+  'X-Indexer-API-Token': string;
+}
+
+export interface KMDTokenHeader {
+  'X-KMD-API-Token': string;
+}
+
+export interface CustomTokenHeader {
+  [headerName: string]: string;
+}
+
+export type TokenHeader =
+  | AlgodTokenHeader
+  | IndexerTokenHeader
+  | KMDTokenHeader
+  | CustomTokenHeader;
+
+/**
+ * Implementation of BaseHTTPClient that uses a URL and a token
+ * and make the REST queries using superagent.
+ * This is the default implementation of BaseHTTPClient.
+ */
+export class URLTokenBaseHTTPClient implements BaseHTTPClient {
+  private readonly baseURL: Url;
+  private readonly tokenHeader: TokenHeader;
+
+  constructor(
+    tokenHeader: TokenHeader,
+    baseServer: string,
+    port?: string | number,
+    private defaultHeaders: Record<string, any> = {}
+  ) {
+    const baseServerURL = new Url(baseServer, {});
+    if (typeof port !== 'undefined') {
+      baseServerURL.set('port', port.toString());
+    }
+
+    if (baseServerURL.protocol.length === 0) {
+      throw new Error('Invalid base server URL, protocol must be defined.');
+    }
+
+    this.baseURL = baseServerURL;
+    this.tokenHeader = tokenHeader;
+  }
+
+  /**
+   * Compute the URL for a path relative to the instance's address
+   * @param relativePath - A path string
+   * @returns A URL string
+   */
+  private addressWithPath(relativePath: string) {
+    const address = new Url(
+      path.posix.join(this.baseURL.pathname, relativePath),
+      this.baseURL
+    );
+    return address.toString();
+  }
+
+  /**
+   * Convert a superagent response to a valid BaseHTTPClientResponse
+   * Modify the superagent response
+   * @private
+   */
+  private static superagentToHTTPClientResponse(
+    res: request.Response
+  ): BaseHTTPClientResponse {
+    if (res.body instanceof ArrayBuffer) {
+      // Handle the case where the body is an arraybuffer which happens in the browser
+      res.body = new Uint8Array(res.body);
+    }
+    return res;
+  }
+
+  async get(
+    relativePath: string,
+    query?: Query<string>,
+    requestHeaders: Record<string, string> = {}
+  ): Promise<BaseHTTPClientResponse> {
+    const r = request
+      .get(this.addressWithPath(relativePath))
+      .set(this.tokenHeader)
+      .set(this.defaultHeaders)
+      .set(requestHeaders)
+      .responseType('arraybuffer')
+      .query(query);
+
+    const res = await r;
+    return URLTokenBaseHTTPClient.superagentToHTTPClientResponse(res);
+  }
+
+  async post(
+    relativePath: string,
+    data: Uint8Array,
+    query?: Query<string>,
+    requestHeaders: Record<string, string> = {}
+  ): Promise<BaseHTTPClientResponse> {
+    const r = request
+      .post(this.addressWithPath(relativePath))
+      .set(this.tokenHeader)
+      .set(this.defaultHeaders)
+      .set(requestHeaders)
+      .query(query)
+      .serialize((o) => o) // disable serialization from superagent
+      .responseType('arraybuffer')
+      .send(Buffer.from(data)); // Buffer.from necessary for superagent
+
+    const res = await r;
+    return URLTokenBaseHTTPClient.superagentToHTTPClientResponse(res);
+  }
+
+  async delete(
+    relativePath: string,
+    data: Uint8Array,
+    query?: Query<string>,
+    requestHeaders: Record<string, string> = {}
+  ): Promise<BaseHTTPClientResponse> {
+    const r = request
+      .delete(this.addressWithPath(relativePath))
+      .set(this.tokenHeader)
+      .set(this.defaultHeaders)
+      .set(requestHeaders)
+      .query(query)
+      .serialize((o) => o) // disable serialization from superagent
+      .responseType('arraybuffer')
+      .send(Buffer.from(data)); // Buffer.from necessary for superagent
+
+    const res = await r;
+    return URLTokenBaseHTTPClient.superagentToHTTPClientResponse(res);
+  }
+}

--- a/src/client/v2/algod/algod.ts
+++ b/src/client/v2/algod/algod.ts
@@ -18,11 +18,11 @@ import Supply from './supply';
 import Versions from './versions';
 import Genesis from './genesis';
 import Proof from './proof';
+import { BaseHTTPClient } from '../../baseHTTPClient';
 import {
   AlgodTokenHeader,
-  BaseHTTPClient,
   CustomTokenHeader,
-} from '../../baseHTTPClient';
+} from '../../urlTokenBaseHTTPClient';
 
 export default class AlgodClient extends ServiceClient {
   /**
@@ -38,7 +38,7 @@ export default class AlgodClient extends ServiceClient {
       | BaseHTTPClient,
     baseServer = 'http://r2.algorand.network',
     port: string | number = 4180,
-    headers: Record<string, string>
+    headers: Record<string, string> = {}
   ) {
     super('X-Algo-API-Token', tokenOrBaseClient, baseServer, port, headers);
   }

--- a/src/client/v2/algod/algod.ts
+++ b/src/client/v2/algod/algod.ts
@@ -1,5 +1,4 @@
 import ServiceClient from '../serviceClient';
-import { AlgodTokenHeader, CustomTokenHeader } from '../../client';
 import * as modelsv2 from './models/types';
 import AccountInformation from './accountInformation';
 import Block from './block';
@@ -19,15 +18,29 @@ import Supply from './supply';
 import Versions from './versions';
 import Genesis from './genesis';
 import Proof from './proof';
+import {
+  AlgodTokenHeader,
+  BaseHTTPClient,
+  CustomTokenHeader,
+} from '../../baseHTTPClient';
 
 export default class AlgodClient extends ServiceClient {
+  /**
+   * Create an AlgodClient from
+   * * either a token, baseServer, port, and optional headers
+   * * or a base client server for interoperability with external dApp wallets
+   */
   constructor(
-    token: string | AlgodTokenHeader | CustomTokenHeader,
+    tokenOrBaseClient:
+      | string
+      | AlgodTokenHeader
+      | CustomTokenHeader
+      | BaseHTTPClient,
     baseServer = 'http://r2.algorand.network',
     port: string | number = 4180,
-    headers = {}
+    headers: Record<string, string>
   ) {
-    super('X-Algo-API-Token', token, baseServer, port, headers);
+    super('X-Algo-API-Token', tokenOrBaseClient, baseServer, port, headers);
   }
 
   healthCheck() {

--- a/src/client/v2/indexer/indexer.ts
+++ b/src/client/v2/indexer/indexer.ts
@@ -1,5 +1,4 @@
 import ServiceClient from '../serviceClient';
-import { CustomTokenHeader, IndexerTokenHeader } from '../../client';
 import MakeHealthCheck from './makeHealthCheck';
 import LookupAssetBalances from './lookupAssetBalances';
 import LookupAssetTransactions from './lookupAssetTransactions';
@@ -14,15 +13,29 @@ import SearchAccounts from './searchAccounts';
 import SearchForTransactions from './searchForTransactions';
 import SearchForAssets from './searchForAssets';
 import SearchForApplications from './searchForApplications';
+import {
+  BaseHTTPClient,
+  CustomTokenHeader,
+  IndexerTokenHeader,
+} from '../../baseHTTPClient';
 
 export default class IndexerClient extends ServiceClient {
+  /**
+   * Create an IndexerClient from
+   * * either a token, baseServer, port, and optional headers
+   * * or a base client server for interoperability with external dApp wallets
+   */
   constructor(
-    token: string | IndexerTokenHeader | CustomTokenHeader,
+    tokenOrBaseClient:
+      | string
+      | IndexerTokenHeader
+      | CustomTokenHeader
+      | BaseHTTPClient,
     baseServer = 'http://127.0.0.1',
     port: string | number = 8080,
     headers = {}
   ) {
-    super('X-Indexer-API-Token', token, baseServer, port, headers);
+    super('X-Indexer-API-Token', tokenOrBaseClient, baseServer, port, headers);
   }
 
   /**

--- a/src/client/v2/indexer/indexer.ts
+++ b/src/client/v2/indexer/indexer.ts
@@ -13,11 +13,11 @@ import SearchAccounts from './searchAccounts';
 import SearchForTransactions from './searchForTransactions';
 import SearchForAssets from './searchForAssets';
 import SearchForApplications from './searchForApplications';
+import { BaseHTTPClient } from '../../baseHTTPClient';
 import {
-  BaseHTTPClient,
   CustomTokenHeader,
   IndexerTokenHeader,
-} from '../../baseHTTPClient';
+} from '../../urlTokenBaseHTTPClient';
 
 export default class IndexerClient extends ServiceClient {
   /**
@@ -33,7 +33,7 @@ export default class IndexerClient extends ServiceClient {
       | BaseHTTPClient,
     baseServer = 'http://127.0.0.1',
     port: string | number = 8080,
-    headers = {}
+    headers: Record<string, string> = {}
   ) {
     super('X-Indexer-API-Token', tokenOrBaseClient, baseServer, port, headers);
   }

--- a/src/client/v2/serviceClient.ts
+++ b/src/client/v2/serviceClient.ts
@@ -1,6 +1,7 @@
 import HTTPClient from '../client';
 import IntDecoding from '../../types/intDecoding';
-import { BaseHTTPClient, TokenHeader } from '../baseHTTPClient';
+import { BaseHTTPClient } from '../baseHTTPClient';
+import { TokenHeader } from '../urlTokenBaseHTTPClient';
 
 export type TokenHeaderIdentifier =
   | 'X-Indexer-API-Token'

--- a/src/main.ts
+++ b/src/main.ts
@@ -123,6 +123,11 @@ export { default as Kmd } from './client/kmd';
 export { default as IntDecoding } from './types/intDecoding';
 export { default as Account } from './types/account';
 export { default as Indexer } from './client/v2/indexer/indexer';
+export {
+  BaseHTTPClient,
+  BaseHTTPClientResponse,
+  BaseHTTPClientError,
+} from './client/baseHTTPClient';
 export { waitForConfirmation } from './wait';
 export {
   isValidAddress,

--- a/tests/9.Client.ts
+++ b/tests/9.Client.ts
@@ -1,11 +1,12 @@
 import assert from 'assert';
 import HTTPClient from '../src/client/client';
+import { URLTokenBaseHTTPClient } from '../src/client/baseHTTPClient';
 
 describe('client', () => {
   describe('url construction', () => {
     /* eslint-disable dot-notation */
     it('should work with trivial paths', () => {
-      const client = new HTTPClient({}, 'http://localhost');
+      const client = new URLTokenBaseHTTPClient({}, 'http://localhost');
       const actual = client['addressWithPath']('/relative');
       const expected = 'http://localhost/relative';
 
@@ -13,7 +14,7 @@ describe('client', () => {
     });
 
     it('should work with number ports and trivial paths', () => {
-      const client = new HTTPClient({}, 'http://localhost', 3000);
+      const client = new URLTokenBaseHTTPClient({}, 'http://localhost', 3000);
       const actual = client['addressWithPath']('/relative');
       const expected = 'http://localhost:3000/relative';
 
@@ -21,7 +22,7 @@ describe('client', () => {
     });
 
     it('should work with complex base URLs and complex paths', () => {
-      const client = new HTTPClient(
+      const client = new URLTokenBaseHTTPClient(
         {},
         'https://testnet-algorand.api.purestake.io/ps2/',
         8080
@@ -35,8 +36,11 @@ describe('client', () => {
     it('should handle slash variations on complex paths', () => {
       const regularBase = 'https://localhost/absolute';
       const regularBaseWithFinalSlash = `${regularBase}/`;
-      const client = new HTTPClient({}, regularBase);
-      const clientWithSlash = new HTTPClient({}, regularBaseWithFinalSlash);
+      const client = new URLTokenBaseHTTPClient({}, regularBase);
+      const clientWithSlash = new URLTokenBaseHTTPClient(
+        {},
+        regularBaseWithFinalSlash
+      );
 
       const relativePath = 'relative';
       const relativePathWithInitialSlash = `/${relativePath}`;
@@ -57,8 +61,15 @@ describe('client', () => {
     it('should throw an error if protocol is the empty', () => {
       const baseServer = 'localhost'; // should be http://localhost
 
-      assert.throws(() => new HTTPClient({}, baseServer));
+      assert.throws(() => new URLTokenBaseHTTPClient({}, baseServer));
     });
     /* eslint-enable dot-notation */
+  });
+  describe('HTTPClient construction', () => {
+    it('should throw an error if protocol is the empty', () => {
+      const baseServer = 'localhost'; // should be http://localhost
+
+      assert.throws(() => new HTTPClient({}, baseServer));
+    });
   });
 });

--- a/tests/9.Client.ts
+++ b/tests/9.Client.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import HTTPClient from '../src/client/client';
-import { URLTokenBaseHTTPClient } from '../src/client/baseHTTPClient';
+import { URLTokenBaseHTTPClient } from '../src/client/urlTokenBaseHTTPClient';
 
 describe('client', () => {
   describe('url construction', () => {


### PR DESCRIPTION
Currently the only way for a dApp to use the SDK with an API service is to know the URL and token of the API service.
This prevents dApps from using API services / algod / indexer provided by the user or by a wallet such as AlgoSigner.

In particular:
* When using a wallet such as AlgoSigner, a dApp either need to manually serialize data and write path for endpoints (https://github.com/PureStake/algosigner/blob/develop/docs/dApp-integration.md#algosigneralgod-ledger-mainnettestnet-path-algod-v2-path--) or need to not use at all the provided API service.
* A user cannot use their preferred (potentially more trusted) API service / algod / index / API services
* A dApp cannot easily connect to a private network of the user

(See also https://github.com/algorandfoundation/ARCs/pull/8 for more details on wallets and discussion around them.)

The goal of this PR is to allow the above scenarios.
It does so by introducing an intermediate interface `BaseHTTPClient` and to allow to construct `Algodv2Client` and `IndexerClient` from such a `BaseHTTPClient`.

A `BaseHTTPClient` is minimal: it does not perform any serialization/de-serialization, does not fix `accept` headers, does not even try to utf8-decode strings. Its only purpose is to execute directly REST queries and return the raw responses.

`BaseHTTPClient`  is meant to be stable over releases of algosdk.