### PR TITLE
LogicSig test names version consolidation

### DIFF
--- a/tests/8.LogicSig.ts
+++ b/tests/8.LogicSig.ts
@@ -882,7 +882,7 @@ describe('Program validation', () => {
         assert.ok(logic.checkProgram(program));
       }
     });
-    it('should support TEAL v2 opcodes', () => {
+    it('should support AVM v2 opcodes', () => {
       assert.ok(logic.langspecEvalMaxVersion >= 2);
       assert.ok(logic.langspecLogicSigVersion >= 2);
 
@@ -902,7 +902,7 @@ describe('Program validation', () => {
       result = logic.checkProgram(program);
       assert.strictEqual(result, true);
     });
-    it('should support TEAL v3 opcodes', () => {
+    it('should support AVM v3 opcodes', () => {
       assert.ok(logic.langspecEvalMaxVersion >= 3);
       assert.ok(logic.langspecLogicSigVersion >= 3);
 
@@ -952,7 +952,7 @@ describe('Program validation', () => {
       ]); // int 0; int 1; swap; pop
       assert.ok(logic.checkProgram(program));
     });
-    it('should support TEAL v4 opcodes', () => {
+    it('should support AVM v4 opcodes', () => {
       assert.ok(logic.langspecEvalMaxVersion >= 4);
 
       // divmodw
@@ -1071,7 +1071,7 @@ describe('Program validation', () => {
       ]); // int 1; loop: int 2; *; dup; int 10; <; bnz loop; int 16; ==
       assert.ok(logic.checkProgram(program));
     });
-    it('should support TEAL v5 opcodes', () => {
+    it('should support AVM v5 opcodes', () => {
       assert.ok(logic.langspecEvalMaxVersion >= 5);
 
       // itxn ops
@@ -1098,7 +1098,7 @@ describe('Program validation', () => {
       // byte "a"; byte "b"; byte "c"; cover 2; uncover 2; concat; concat; log; int 1
       assert.ok(logic.checkProgram(program));
     });
-    it('should support TEAL v6 opcodes', () => {
+    it('should support AVM v6 opcodes', () => {
       assert.ok(logic.langspecEvalMaxVersion >= 6);
 
       // bsqrt op


### PR DESCRIPTION
This PR adds additional version consolidation changes to the [existing TEAL/AVM language consolidation PR](https://github.com/algorand/js-algorand-sdk/pull/609).