### PR TITLE
API: Support attaching signatures to standard and multisig transactions

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -166,6 +166,8 @@ export {
   signMultisigTransaction,
   mergeMultisigTransactions,
   appendSignMultisigTransaction,
+  appendSignRawMultisigSignature,
+  verifyMultisig,
   multisigAddress,
 } from './multisig';
 export const LogicTemplates = LogicTemplatesCommonJSExport.default;

--- a/src/main.ts
+++ b/src/main.ts
@@ -166,7 +166,7 @@ export {
   signMultisigTransaction,
   mergeMultisigTransactions,
   appendSignMultisigTransaction,
-  createRawMultisigTransaction,
+  createMultisigTransaction as createRawMultisigTransaction,
   appendSignRawMultisigSignature,
   verifyMultisig,
   multisigAddress,

--- a/src/main.ts
+++ b/src/main.ts
@@ -166,7 +166,7 @@ export {
   signMultisigTransaction,
   mergeMultisigTransactions,
   appendSignMultisigTransaction,
-  createMultisigTransaction as createRawMultisigTransaction,
+  createMultisigTransaction,
   appendSignRawMultisigSignature,
   verifyMultisig,
   multisigAddress,

--- a/src/main.ts
+++ b/src/main.ts
@@ -166,6 +166,7 @@ export {
   signMultisigTransaction,
   mergeMultisigTransactions,
   appendSignMultisigTransaction,
+  createRawMultisigTransaction,
   appendSignRawMultisigSignature,
   verifyMultisig,
   multisigAddress,

--- a/src/multisig.ts
+++ b/src/multisig.ts
@@ -29,6 +29,8 @@ export const MULTISIG_NO_MUTATE_ERROR_MSG =
   'Cannot mutate a multisig field as it would invalidate all existing signatures.';
 export const MULTISIG_USE_PARTIAL_SIGN_ERROR_MSG =
   'Cannot sign a multisig transaction using `signTxn`. Use `partialSignTxn` instead.';
+export const MULTISIG_SIGNATURE_LENGTH_ERROR_MSG =
+  'Cannot add multisig signature. Signature is not of the correct length.';
 
 interface MultisigOptions {
   rawSig: Uint8Array;
@@ -160,9 +162,15 @@ export class MultisigTransaction extends txnBuilder.Transaction {
     signerAddr: string,
     signature: Uint8Array
   ) {
+    if (!nacl.isValidSignatureLength(signature.length)) {
+      throw new Error(MULTISIG_SIGNATURE_LENGTH_ERROR_MSG);
+    }
     return createMultisigTransaction(
       this.get_obj_for_encoding(),
-      { rawSig: signature, myPk: address.decodeAddress(signerAddr).publicKey },
+      {
+        rawSig: signature,
+        myPk: address.decodeAddress(signerAddr).publicKey,
+      },
       metadata
     );
   }

--- a/src/multisig.ts
+++ b/src/multisig.ts
@@ -51,9 +51,10 @@ interface MultisigMetadataWithPks extends Omit<MultisigMetadata, 'addrs'> {
  */
 export function createMultisigTransaction(
   txn: txnBuilder.Transaction,
-  { version, threshold, pks }: MultisigMetadataWithPks
+  { version, threshold, addrs }: MultisigMetadata
 ) {
   // construct the appendable multisigned transaction format
+  const pks = addrs.map((addr) => address.decodeAddress(addr).publicKey);
   const subsigs = pks.map((pk) => ({ pk: Buffer.from(pk) }));
 
   const msig: EncodedMultisig = {
@@ -103,7 +104,7 @@ function createMultisigTransactionWithSignature(
   const encodedMsig = createMultisigTransaction(txn, {
     version,
     threshold,
-    pks,
+    addrs: pks.map((pk) => address.encodeAddress(pk)),
   });
   // note: this is not signed yet, but will be shortly
   const signedTxn = encoding.decode(encodedMsig) as EncodedSignedTransaction;

--- a/src/nacl/naclWrappers.ts
+++ b/src/nacl/naclWrappers.ts
@@ -18,6 +18,10 @@ export function keyPair() {
   return keyPairFromSeed(seed);
 }
 
+export function isValidSignatureLength(len: number) {
+  return len === nacl.sign.signatureLength;
+}
+
 export function keyPairFromSecretKey(sk: Uint8Array) {
   return nacl.sign.keyPair.fromSecretKey(sk);
 }

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -1035,6 +1035,19 @@ export class Transaction implements TransactionStorageStructure {
     return new Uint8Array(encoding.encode(sTxn));
   }
 
+  attachSignature(signerAddr: string, signature: Uint8Array) {
+    const sTxn: EncodedSignedTransaction = {
+      sig: Buffer.from(signature),
+      txn: this.get_obj_for_encoding(),
+    };
+    // add AuthAddr if signing with a different key than From indicates
+    if (signerAddr !== address.encodeAddress(this.from.publicKey)) {
+      const signerPublicKey = address.decodeAddress(signerAddr).publicKey;
+      sTxn.sgnr = Buffer.from(signerPublicKey);
+    }
+    return new Uint8Array(encoding.encode(sTxn));
+  }
+
   rawTxID() {
     const enMsg = this.toByte();
     const gh = Buffer.from(utils.concatArrays(this.tag, enMsg));

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -1036,6 +1036,9 @@ export class Transaction implements TransactionStorageStructure {
   }
 
   attachSignature(signerAddr: string, signature: Uint8Array) {
+    if (!nacl.isValidSignatureLength(signature.length)) {
+      throw new Error('Invalid signature length');
+    }
     const sTxn: EncodedSignedTransaction = {
       sig: Buffer.from(signature),
       txn: this.get_obj_for_encoding(),

--- a/tests/4.Utils.ts
+++ b/tests/4.Utils.ts
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import * as utils from '../src/utils/utils';
+import * as nacl from '../src/nacl/naclWrappers';
 
 describe('utils', () => {
   describe('concatArrays', () => {
@@ -31,5 +32,12 @@ describe('utils', () => {
       const actual = utils.concatArrays(a, b, c);
       assert.deepStrictEqual(expected, actual);
     });
+  });
+});
+
+describe('nacl wrapper', () => {
+  it('should validate signature length', () => {
+    assert.strictEqual(nacl.isValidSignatureLength(6), false);
+    assert.strictEqual(nacl.isValidSignatureLength(64), true);
   });
 });

--- a/tests/6.Multisig.ts
+++ b/tests/6.Multisig.ts
@@ -212,6 +212,7 @@ describe('Multisig Functionality', () => {
         'gqRtc2lng6ZzdWJzaWeTgqJwa8QgG37AsEvqYbeWkJfmy/QH4QinBTUdC8mKvrEiCairgXihc8RAuLAFE0oma0skOoAmOzEwfPuLYpEWl4LINtsiLrUqWQkDxh4WHb29//YCpj4MFbiSgD2jKYt0XKRD86zKCF4RDYKicGvEIAljMglTc4nwdWcRdzmRx9A+G3PIxPUr9q/wGqJc+cJxoXPEQBAhuyRjsOrnHp3s/xI+iMKiL7QPsh8iJZ22YOJJP0aFUwedMr+a6wfdBXk1OefyrAN1wqJ9rq6O+DrWV1fH0ASBonBrxCDn8PhNBoEd+fMcjYeLEVX0Zx1RoYXCAJCGZ/RJWHBooaN0aHICoXYBo3R4boujYW10zQPopWNsb3NlxCBA6TSSiCVky86cWaabZ1Qmiemhw6Kp6ltlpuikQh/8V6NmZWXNA+iiZnbN8xWjZ2VurGRldm5ldC12MzguMKJnaMQg/rNsORAUOQDD2lVCyhg2sA/S+BlZElfNI/YEL5jINp2ibHbN9v2kbm90ZcQIRSYiABhShvujcmN2xCB7bOJP61uswLFk4pwiLFf19j3Dh9Q5BIJYQRxf4Q98AqNzbmTEII2StImQAXOgTfpDWaNmamr86ixCoF3Zwfc+66VHgDfppHR5cGWjcGF5',
         'base64'
       );
+
       assert.deepStrictEqual(Buffer.from(blob), expectedBlob);
     });
 
@@ -255,6 +256,82 @@ describe('Multisig Functionality', () => {
           ),
         Error(MULTISIG_SIGNATURE_LENGTH_ERROR_MSG)
       );
+    });
+
+    it('should append signature to created raw multisig transaction', () => {
+      const rawTxBlob = Buffer.from(
+        'jKNmZWXOAAPIwKJmds4ADvnao2dlbqxkZXZuZXQtdjM4LjCiZ2jEIP6zbDkQFDkAw9pVQsoYNrAP0vgZWRJXzSP2BC+YyDadomx2zgAO/cKmc2Vsa2V5xCAyEisr1j3cUzGWF6WqU8Sxwm/j3MryjTYitWl3oUBchqNzbmTEII2StImQAXOgTfpDWaNmamr86ixCoF3Zwfc+66VHgDfppHR5cGWma2V5cmVnp3ZvdGVmc3TOAA27oKZ2b3Rla2TNJxCndm90ZWtlecQgcBvX+5ErB7MIEf8oHZ/ulWPlgC4gJokjGSWPd/qTHoindm90ZWxzdM4AD0JA',
+        'base64'
+      );
+      const decRawTx = algosdk.decodeUnsignedTransaction(rawTxBlob);
+      const encodedRawTx = decRawTx.get_obj_for_encoding();
+      if (encodedRawTx === undefined) {
+        throw new Error('encodedRawTx is undefined');
+      }
+
+      const unsignedMultisigTx = algosdk.createRawMultisigTransaction(
+        encodedRawTx,
+        sampleMultisigParams
+      );
+
+      // Check that the unsignedMultisigTx is valid
+      interface ExpectedMultisigTxStructure {
+        msig: {
+          subsig: {
+            pk: Uint8Array;
+            s: Uint8Array;
+          }[];
+        };
+      }
+      const unsignedMultisigTxBlob = algosdk.decodeObj(
+        unsignedMultisigTx
+      ) as ExpectedMultisigTxStructure;
+      assert.deepStrictEqual(
+        unsignedMultisigTxBlob.msig.subsig[0].pk,
+        algosdk.decodeAddress(sampleAccount1.addr).publicKey
+      );
+      assert.strictEqual(unsignedMultisigTxBlob.msig.subsig[1].s, undefined);
+
+      // Sign the raw transaction with a signature generated from the first account
+      const signerAddr = sampleAccount1.addr;
+      const signedTxn = algosdk.appendSignMultisigTransaction(
+        unsignedMultisigTx,
+        sampleMultisigParams,
+        sampleAccount1.sk
+      );
+
+      const multisig = algosdk.decodeSignedTransaction(signedTxn.blob).msig;
+      if (multisig === undefined) {
+        throw new Error('multisig is undefined');
+      }
+
+      const signatures = multisig.subsig;
+      if (signatures === undefined) {
+        throw new Error('No signatures found');
+      }
+
+      const signature = signatures[0].s;
+      if (signature === undefined) {
+        throw new Error('No signature found');
+      }
+      const { txID, blob } = algosdk.appendSignRawMultisigSignature(
+        unsignedMultisigTx,
+        sampleMultisigParams,
+        signerAddr,
+        signature
+      );
+
+      // Check that the signed raw multisig is valid
+      const expectedTxID =
+        'E7DA7WTJCWWFQMKSVU5HOIJ5F5HGVGMOZGBIHRJRYGIX7FIJ5VWA';
+      assert.strictEqual(txID, expectedTxID);
+
+      const expectedBlob = Buffer.from(
+        'gqRtc2lng6ZzdWJzaWeTgqJwa8QgG37AsEvqYbeWkJfmy/QH4QinBTUdC8mKvrEiCairgXihc8RAcT0s17wJbvnza+NpyHwM0RWbQ+HwKmsT1PLs+w6d6MpdTH3tra+yKZE0K0qEyhSE7Y56+B9oaf2orEbjc/njDYGicGvEIAljMglTc4nwdWcRdzmRx9A+G3PIxPUr9q/wGqJc+cJxgaJwa8Qg5/D4TQaBHfnzHI2HixFV9GcdUaGFwgCQhmf0SVhwaKGjdGhyAqF2AaN0eG6Mo2ZlZc4AA8jAomZ2zgAO+dqjZ2VurGRldm5ldC12MzguMKJnaMQg/rNsORAUOQDD2lVCyhg2sA/S+BlZElfNI/YEL5jINp2ibHbOAA79wqZzZWxrZXnEIDISKyvWPdxTMZYXpapTxLHCb+PcyvKNNiK1aXehQFyGo3NuZMQgjZK0iZABc6BN+kNZo2ZqavzqLEKgXdnB9z7rpUeAN+mkdHlwZaZrZXlyZWendm90ZWZzdM4ADbugpnZvdGVrZM0nEKd2b3Rla2V5xCBwG9f7kSsHswgR/ygdn+6VY+WALiAmiSMZJY93+pMeiKd2b3RlbHN0zgAPQkA=',
+        'base64'
+      );
+
+      assert.deepStrictEqual(Buffer.from(blob), expectedBlob);
     });
   });
 

--- a/tests/6.Multisig.ts
+++ b/tests/6.Multisig.ts
@@ -167,6 +167,48 @@ describe('Multisig Functionality', () => {
     });
   });
 
+  describe('appendMultisigTransactionSignature', () => {
+    it('should match golden main repo result', () => {
+      const oneSigTxn = Buffer.from(
+        'gqRtc2lng6ZzdWJzaWeTgqJwa8QgG37AsEvqYbeWkJfmy/QH4QinBTUdC8mKvrEiCairgXihc8RAuLAFE0oma0skOoAmOzEwfPuLYpEWl4LINtsiLrUqWQkDxh4WHb29//YCpj4MFbiSgD2jKYt0XKRD86zKCF4RDYGicGvEIAljMglTc4nwdWcRdzmRx9A+G3PIxPUr9q/wGqJc+cJxgaJwa8Qg5/D4TQaBHfnzHI2HixFV9GcdUaGFwgCQhmf0SVhwaKGjdGhyAqF2AaN0eG6Lo2FtdM0D6KVjbG9zZcQgQOk0koglZMvOnFmmm2dUJonpocOiqepbZabopEIf/FejZmVlzQPoomZ2zfMVo2dlbqxkZXZuZXQtdjM4LjCiZ2jEIP6zbDkQFDkAw9pVQsoYNrAP0vgZWRJXzSP2BC+YyDadomx2zfb9pG5vdGXECEUmIgAYUob7o3JjdsQge2ziT+tbrMCxZOKcIixX9fY9w4fUOQSCWEEcX+EPfAKjc25kxCCNkrSJkAFzoE36Q1mjZmpq/OosQqBd2cH3PuulR4A36aR0eXBlo3BheQ==',
+        'base64'
+      );
+
+      const signerAddr = sampleAccount2.addr;
+      const signedTxn = algosdk.appendSignMultisigTransaction(
+        oneSigTxn,
+        sampleMultisigParams,
+        sampleAccount2.sk
+      );
+      const signatures = algosdk.decodeSignedTransaction(signedTxn.blob).msig
+        ?.subsig;
+      if (signatures === undefined) {
+        throw new Error('No signatures found');
+      }
+      const signature = signatures[1].s;
+      if (signature === undefined) {
+        throw new Error('No signature found');
+      }
+
+      const { txID, blob } = algosdk.appendSignRawMultisigSignature(
+        oneSigTxn,
+        sampleMultisigParams,
+        signerAddr,
+        signature
+      );
+
+      const expectedTxID =
+        'MANN3ESOHQVHFZBAGD6UK6XFVWEFZQJPWO5SQ2J5LZRCF5E2VVQQ';
+      assert.strictEqual(txID, expectedTxID);
+
+      const expectedBlob = Buffer.from(
+        'gqRtc2lng6ZzdWJzaWeTgqJwa8QgG37AsEvqYbeWkJfmy/QH4QinBTUdC8mKvrEiCairgXihc8RAuLAFE0oma0skOoAmOzEwfPuLYpEWl4LINtsiLrUqWQkDxh4WHb29//YCpj4MFbiSgD2jKYt0XKRD86zKCF4RDYKicGvEIAljMglTc4nwdWcRdzmRx9A+G3PIxPUr9q/wGqJc+cJxoXPEQBAhuyRjsOrnHp3s/xI+iMKiL7QPsh8iJZ22YOJJP0aFUwedMr+a6wfdBXk1OefyrAN1wqJ9rq6O+DrWV1fH0ASBonBrxCDn8PhNBoEd+fMcjYeLEVX0Zx1RoYXCAJCGZ/RJWHBooaN0aHICoXYBo3R4boujYW10zQPopWNsb3NlxCBA6TSSiCVky86cWaabZ1Qmiemhw6Kp6ltlpuikQh/8V6NmZWXNA+iiZnbN8xWjZ2VurGRldm5ldC12MzguMKJnaMQg/rNsORAUOQDD2lVCyhg2sA/S+BlZElfNI/YEL5jINp2ibHbN9v2kbm90ZcQIRSYiABhShvujcmN2xCB7bOJP61uswLFk4pwiLFf19j3Dh9Q5BIJYQRxf4Q98AqNzbmTEII2StImQAXOgTfpDWaNmamr86ixCoF3Zwfc+66VHgDfppHR5cGWjcGF5',
+        'base64'
+      );
+      assert.deepStrictEqual(Buffer.from(blob), expectedBlob);
+    });
+  });
+
   describe('should sign keyreg transaction types', () => {
     it('first partial sig should match golden main repo result', () => {
       const rawTxBlob = Buffer.from(

--- a/tests/6.Multisig.ts
+++ b/tests/6.Multisig.ts
@@ -265,7 +265,7 @@ describe('Multisig Functionality', () => {
       );
       const decRawTx = algosdk.decodeUnsignedTransaction(rawTxBlob);
 
-      const unsignedMultisigTx = algosdk.createRawMultisigTransaction(
+      const unsignedMultisigTx = algosdk.createMultisigTransaction(
         decRawTx,
         sampleMultisigParams
       );

--- a/tests/6.Multisig.ts
+++ b/tests/6.Multisig.ts
@@ -264,13 +264,9 @@ describe('Multisig Functionality', () => {
         'base64'
       );
       const decRawTx = algosdk.decodeUnsignedTransaction(rawTxBlob);
-      const encodedRawTx = decRawTx.get_obj_for_encoding();
-      if (encodedRawTx === undefined) {
-        throw new Error('encodedRawTx is undefined');
-      }
 
       const unsignedMultisigTx = algosdk.createRawMultisigTransaction(
-        encodedRawTx,
+        decRawTx,
         sampleMultisigParams
       );
 

--- a/tests/6.Multisig.ts
+++ b/tests/6.Multisig.ts
@@ -168,7 +168,7 @@ describe('Multisig Functionality', () => {
     });
   });
 
-  describe('appendMultisigTransactionSignature', () => {
+  describe('create/append multisig with external signatures', () => {
     it('should match golden main repo result', () => {
       const oneSigTxn = Buffer.from(
         'gqRtc2lng6ZzdWJzaWeTgqJwa8QgG37AsEvqYbeWkJfmy/QH4QinBTUdC8mKvrEiCairgXihc8RAuLAFE0oma0skOoAmOzEwfPuLYpEWl4LINtsiLrUqWQkDxh4WHb29//YCpj4MFbiSgD2jKYt0XKRD86zKCF4RDYGicGvEIAljMglTc4nwdWcRdzmRx9A+G3PIxPUr9q/wGqJc+cJxgaJwa8Qg5/D4TQaBHfnzHI2HixFV9GcdUaGFwgCQhmf0SVhwaKGjdGhyAqF2AaN0eG6Lo2FtdM0D6KVjbG9zZcQgQOk0koglZMvOnFmmm2dUJonpocOiqepbZabopEIf/FejZmVlzQPoomZ2zfMVo2dlbqxkZXZuZXQtdjM4LjCiZ2jEIP6zbDkQFDkAw9pVQsoYNrAP0vgZWRJXzSP2BC+YyDadomx2zfb9pG5vdGXECEUmIgAYUob7o3JjdsQge2ziT+tbrMCxZOKcIixX9fY9w4fUOQSCWEEcX+EPfAKjc25kxCCNkrSJkAFzoE36Q1mjZmpq/OosQqBd2cH3PuulR4A36aR0eXBlo3BheQ==',

--- a/tests/6.Multisig.ts
+++ b/tests/6.Multisig.ts
@@ -180,11 +180,17 @@ describe('Multisig Functionality', () => {
         sampleMultisigParams,
         sampleAccount2.sk
       );
-      const signatures = algosdk.decodeSignedTransaction(signedTxn.blob).msig
-        ?.subsig;
+
+      const multisig = algosdk.decodeSignedTransaction(signedTxn.blob).msig;
+      if (multisig === undefined) {
+        throw new Error('multisig is undefined');
+      }
+
+      const signatures = multisig.subsig;
       if (signatures === undefined) {
         throw new Error('No signatures found');
       }
+
       const signature = signatures[1].s;
       if (signature === undefined) {
         throw new Error('No signature found');

--- a/tests/7.AlgoSDK.js
+++ b/tests/7.AlgoSDK.js
@@ -304,6 +304,36 @@ describe('Algosdk (AKA end to end)', () => {
         algosdk.decodeAddress(signer.addr).publicKey
       );
     });
+
+    it('should not attach signature with incorrect length', () => {
+      const sender = algosdk.generateAccount();
+      const signer = algosdk.generateAccount();
+
+      // Create a transaction
+      const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
+        from: sender.addr,
+        to: signer.addr,
+        amount: 1000,
+        suggestedParams: {
+          firstRound: 12466,
+          lastRound: 13466,
+          genesisID: 'devnet-v33.0',
+          genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
+          fee: 4,
+        },
+      });
+
+      // Sign it directly to get a signature
+      const signedWithSk = txn.signTxn(signer.sk);
+      const decoded = algosdk.decodeObj(signedWithSk);
+      const signature = decoded.sig.slice(0, -1); // without the last byte
+
+      // Check that the signature is not attached
+      assert.throws(
+        () => txn.attachSignature(signer.addr, signature),
+        Error('Invalid signature length')
+      );
+    });
   });
 
   describe('Multisig Sign', () => {

--- a/tests/7.AlgoSDK.js
+++ b/tests/7.AlgoSDK.js
@@ -261,12 +261,48 @@ describe('Algosdk (AKA end to end)', () => {
       const signed = algosdk.signBytes(toSign, account.sk);
       assert.equal(true, algosdk.verifyBytes(toSign, signed, account.addr));
     });
+
     it('should not verify a corrupted signature', () => {
       const account = algosdk.generateAccount();
       const toSign = Buffer.from([1, 9, 25, 49]);
       const signed = algosdk.signBytes(toSign, account.sk);
       signed[0] = (signed[0] + 1) % 256;
       assert.equal(false, algosdk.verifyBytes(toSign, signed, account.addr));
+    });
+
+    it('should attach arbitrary signatures', () => {
+      const sender = algosdk.generateAccount();
+      const signer = algosdk.generateAccount();
+
+      // Create a transaction
+      const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
+        from: sender.addr,
+        to: signer.addr,
+        amount: 1000,
+        suggestedParams: {
+          firstRound: 12466,
+          lastRound: 13466,
+          genesisID: 'devnet-v33.0',
+          genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
+          fee: 4,
+        },
+      });
+
+      // Sign it directly to get a signature
+      const signedWithSk = txn.signTxn(signer.sk);
+      const decoded = algosdk.decodeObj(signedWithSk);
+      const signature = decoded.sig;
+
+      // Attach the signature to the transaction indirectly, and compare
+      const signedWithSignature = txn.attachSignature(signer.addr, signature);
+      assert.deepEqual(signedWithSk, signedWithSignature);
+
+      // Check that signer was set
+      const decodedWithSigner = algosdk.decodeObj(signedWithSignature);
+      assert.deepEqual(
+        decodedWithSigner.sgnr,
+        algosdk.decodeAddress(signer.addr).publicKey
+      );
     });
   });
 


### PR DESCRIPTION
This PR adds an `attachSignature` method to the Transaction class and related external signature methods for multisig transactions.