### PR TITLE
fix app creation createDryrun error

### DIFF
--- a/src/dryrun.ts
+++ b/src/dryrun.ts
@@ -81,7 +81,7 @@ export async function createDryrun({
       if (t.txn.appForeignAssets) assets.push(...t.txn.appForeignAssets);
 
       // Create application,
-      if (t.txn.appIndex === 0) {
+      if (t.txn.appIndex === undefined) {
         appInfos.push(
           new Application(
             defaultAppId,

--- a/src/dryrun.ts
+++ b/src/dryrun.ts
@@ -81,7 +81,7 @@ export async function createDryrun({
       if (t.txn.appForeignAssets) assets.push(...t.txn.appForeignAssets);
 
       // Create application,
-      if (t.txn.appIndex === undefined) {
+      if (t.txn.appIndex === undefined || t.txn.appIndex === 0) {
         appInfos.push(
           new Application(
             defaultAppId,


### PR DESCRIPTION
This PR fixes #538 

The error stems from line 84, which checks if the appIndex is zero:

```js
      if (t.txn.appIndex === 0) {
```

When creating a new transaction, `t.txn.appIndex` will be `undefined` instead of zero. To get intended functionality, we must be checking if `t.txn.appIndex` is `undefined`, otherwise it will assume the created app is a pre-exsting app and attempt to pass `undefined` as the appIndex. 