### PR TITLE
Fix cucumber tests for asset lookup step

### DIFF
--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -1938,19 +1938,11 @@ module.exports = function getSteps(options) {
   );
 
   When(
-    'we make a Lookup Asset Balances call against asset index {int} with limit {int} nextToken {string} round {int} currencyGreaterThan {int} currencyLessThan {int}',
-    async function (
-      index,
-      limit,
-      nextToken,
-      round,
-      currencyGreater,
-      currencyLesser
-    ) {
+    'we make a Lookup Asset Balances call against asset index {int} with limit {int} nextToken {string} currencyGreaterThan {int} currencyLessThan {int}',
+    async function (index, limit, nextToken, currencyGreater, currencyLesser) {
       await this.indexerClient
         .lookupAssetBalances(index)
         .limit(limit)
-        .round(round)
         .currencyGreaterThan(currencyGreater)
         .currencyLessThan(currencyLesser)
         .nextToken(nextToken)
@@ -1959,19 +1951,17 @@ module.exports = function getSteps(options) {
   );
 
   When(
-    'we make a Lookup Asset Balances call against asset index {int} with limit {int} afterAddress {string} round {int} currencyGreaterThan {int} currencyLessThan {int}',
+    'we make a Lookup Asset Balances call against asset index {int} with limit {int} afterAddress {string} currencyGreaterThan {int} currencyLessThan {int}',
     async function (
       index,
       limit,
       afterAddress,
-      round,
       currencyGreater,
       currencyLesser
     ) {
       await this.indexerClient
         .lookupAssetBalances(index)
         .limit(limit)
-        .round(round)
         .currencyGreaterThan(currencyGreater)
         .currencyLessThan(currencyLesser)
         .do();

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -1938,11 +1938,19 @@ module.exports = function getSteps(options) {
   );
 
   When(
-    'we make a Lookup Asset Balances call against asset index {int} with limit {int} nextToken {string} currencyGreaterThan {int} currencyLessThan {int}',
-    async function (index, limit, nextToken, currencyGreater, currencyLesser) {
+    'we make a Lookup Asset Balances call against asset index {int} with limit {int} nextToken {string} round {int} currencyGreaterThan {int} currencyLessThan {int}',
+    async function (
+      index,
+      limit,
+      nextToken,
+      round,
+      currencyGreater,
+      currencyLesser
+    ) {
       await this.indexerClient
         .lookupAssetBalances(index)
         .limit(limit)
+        .round(round)
         .currencyGreaterThan(currencyGreater)
         .currencyLessThan(currencyLesser)
         .nextToken(nextToken)


### PR DESCRIPTION
There was a [PR in the SDK testing repo](https://github.com/algorand/algorand-sdk-testing/pull/162) that changed the wording for one of the cucumber steps. This PR makes sure that the JS steps conform to this wording change.