### PR TITLE
perf: waitForConfirmation

### DIFF
--- a/src/wait.ts
+++ b/src/wait.ts
@@ -21,7 +21,7 @@ export async function waitForConfirmation(
   let counter = 0;
 
   /* eslint-disable no-await-in-loop */
-  while (counter < waitRounds) {
+  while (counter <= waitRounds) {
     let pendingInfo = {};
     try {
       pendingInfo = await client.pendingTransactionInformation(txid).do();
@@ -42,7 +42,7 @@ export async function waitForConfirmation(
     }
 
     const status = await client.statusAfterBlock(currentRound).do();
-    currentRound = status['last-round'] + 1;
+    currentRound = ((status && status['last-round']) || currentRound) + 1;
     counter += 1;
   }
   /* eslint-enable no-await-in-loop */

--- a/src/wait.ts
+++ b/src/wait.ts
@@ -42,6 +42,10 @@ export async function waitForConfirmation(
     }
 
     const status = await client.statusAfterBlock(currentRound).do();
+    // wait 2 seconds if we do not get any status back or if currentRound is 0
+    if (!status || !currentRound) {
+      await new Promise<void>((res) => setTimeout(res, 2000));
+    }
     currentRound = ((status && status['last-round']) || currentRound) + 1;
     counter += 1;
   }


### PR DESCRIPTION
This PR addresses some undesirable behavior in the waitForConfirmation function.
- Separation of concerns. The function as it was would throw an error when unable to fetch the node status. This behavior is undocumented and dApps may consider that an error from waitForConfirmation means the transaction has been rejected, when it could be an unrelated issue.
-  It is possible to initialize the loop with a currentRound of 0, fixing the above issue and saving an api call in the process. This is what I did here.