### PR TITLE
Improve HTTP error messages

### DIFF
--- a/src/client/urlTokenBaseHTTPClient.ts
+++ b/src/client/urlTokenBaseHTTPClient.ts
@@ -85,6 +85,22 @@ export class URLTokenBaseHTTPClient implements BaseHTTPClient {
     return res;
   }
 
+  /**
+   * Make a superagent error more readable. For more info, see https://github.com/visionmedia/superagent/issues/1074
+   */
+  private static formatSuperagentError(err: any): Error {
+    if (err.response) {
+      try {
+        const decoded = JSON.parse(Buffer.from(err.response.body).toString());
+        // eslint-disable-next-line no-param-reassign
+        err.message = `Network request error. Received status ${err.response.status}: ${decoded.message}`;
+      } catch (err2) {
+        // ignore any error that happened while we are formatting the original error
+      }
+    }
+    return err;
+  }
+
   async get(
     relativePath: string,
     query?: Query<string>,
@@ -98,8 +114,12 @@ export class URLTokenBaseHTTPClient implements BaseHTTPClient {
       .responseType('arraybuffer')
       .query(query);
 
-    const res = await r;
-    return URLTokenBaseHTTPClient.superagentToHTTPClientResponse(res);
+    try {
+      const res = await r;
+      return URLTokenBaseHTTPClient.superagentToHTTPClientResponse(res);
+    } catch (err) {
+      throw URLTokenBaseHTTPClient.formatSuperagentError(err);
+    }
   }
 
   async post(
@@ -118,8 +138,12 @@ export class URLTokenBaseHTTPClient implements BaseHTTPClient {
       .responseType('arraybuffer')
       .send(Buffer.from(data)); // Buffer.from necessary for superagent
 
-    const res = await r;
-    return URLTokenBaseHTTPClient.superagentToHTTPClientResponse(res);
+    try {
+      const res = await r;
+      return URLTokenBaseHTTPClient.superagentToHTTPClientResponse(res);
+    } catch (err) {
+      throw URLTokenBaseHTTPClient.formatSuperagentError(err);
+    }
   }
 
   async delete(
@@ -138,7 +162,11 @@ export class URLTokenBaseHTTPClient implements BaseHTTPClient {
       .responseType('arraybuffer')
       .send(Buffer.from(data)); // Buffer.from necessary for superagent
 
-    const res = await r;
-    return URLTokenBaseHTTPClient.superagentToHTTPClientResponse(res);
+    try {
+      const res = await r;
+      return URLTokenBaseHTTPClient.superagentToHTTPClientResponse(res);
+    } catch (err) {
+      throw URLTokenBaseHTTPClient.formatSuperagentError(err);
+    }
   }
 }

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -1874,7 +1874,7 @@ module.exports = function getSteps(options) {
           throw err;
         }
         if (this.expectedMockResponseCode === 500) {
-          if (!err.toString().includes('Internal Server Error')) {
+          if (!err.toString().includes('Received status 500')) {
             throw Error(
               `expected response code 500 implies error Internal Server Error but instead had error: ${err}`
             );


### PR DESCRIPTION
Improve the HTTP error messages that superagent returns.

Before this PR, an error would look like:

```
Error: Bad Request
```

After this PR, it contains the error message returned from the server, like this:

```
Error: Network request unsuccessful. Received status 400: TransactionPool.Remember: transaction QJALLV5B3QDLCOOMOBGBEORNUGBRNNG6DVQ2DN42XATI4P2WFSAA: logic eval error: + overflowed. Details: pc=316, opcodes=load 4
       btoi
       +
```

Closes #462 