### PR TITLE
docs: tealSign

### DIFF
--- a/src/logicsig.ts
+++ b/src/logicsig.ts
@@ -456,18 +456,18 @@ export function logicSigFromByte(encoded: Uint8Array) {
 const SIGN_PROGRAM_DATA_PREFIX = Buffer.from('ProgData');
 
 /**
- * tealSign creates a signature compatible with ed25519verify opcode from contract address
+ * tealSign creates a signature compatible with ed25519verify opcode from program hash
  * @param sk - uint8array with secret key
  * @param data - buffer with data to sign
- * @param contractAddress - string representation of teal contract address (program hash)
+ * @param programHash - string representation of teal program hash (= contract address for LogicSigs)
  */
 export function tealSign(
   sk: Uint8Array,
   data: Uint8Array | Buffer,
-  contractAddress: string
+  programHash: string
 ) {
   const parts = utils.concatArrays(
-    address.decodeAddress(contractAddress).publicKey,
+    address.decodeAddress(programHash).publicKey,
     data
   );
   const toBeSigned = Buffer.from(


### PR DESCRIPTION
I'm using `ed25519verify` in a stateful app and it took a while to understand the third argument to provide `tealSign` is not the contract address but the program hash. Those are equals for LogicSigs but not for apps. I updated the doc to make it clear.