### PR TITLE
Fix JSON decoding

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -140,9 +140,8 @@ export default class HTTPClient {
    * @param status Status of the response (used in case parseJSON fails)
    * @param jsonOptions Options object to use to decode JSON responses. See
    *   utils.parseJSON for the options available.
-   * @private
    */
-  private static parseJSON(
+  public static parseJSON(
     text: string,
     status: number,
     jsonOptions: utils.JSONOptions = {}

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -148,7 +148,7 @@ export default class HTTPClient {
     jsonOptions: utils.JSONOptions = {}
   ) {
     try {
-      if (Object.keys(jsonOptions).length !== 0) {
+      if (Object.keys(jsonOptions).length === 0) {
         return text && JSON.parse(text);
       }
       return text && utils.parseJSON(text, jsonOptions);

--- a/tests/9.Client.ts
+++ b/tests/9.Client.ts
@@ -1,6 +1,8 @@
 import assert from 'assert';
 import HTTPClient from '../src/client/client';
 import { URLTokenBaseHTTPClient } from '../src/client/urlTokenBaseHTTPClient';
+import IntDecoding from '../src/types/intDecoding';
+import * as utils from '../src/utils/utils';
 
 describe('client', () => {
   describe('url construction', () => {
@@ -31,6 +33,40 @@ describe('client', () => {
       const expected =
         'https://testnet-algorand.api.purestake.io:8080/ps2/relative?with=query';
       assert.strictEqual(actual, expected);
+    });
+
+    it('should encode and decode values correctly', () => {
+      const j = '{"total":18446744073709551615, "base":42}';
+
+      let options = {
+        // intDecoding: IntDecoding.DEFAULT,
+      };
+      let actual = HTTPClient.parseJSON(j, 200, options);
+      let expected = JSON.parse(j);
+      assert.strictEqual(actual.total, expected.total);
+      assert.strictEqual(typeof actual.total, 'number');
+
+      options = {
+        intDecoding: IntDecoding.BIGINT,
+      };
+      actual = HTTPClient.parseJSON(j, 200, options);
+      expected = utils.parseJSON(j, options);
+      assert.strictEqual(actual.total, expected.total);
+      assert.strictEqual(typeof actual.total, 'bigint');
+
+      options = {
+        intDecoding: IntDecoding.MIXED,
+      };
+      actual = HTTPClient.parseJSON(j, 200, options);
+      expected = utils.parseJSON(j, options);
+      assert.strictEqual(actual.total, expected.total);
+      assert.strictEqual(typeof actual.total, 'bigint');
+      assert.strictEqual(typeof actual.base, 'number');
+
+      options = {
+        intDecoding: IntDecoding.SAFE,
+      };
+      assert.throws(() => HTTPClient.parseJSON(j, 200, options), Error);
     });
 
     it('should handle slash variations on complex paths', () => {


### PR DESCRIPTION
Hey team,

I think I found a bug in how we decode json responses; essentially, we always pick the wrong parser.

Look at the following code snippet:

```typescript
  const assetDetails = await client
    .getAssetByID(ASAIdx)
    .setIntDecoding(algosdk.IntDecoding.BIGINT)
    .do();
  console.log(typeof assetDetails.params.total);
```

Before: `number`
Now: `bigint`

I also think that we should add a unit test for this. My JS skills are somehow limited, but I'd be happy to give it a shot if you point me in the right direction :)