### PR TITLE
Support ABI reference types and other improvements

### DIFF
--- a/src/abi/abi_type.ts
+++ b/src/abi/abi_type.ts
@@ -43,7 +43,7 @@ export abstract class ABIType {
   // Converts a ABIType object to a string
   abstract toString(): string;
   // Checks if two ABIType objects are equal in value
-  abstract equal(other: ABIType): boolean;
+  abstract equals(other: ABIType): boolean;
   // Checks if the ABIType object (or any of its child types) have dynamic length
   abstract isDynamic(): boolean;
   // Returns the size of the ABIType object in bytes
@@ -139,7 +139,7 @@ export class ABIUintType extends ABIType {
     return `uint${this.bitSize}`;
   }
 
-  equal(other: ABIType) {
+  equals(other: ABIType) {
     return other instanceof ABIUintType && this.bitSize === other.bitSize;
   }
 
@@ -196,7 +196,7 @@ export class ABIUfixedType extends ABIType {
     return `ufixed${this.bitSize}x${this.precision}`;
   }
 
-  equal(other: ABIType) {
+  equals(other: ABIType) {
     return (
       other instanceof ABIUfixedType &&
       this.bitSize === other.bitSize &&
@@ -242,7 +242,7 @@ export class ABIAddressType extends ABIType {
     return 'address';
   }
 
-  equal(other: ABIType) {
+  equals(other: ABIType) {
     return other instanceof ABIAddressType;
   }
 
@@ -282,7 +282,7 @@ export class ABIBoolType extends ABIType {
     return 'bool';
   }
 
-  equal(other: ABIType) {
+  equals(other: ABIType) {
     return other instanceof ABIBoolType;
   }
 
@@ -324,7 +324,7 @@ export class ABIByteType extends ABIType {
     return 'byte';
   }
 
-  equal(other: ABIType) {
+  equals(other: ABIType) {
     return other instanceof ABIByteType;
   }
 
@@ -363,7 +363,7 @@ export class ABIStringType extends ABIType {
     return 'string';
   }
 
-  equal(other: ABIType) {
+  equals(other: ABIType) {
     return other instanceof ABIStringType;
   }
 
@@ -425,11 +425,11 @@ export class ABIArrayStaticType extends ABIType {
     return `${this.childType.toString()}[${this.staticLength}]`;
   }
 
-  equal(other: ABIType) {
+  equals(other: ABIType) {
     return (
       other instanceof ABIArrayStaticType &&
       this.staticLength === other.staticLength &&
-      this.childType.equal(other.childType)
+      this.childType.equals(other.childType)
     );
   }
 
@@ -479,10 +479,10 @@ export class ABIArrayDynamicType extends ABIType {
     return `${this.childType.toString()}[]`;
   }
 
-  equal(other: ABIType) {
+  equals(other: ABIType) {
     return (
       other instanceof ABIArrayDynamicType &&
-      this.childType.equal(other.childType)
+      this.childType.equals(other.childType)
     );
   }
 
@@ -543,12 +543,12 @@ export class ABITupleType extends ABIType {
     return `(${typeStrings.join(',')})`;
   }
 
-  equal(other: ABIType) {
+  equals(other: ABIType) {
     return (
       other instanceof ABITupleType &&
       this.childTypes.length === other.childTypes.length &&
       this.childTypes.every((child, index) =>
-        child.equal(other.childTypes[index])
+        child.equals(other.childTypes[index])
       )
     );
   }

--- a/src/abi/abi_type.ts
+++ b/src/abi/abi_type.ts
@@ -389,7 +389,9 @@ export class ABIStringType extends ABIType {
 
   decode(byteString: Uint8Array): string {
     if (byteString.length < LENGTH_ENCODE_BYTE_SIZE) {
-      throw new Error(`byte string is too short to be decoded: ${byteString}`);
+      throw new Error(
+        `byte string is too short to be decoded. Actual length is ${byteString.length}, but expected at least ${LENGTH_ENCODE_BYTE_SIZE}`
+      );
     }
     const buf = Buffer.from(byteString);
     const byteLength = buf.readUIntBE(0, LENGTH_ENCODE_BYTE_SIZE);
@@ -399,7 +401,7 @@ export class ABIStringType extends ABIType {
     );
     if (byteLength !== byteValue.length) {
       throw new Error(
-        `string length bytes do not match the actual length of string: ${byteString}`
+        `string length bytes do not match the actual length of string. Expected ${byteLength}, got ${byteValue.length}`
       );
     }
     return Buffer.from(byteValue).toString('utf-8');

--- a/src/abi/contract.ts
+++ b/src/abi/contract.ts
@@ -1,34 +1,42 @@
 import { ABIMethod, ABIMethodParams } from './method';
 
+export interface ABIContractNetworkInfo {
+  appID: number;
+}
+
+export interface ABIContractNetworks {
+  [network: string]: ABIContractNetworkInfo;
+}
+
 export interface ABIContractParams {
   name: string;
-  appId: number;
+  networks?: ABIContractNetworks;
   methods: ABIMethodParams[];
 }
 
 export class ABIContract {
   public readonly name: string;
-  public readonly appId: number;
+  public readonly networks: ABIContractNetworks;
   public readonly methods: ABIMethod[];
 
   constructor(params: ABIContractParams) {
     if (
       typeof params.name !== 'string' ||
-      typeof params.appId !== 'number' ||
-      !Array.isArray(params.methods)
+      !Array.isArray(params.methods) ||
+      (params.networks && typeof params.networks !== 'object')
     ) {
       throw new Error('Invalid ABIContract parameters');
     }
 
     this.name = params.name;
-    this.appId = params.appId;
+    this.networks = params.networks ? { ...params.networks } : {};
     this.methods = params.methods.map((method) => new ABIMethod(method));
   }
 
   toJSON(): ABIContractParams {
     return {
       name: this.name,
-      appId: this.appId,
+      networks: this.networks,
       methods: this.methods.map((method) => method.toJSON()),
     };
   }

--- a/src/abi/contract.ts
+++ b/src/abi/contract.ts
@@ -10,12 +10,14 @@ export interface ABIContractNetworks {
 
 export interface ABIContractParams {
   name: string;
+  desc?: string;
   networks?: ABIContractNetworks;
   methods: ABIMethodParams[];
 }
 
 export class ABIContract {
   public readonly name: string;
+  public readonly description?: string;
   public readonly networks: ABIContractNetworks;
   public readonly methods: ABIMethod[];
 
@@ -29,6 +31,7 @@ export class ABIContract {
     }
 
     this.name = params.name;
+    this.description = params.desc;
     this.networks = params.networks ? { ...params.networks } : {};
     this.methods = params.methods.map((method) => new ABIMethod(method));
   }
@@ -36,6 +39,7 @@ export class ABIContract {
   toJSON(): ABIContractParams {
     return {
       name: this.name,
+      desc: this.description,
       networks: this.networks,
       methods: this.methods.map((method) => method.toJSON()),
     };

--- a/src/abi/index.ts
+++ b/src/abi/index.ts
@@ -2,3 +2,5 @@ export * from './abi_type';
 export * from './contract';
 export * from './interface';
 export * from './method';
+export * from './transaction';
+export * from './reference';

--- a/src/abi/interface.ts
+++ b/src/abi/interface.ts
@@ -2,11 +2,13 @@ import { ABIMethod, ABIMethodParams } from './method';
 
 export interface ABIInterfaceParams {
   name: string;
+  desc?: string;
   methods: ABIMethodParams[];
 }
 
 export class ABIInterface {
   public readonly name: string;
+  public readonly description?: string;
   public readonly methods: ABIMethod[];
 
   constructor(params: ABIInterfaceParams) {
@@ -15,12 +17,14 @@ export class ABIInterface {
     }
 
     this.name = params.name;
+    this.description = params.desc;
     this.methods = params.methods.map((method) => new ABIMethod(method));
   }
 
   toJSON(): ABIInterfaceParams {
     return {
       name: this.name,
+      desc: this.description,
       methods: this.methods.map((method) => method.toJSON()),
     };
   }

--- a/src/abi/method.ts
+++ b/src/abi/method.ts
@@ -1,10 +1,7 @@
 import { genericHash } from '../nacl/naclWrappers';
-import { TransactionType } from '../types/transactions/base';
 import { ABIType, ABITupleType } from './abi_type';
-
-export function abiTypeIsTransaction(type: string): type is TransactionType {
-  return type === 'txn' || Object.keys(TransactionType).includes(type);
-}
+import { ABITransactionType, abiTypeIsTransaction } from './transaction';
+import { ABIReferenceType, abiTypeIsReference } from './reference';
 
 function parseMethodSignature(
   signature: string
@@ -55,7 +52,7 @@ export interface ABIMethodParams {
   returns: { type: string; desc?: string };
 }
 
-export type ABIArgumentType = ABIType | TransactionType;
+export type ABIArgumentType = ABIType | ABITransactionType | ABIReferenceType;
 
 export type ABIReturnType = ABIType | 'void';
 
@@ -82,7 +79,7 @@ export class ABIMethod {
     this.name = params.name;
     this.description = params.desc;
     this.args = params.args.map(({ type, name, desc }) => {
-      if (abiTypeIsTransaction(type)) {
+      if (abiTypeIsTransaction(type) || abiTypeIsReference(type)) {
         return {
           type,
           name,

--- a/src/abi/method.ts
+++ b/src/abi/method.ts
@@ -45,11 +45,22 @@ function parseMethodSignature(
   };
 }
 
+export interface ABIMethodArgParams {
+  type: string;
+  name?: string;
+  desc?: string;
+}
+
+export interface ABIMethodReturnParams {
+  type: string;
+  desc?: string;
+}
+
 export interface ABIMethodParams {
   name: string;
   desc?: string;
-  args: Array<{ type: string; name?: string; desc?: string }>;
-  returns: { type: string; desc?: string };
+  args: ABIMethodArgParams[];
+  returns: ABIMethodReturnParams;
 }
 
 export type ABIArgumentType = ABIType | ABITransactionType | ABIReferenceType;

--- a/src/abi/reference.ts
+++ b/src/abi/reference.ts
@@ -1,0 +1,24 @@
+export enum ABIReferenceType {
+  /**
+   * Account reference type
+   */
+  account = 'account',
+
+  /**
+   * Application reference type
+   */
+  application = 'application',
+
+  /**
+   * Asset reference type
+   */
+  asset = 'asset',
+}
+
+export function abiTypeIsReference(type: any): type is ABIReferenceType {
+  return (
+    type === ABIReferenceType.account ||
+    type === ABIReferenceType.application ||
+    type === ABIReferenceType.asset
+  );
+}

--- a/src/abi/transaction.ts
+++ b/src/abi/transaction.ts
@@ -1,0 +1,61 @@
+import { Transaction } from '../transaction';
+
+export enum ABITransactionType {
+  /**
+   * Any transaction type
+   */
+  any = 'txn',
+
+  /**
+   * Payment transaction type
+   */
+  pay = 'pay',
+
+  /**
+   * Key registration transaction type
+   */
+  keyreg = 'keyreg',
+
+  /**
+   * Asset configuration transaction type
+   */
+  acfg = 'acfg',
+
+  /**
+   * Asset transfer transaction type
+   */
+  axfer = 'axfer',
+
+  /**
+   * Asset freeze transaction type
+   */
+  afrz = 'afrz',
+
+  /**
+   * Application transaction type
+   */
+  appl = 'appl',
+}
+
+export function abiTypeIsTransaction(type: any): type is ABITransactionType {
+  return (
+    type === ABITransactionType.any ||
+    type === ABITransactionType.pay ||
+    type === ABITransactionType.keyreg ||
+    type === ABITransactionType.acfg ||
+    type === ABITransactionType.axfer ||
+    type === ABITransactionType.afrz ||
+    type === ABITransactionType.appl
+  );
+}
+
+export function abiCheckTransactionType(
+  type: ABITransactionType,
+  txn: Transaction
+): boolean {
+  if (type === ABITransactionType.any) {
+    return true;
+  }
+
+  return txn.type && txn.type.toString() === type.toString();
+}

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -62,6 +62,19 @@ export enum AtomicTransactionComposerStatus {
   COMMITTED,
 }
 
+/**
+ * Add a value to an application call's foreign array. The addition will be as compact as possible,
+ * and this function will return an index that can be used to reference `valueToAdd` in `array`.
+ *
+ * @param valueToAdd - The value to add to the array. If this value is already present in the array,
+ *   it will not be added again. Instead, the existing index will be returned.
+ * @param array - The existing foreign array. This input may be modified to append `valueToAdd`.
+ * @param zeroValue - If provided, this value indicated two things: the 0 value is special for this
+ *   array, so all indexes into `array` must start at 1; additionally, if `valueToAdd` equals
+ *   `zeroValue`, then `valueToAdd` will not be added to the array, and instead the 0 indexes will
+ *   be returned.
+ * @returns An index that can be used to reference `valueToAdd` in `array`.
+ */
 function populateForeignArray<Type>(
   valueToAdd: Type,
   array: Type[],

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -603,6 +603,7 @@ export class AtomicTransactionComposer {
     }
 
     const txIDs = await this.submit(client);
+    this.status = AtomicTransactionComposerStatus.SUBMITTED;
 
     const firstMethodCallIndex = this.transactions.findIndex((_, index) =>
       this.methodCalls.has(index)
@@ -614,7 +615,6 @@ export class AtomicTransactionComposer {
       txIDs[indexToWaitFor],
       waitRounds
     );
-
     this.status = AtomicTransactionComposerStatus.COMMITTED;
 
     const confirmedRound: number = confirmedTxnInfo['confirmed-round'];

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -25,8 +25,11 @@ import {
   SuggestedParams,
 } from './types/transactions/base';
 
-// first 4 bytes of SHA-512/256 hash of "return"
+// First 4 bytes of SHA-512/256 hash of "return"
 const RETURN_PREFIX = Buffer.from([21, 31, 124, 117]);
+
+// The maximum number of arguments for an application call transaction
+const MAX_APP_ARGS = 16;
 
 export type ABIArgument = ABIValue | TransactionWithSigner;
 
@@ -404,12 +407,12 @@ export class AtomicTransactionComposer {
       basicArgValues[basicArgIndex] = resolvedRefIndexes[i];
     }
 
-    if (basicArgTypes.length > 15) {
-      const lastArgTupleTypes = basicArgTypes.slice(14);
-      const lastArgTupleValues = basicArgValues.slice(14);
+    if (basicArgTypes.length > MAX_APP_ARGS - 1) {
+      const lastArgTupleTypes = basicArgTypes.slice(MAX_APP_ARGS - 2);
+      const lastArgTupleValues = basicArgValues.slice(MAX_APP_ARGS - 2);
 
-      basicArgTypes = basicArgTypes.slice(0, 14);
-      basicArgValues = basicArgValues.slice(0, 14);
+      basicArgTypes = basicArgTypes.slice(0, MAX_APP_ARGS - 2);
+      basicArgValues = basicArgValues.slice(0, MAX_APP_ARGS - 2);
 
       basicArgTypes.push(new ABITupleType(lastArgTupleTypes));
       basicArgValues.push(lastArgTupleValues);

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -772,8 +772,9 @@ export class Transaction implements TransactionStorageStructure {
       if (!txn.apap) delete txn.apap;
       if (!txn.apsu) delete txn.apsu;
       if (!txn.apan) delete txn.apan;
-      if (!txn.apfa) delete txn.apfa;
-      if (!txn.apas) delete txn.apas;
+      if (!txn.apfa || !txn.apfa.length) delete txn.apfa;
+      if (!txn.apas || !txn.apas.length) delete txn.apas;
+      if (!txn.apat || !txn.apat.length) delete txn.apat;
       if (!txn.apep) delete txn.apep;
       if (txn.grp === undefined) delete txn.grp;
       return txn;

--- a/tests/cucumber/docker/run_docker.sh
+++ b/tests/cucumber/docker/run_docker.sh
@@ -7,7 +7,7 @@ rm -rf test-harness
 rm -rf tests/cucumber/features
 
 # clone test harness
-git clone --single-branch --branch master https://github.com/algorand/algorand-sdk-testing.git test-harness
+git clone --single-branch --branch more-abi-tests https://github.com/algorand/algorand-sdk-testing.git test-harness
 
 # move feature files and example files to destination
 mv test-harness/features tests/cucumber/features

--- a/tests/cucumber/docker/run_docker.sh
+++ b/tests/cucumber/docker/run_docker.sh
@@ -7,7 +7,7 @@ rm -rf test-harness
 rm -rf tests/cucumber/features
 
 # clone test harness
-git clone --single-branch --branch more-abi-tests https://github.com/algorand/algorand-sdk-testing.git test-harness
+git clone --single-branch --branch master https://github.com/algorand/algorand-sdk-testing.git test-harness
 
 # move feature files and example files to destination
 mv test-harness/features tests/cucumber/features

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -5120,7 +5120,7 @@ module.exports = function getSteps(options) {
         const returnType = method.returns.type;
         if (returnType === 'void') {
           assert.strictEqual(expectedReturnValue.byteLength, 0);
-          return;
+          continue;
         }
 
         assert.deepStrictEqual(

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -4681,15 +4681,21 @@ module.exports = function getSteps(options) {
   );
 
   When(
-    'I create a Contract object from the Method object with name {string} and appId {int}',
-    function (name, appId) {
+    'I create a Contract object from the Method object with name {string}',
+    function (name) {
       this.contract = makeABIContract(
         makeObject({
           name,
-          appId: parseInt(appId, 10),
           methods: makeArray(this.method.toJSON()),
         })
       );
+    }
+  );
+
+  When(
+    "I set the Contract's appID to {int} for the network {string}",
+    function (appID, network) {
+      this.contract.networks[network] = { appID: parseInt(appID, 10) };
     }
   );
 

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -4777,7 +4777,30 @@ module.exports = function getSteps(options) {
     }
   );
 
-  function addMethodCallToComposer(sender, onComplete) {
+  async function addMethodCallToComposer(
+    sender,
+    onComplete,
+    approvalProgramFile,
+    clearProgramFile,
+    globalBytes,
+    globalInts,
+    localBytes,
+    localInts,
+    extraPages
+  ) {
+    // open and load in approval program
+    let approvalProgramBytes;
+    if (approvalProgramFile !== '') {
+      const resouce = await loadResource(approvalProgramFile);
+      approvalProgramBytes = makeUint8Array(resouce);
+    }
+    // open and load in clear program
+    let clearProgramBytes;
+    if (clearProgramFile !== '') {
+      const resouce = await loadResource(clearProgramFile);
+      clearProgramBytes = makeUint8Array(resouce);
+    }
+
     const methodArgs = [];
 
     assert.strictEqual(
@@ -4818,12 +4841,19 @@ module.exports = function getSteps(options) {
     }
 
     this.composer.addMethodCall({
-      appId: this.currentApplicationIndex,
+      appID: this.currentApplicationIndex,
       method: this.method,
       methodArgs,
       sender,
       suggestedParams: this.suggestedParams,
       onComplete: operationStringToEnum(onComplete),
+      approvalProgram: approvalProgramBytes,
+      clearProgram: clearProgramBytes,
+      numGlobalInts: globalInts,
+      numGlobalByteSlices: globalBytes,
+      numLocalInts: localInts,
+      numLocalByteSlices: localBytes,
+      extraPages,
       signer: this.transactionSigner,
     });
     this.composerMethods.push(this.method);
@@ -4831,19 +4861,129 @@ module.exports = function getSteps(options) {
 
   When(
     'I add a method call with the transient account, the current application, suggested params, on complete {string}, current transaction signer, current method arguments.',
-    function (onComplete) {
-      addMethodCallToComposer.call(
+    async function (onComplete) {
+      await addMethodCallToComposer.call(
         this,
         this.transientAccount.addr,
-        onComplete
+        onComplete,
+        '',
+        '',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined
       );
     }
   );
 
   When(
     'I add a method call with the signing account, the current application, suggested params, on complete {string}, current transaction signer, current method arguments.',
-    function (onComplete) {
-      addMethodCallToComposer.call(this, this.signingAccount.addr, onComplete);
+    async function (onComplete) {
+      await addMethodCallToComposer.call(
+        this,
+        this.signingAccount.addr,
+        onComplete,
+        '',
+        '',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined
+      );
+    }
+  );
+
+  When(
+    'I add a method call with the transient account, the current application, suggested params, on complete {string}, current transaction signer, current method arguments, approval-program {string}, clear-program {string}, global-bytes {int}, global-ints {int}, local-bytes {int}, local-ints {int}, extra-pages {int}.',
+    async function (
+      onComplete,
+      approvalProg,
+      clearProg,
+      globalBytes,
+      globalInts,
+      localBytes,
+      localInts,
+      extraPages
+    ) {
+      await addMethodCallToComposer.call(
+        this,
+        this.transientAccount.addr,
+        onComplete,
+        approvalProg,
+        clearProg,
+        parseInt(globalBytes, 10),
+        parseInt(globalInts, 10),
+        parseInt(localBytes, 10),
+        parseInt(localInts, 10),
+        parseInt(extraPages, 10)
+      );
+    }
+  );
+
+  When(
+    'I add a method call with the signing account, the current application, suggested params, on complete {string}, current transaction signer, current method arguments, approval-program {string}, clear-program {string}, global-bytes {int}, global-ints {int}, local-bytes {int}, local-ints {int}, extra-pages {int}.',
+    async function (
+      onComplete,
+      approvalProg,
+      clearProg,
+      globalBytes,
+      globalInts,
+      localBytes,
+      localInts,
+      extraPages
+    ) {
+      await addMethodCallToComposer.call(
+        this,
+        this.signingAccount.addr,
+        onComplete,
+        approvalProg,
+        clearProg,
+        parseInt(globalBytes, 10),
+        parseInt(globalInts, 10),
+        parseInt(localBytes, 10),
+        parseInt(localInts, 10),
+        parseInt(extraPages, 10)
+      );
+    }
+  );
+
+  When(
+    'I add a method call with the transient account, the current application, suggested params, on complete {string}, current transaction signer, current method arguments, approval-program {string}, clear-program {string}.',
+    async function (onCompletion, approvalProg, clearProg) {
+      assert.strictEqual(onCompletion, 'update');
+      await addMethodCallToComposer.call(
+        this,
+        this.transientAccount.addr,
+        onCompletion,
+        approvalProg,
+        clearProg,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined
+      );
+    }
+  );
+
+  When(
+    'I add a method call with the signing account, the current application, suggested params, on complete {string}, current transaction signer, current method arguments, approval-program {string}, clear-program {string}.',
+    async function (onCompletion, approvalProg, clearProg) {
+      assert.strictEqual(onCompletion, 'update');
+      await addMethodCallToComposer.call(
+        this,
+        this.signingAccount.addr,
+        onCompletion,
+        approvalProg,
+        clearProg,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined
+      );
     }
   );
 

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -4655,11 +4655,12 @@ module.exports = function getSteps(options) {
   );
 
   When(
-    'I create an Interface object from the Method object with name {string}',
-    function (name) {
+    'I create an Interface object from the Method object with name {string} and description {string}',
+    function (name, desc) {
       this.interface = new algosdk.ABIInterface(
         makeObject({
           name,
+          desc,
           methods: makeArray(this.method.toJSON()),
         })
       );
@@ -4681,11 +4682,12 @@ module.exports = function getSteps(options) {
   );
 
   When(
-    'I create a Contract object from the Method object with name {string}',
-    function (name) {
+    'I create a Contract object from the Method object with name {string} and description {string}',
+    function (name, desc) {
       this.contract = makeABIContract(
         makeObject({
           name,
+          desc,
           methods: makeArray(this.method.toJSON()),
         })
       );

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -4695,7 +4695,9 @@ module.exports = function getSteps(options) {
   When(
     "I set the Contract's appID to {int} for the network {string}",
     function (appID, network) {
-      this.contract.networks[network] = { appID: parseInt(appID, 10) };
+      this.contract.networks[network] = makeObject({
+        appID: parseInt(appID, 10),
+      });
     }
   );
 


### PR DESCRIPTION
- [x] Add reference type support
- [x] Throw error if transaction type argument does not match transaction argument type
- [x] Add more type checking for implementations of `ABIType.encode` and `.equal`
- [x] AtomicTransactionComposer does not assign group ID if there's only 1 transaction in the group
- [x] Changes from https://github.com/algorandfoundation/ARCs/pull/53
  - [x] Don't tuple last argument when length is 15
  - [x] Modify `ABIContract` class
- [x] Add Contract and Interface descriptions, from  https://github.com/algorandfoundation/ARCs/pull/55
- [x] Changes from https://github.com/algorandfoundation/ARCs/pull/57
  - [x] AtomicTransactionComposer only checks the last log for a return value
  - [x] App creation and update transactions are supported in ABI method calls
- [x] Change `algorand-sdk-testing` branch back to `master` after https://github.com/algorand/algorand-sdk-testing/pull/153 is merged

Closes #468, closes #483