### PR TITLE
Properly set maxWidth in trace

### DIFF
--- a/src/dryrun.ts
+++ b/src/dryrun.ts
@@ -365,8 +365,7 @@ class DryrunTransactionResult {
     disassembly: string[],
     spc: StackPrinterConfig
   ): string {
-    let maxWidth = defaultMaxWidth;
-    if (spc.maxValueWidth === undefined) maxWidth = spc.maxValueWidth;
+    const maxWidth = spc.maxValueWidth || defaultMaxWidth;
 
     // Create the array of arrays, each sub array contains N columns
     const lines = [['pc#', 'ln#', 'source', 'scratch', 'stack']];


### PR DESCRIPTION
This fixes #592. The `maxWidth` was simply never updated if a non-default value was provided in the spc. This PR ensures that `maxWidth` is properly set. Tested with default `maxWidth` and a specific `spc.maxValueWidth` and functionality now works as expected. 