### PR TITLE
Remove code that relies on node's path module

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -33,17 +33,7 @@ With Vite, you would see:
 Uncaught ReferenceError: Buffer is not defined
 ```
 
-You will have to install `buffer` and `path-browserify` as dependencies.
-
-In `vite.config.js`, specify:
-
-```js
-resolve: {
-  alias: {
-    path: 'path-browserify';
-  }
-}
-```
+You will have to install `buffer` as dependency.
 
 In `index.html`, add the following:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,7 @@
         "js-sha512": "^0.8.0",
         "json-bigint": "^1.0.0",
         "superagent": "^6.1.0",
-        "tweetnacl": "^1.0.3",
-        "url-parse": "^1.5.1"
+        "tweetnacl": "^1.0.3"
       },
       "devDependencies": {
         "@types/json-bigint": "^1.0.0",
@@ -45,7 +44,6 @@
         "mocha": "^9.0.0",
         "mocha-lcov-reporter": "^1.3.0",
         "mock-http-server": "^1.4.3",
-        "path-browserify": "^1.0.1",
         "prettier": "2.2.1",
         "selenium-webdriver": "^4.2.0",
         "source-map-loader": "^2.0.2",
@@ -5782,12 +5780,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/path-browserify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-      "dev": true
-    },
     "node_modules/path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -5996,11 +5988,6 @@
       "engines": {
         "node": ">=0.6"
       }
-    },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -6251,11 +6238,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "node_modules/resolve": {
       "version": "1.20.0",
@@ -7689,15 +7671,6 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/url-parse": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.8.tgz",
-      "integrity": "sha512-9JZ5zDrn9wJoOy/t+rH00HHejbU8dq9VsOYVu272TYDrCiyVAgHKUSpPh3ruZIpv8PMVR+NXLZvfRPJv8xAcQw==",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
       }
     },
     "node_modules/util": {
@@ -12757,12 +12730,6 @@
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "dev": true
     },
-    "path-browserify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-      "dev": true
-    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -12923,11 +12890,6 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
       "dev": true
-    },
-    "querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -13115,11 +13077,6 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
-    },
-    "requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.20.0",
@@ -14230,15 +14187,6 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
-      }
-    },
-    "url-parse": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.8.tgz",
-      "integrity": "sha512-9JZ5zDrn9wJoOy/t+rH00HHejbU8dq9VsOYVu272TYDrCiyVAgHKUSpPh3ruZIpv8PMVR+NXLZvfRPJv8xAcQw==",
-      "requires": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
       }
     },
     "util": {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "js-sha512": "^0.8.0",
     "json-bigint": "^1.0.0",
     "superagent": "^6.1.0",
-    "tweetnacl": "^1.0.3",
-    "url-parse": "^1.5.1"
+    "tweetnacl": "^1.0.3"
   },
   "devDependencies": {
     "@types/json-bigint": "^1.0.0",
@@ -53,7 +52,6 @@
     "mocha": "^9.0.0",
     "mocha-lcov-reporter": "^1.3.0",
     "mock-http-server": "^1.4.3",
-    "path-browserify": "^1.0.1",
     "prettier": "2.2.1",
     "selenium-webdriver": "^4.2.0",
     "source-map-loader": "^2.0.2",

--- a/src/client/urlTokenBaseHTTPClient.ts
+++ b/src/client/urlTokenBaseHTTPClient.ts
@@ -1,5 +1,4 @@
 import Url from 'url-parse';
-import path from 'path';
 import * as request from 'superagent';
 import {
   BaseHTTPClient,
@@ -44,7 +43,13 @@ export class URLTokenBaseHTTPClient implements BaseHTTPClient {
     port?: string | number,
     private defaultHeaders: Record<string, any> = {}
   ) {
-    const baseServerURL = new Url(baseServer, {});
+    // Append a trailing slash so we can use relative paths. Without the trailing
+    // slash, the last path segment will be replaced by the relative path. See
+    // usage in `addressWithPath`.
+    const fixedBaseServer = baseServer.endsWith('/')
+      ? baseServer
+      : `${baseServer}/`;
+    const baseServerURL = new Url(fixedBaseServer);
     if (typeof port !== 'undefined') {
       baseServerURL.set('port', port.toString());
     }
@@ -63,10 +68,15 @@ export class URLTokenBaseHTTPClient implements BaseHTTPClient {
    * @returns A URL string
    */
   private addressWithPath(relativePath: string) {
-    const address = new Url(
-      path.posix.join(this.baseURL.pathname, relativePath),
-      this.baseURL
-    );
+    let fixedRelativePath: string;
+    if (relativePath.startsWith('./')) {
+      fixedRelativePath = relativePath;
+    } else if (relativePath.startsWith('/')) {
+      fixedRelativePath = `.${relativePath}`;
+    } else {
+      fixedRelativePath = `./${relativePath}`;
+    }
+    const address = new Url(fixedRelativePath, this.baseURL);
     return address.toString();
   }
 

--- a/src/client/urlTokenBaseHTTPClient.ts
+++ b/src/client/urlTokenBaseHTTPClient.ts
@@ -1,4 +1,3 @@
-import Url from 'url-parse';
 import * as request from 'superagent';
 import {
   BaseHTTPClient,
@@ -34,7 +33,7 @@ export type TokenHeader =
  * This is the default implementation of BaseHTTPClient.
  */
 export class URLTokenBaseHTTPClient implements BaseHTTPClient {
-  private readonly baseURL: Url;
+  private readonly baseURL: URL;
   private readonly tokenHeader: TokenHeader;
 
   constructor(
@@ -49,9 +48,9 @@ export class URLTokenBaseHTTPClient implements BaseHTTPClient {
     const fixedBaseServer = baseServer.endsWith('/')
       ? baseServer
       : `${baseServer}/`;
-    const baseServerURL = new Url(fixedBaseServer);
+    const baseServerURL = new URL(fixedBaseServer);
     if (typeof port !== 'undefined') {
-      baseServerURL.set('port', port.toString());
+      baseServerURL.port = port.toString();
     }
 
     if (baseServerURL.protocol.length === 0) {
@@ -76,7 +75,7 @@ export class URLTokenBaseHTTPClient implements BaseHTTPClient {
     } else {
       fixedRelativePath = `./${relativePath}`;
     }
-    const address = new Url(fixedRelativePath, this.baseURL);
+    const address = new URL(fixedRelativePath, this.baseURL);
     return address.toString();
   }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,11 +16,6 @@ module.exports = {
   resolve: {
     // Add '.ts' as resolvable extensions
     extensions: ['.ts', '.js'],
-
-    // Support `path` in the browser
-    fallback: {
-      path: require.resolve('path-browserify'),
-    },
   },
   plugins: [
     new webpack.ProvidePlugin({


### PR DESCRIPTION
With the removal of the dependency to node's path module, there's one less thing to 'browserify'. All tests, especially the ones under client url construction, passed. I'll leave the the webpack configuration updates to you all, I guess...