### PR TITLE
Testing: Use Dev mode network for cucumber tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ unit:
 	node_modules/.bin/cucumber-js --tags "@unit.offline or @unit.algod or @unit.indexer or @unit.rekey or @unit.tealsign or @unit.dryrun or @unit.applications or @unit.responses or @unit.transactions or @unit.transactions.keyreg or @unit.transactions.payment or @unit.responses.231 or @unit.feetest or @unit.indexer.logs or @unit.abijson or @unit.abijson.byname or @unit.atomic_transaction_composer or @unit.responses.unlimited_assets or @unit.indexer.ledger_refactoring or @unit.algod.ledger_refactoring or @unit.dryrun.trace.application or @unit.sourcemap" tests/cucumber/features --require-module ts-node/register --require tests/cucumber/steps/index.js
 	
 integration:
-	node_modules/.bin/cucumber-js --tags "@algod or @assets or @auction or @kmd or @send or @indexer or @rekey or @send.keyregtxn or @dryrun or @compile or @applications or @indexer.applications or @applications.verified or @indexer.231 or @abi or @c2c or @compile.sourcemap" tests/cucumber/features --require-module ts-node/register --require tests/cucumber/steps/index.js
+	node_modules/.bin/cucumber-js --tags "@algod or @assets or @auction or @kmd or @send or @indexer or @rekey_v1 or @send.keyregtxn or @dryrun or @compile or @applications or @indexer.applications or @applications.verified or @indexer.231 or @abi or @c2c or @compile.sourcemap" tests/cucumber/features --require-module ts-node/register --require tests/cucumber/steps/index.js
 
 docker-test:
 	./tests/cucumber/docker/run_docker.sh

--- a/tests/cucumber/docker/run_docker.sh
+++ b/tests/cucumber/docker/run_docker.sh
@@ -7,10 +7,7 @@ rm -rf test-harness
 rm -rf tests/cucumber/features
 
 # clone test harness
-git clone --single-branch --branch devmodenet https://github.com/algorand/algorand-sdk-testing.git test-harness
-
-# Export env variable so network is set to dev mode
-export NETWORK_TEMPLATE="DevModeNetwork.json"
+git clone --single-branch --branch master https://github.com/algorand/algorand-sdk-testing.git test-harness
 
 # move feature files and example files to destination
 mv test-harness/features tests/cucumber/features

--- a/tests/cucumber/docker/run_docker.sh
+++ b/tests/cucumber/docker/run_docker.sh
@@ -7,7 +7,7 @@ rm -rf test-harness
 rm -rf tests/cucumber/features
 
 # clone test harness
-git clone --single-branch --branch master https://github.com/algorand/algorand-sdk-testing.git test-harness
+git clone --single-branch --branch devmodenet https://github.com/algorand/algorand-sdk-testing.git test-harness
 
 # move feature files and example files to destination
 mv test-harness/features tests/cucumber/features

--- a/tests/cucumber/docker/run_docker.sh
+++ b/tests/cucumber/docker/run_docker.sh
@@ -9,6 +9,9 @@ rm -rf tests/cucumber/features
 # clone test harness
 git clone --single-branch --branch devmodenet https://github.com/algorand/algorand-sdk-testing.git test-harness
 
+# Export env variable so network is set to dev mode
+export NETWORK_TEMPLATE="DevModeNetwork.json"
+
 # move feature files and example files to destination
 mv test-harness/features tests/cucumber/features
 

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -90,9 +90,6 @@ const steps = {
   then: {},
 };
 
-// Dev Mode State
-const DEV_MODE_INITIAL_MICROALGOS = 10_000_000;
-
 /**
  * The getSteps function defines the cucumber steps and returns them.
  *
@@ -128,30 +125,10 @@ module.exports = function getSteps(options) {
     steps.then[name] = fn;
   }
 
-  const { algod_token: algodToken, kmd_token: kmdToken } = options;
+  // Dev Mode State
+  const DEV_MODE_INITIAL_MICROALGOS = 10_000_000;
 
-  // function initializeAccount(client) {
-  //   const sp = await client.getTransactionParams().do();
-  //   if (sp.firstRound === 0) sp.firstRound = 1;
-  //   const fundingTxnArgs = {
-  //     from: this.accounts[0],
-  //     to: this.accounts[0],
-  //     amount: 0,
-  //     suggestedParams: sp,
-  //   };
-  //   const stxKmd = await this.kcl.signTransaction(
-  //     this.handle,
-  //     this.wallet_pswd,
-  //     fundingTxnArgs
-  //   );
-  //   const fundingResponse = await this.v2Client.sendRawTransaction(stxKmd).do();
-  //   const info = await algosdk.waitForConfirmation(
-  //     this.v2Client,
-  //     fundingResponse.txId,
-  //     1
-  //   );
-  //   assert.ok(info['confirmed-round'] > 0);
-  // }
+  const { algod_token: algodToken, kmd_token: kmdToken } = options;
 
   Given('an algod client', async function () {
     this.acl = new algosdk.Algod(algodToken, 'http://localhost', 60000);

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -903,7 +903,22 @@ module.exports = function getSteps(options) {
   });
 
   Then('I can get the transaction by ID', async function () {
-    // await this.acl.statusAfterBlock(this.lastRound + 2);
+    // Send a transaction to advance blocks in dev mode.
+    const sp = await this.v2Client.getTransactionParams().do();
+    if (sp.firstRound === 0) sp.firstRound = 1;
+    const fundingTxnArgs = {
+      from: this.accounts[0],
+      to: this.accounts[0],
+      amount: 0,
+      suggestedParams: sp,
+    };
+    const stxKmd = await this.kcl.signTransaction(
+      this.handle,
+      this.wallet_pswd,
+      fundingTxnArgs
+    );
+    await this.v2Client.sendRawTransaction(stxKmd).do();
+
     const info = await this.acl.transactionById(this.txid);
     assert.deepStrictEqual(true, 'type' in info);
   });

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -133,7 +133,7 @@ module.exports = function getSteps(options) {
    * Since Dev mode produces blocks on a per transaction basis, it's possible
    * algod generates a block _before_ the corresponding SDK call to wait for a block.
    * Without _any_ wait, it's possible the SDK looks for the transaction before algod completes processing.
-   * So, the method performs a local sleep (0.5s) to simulate waiting for a block.
+   * So, the method performs a local sleep to simulate waiting for a block.
    */
   function waitForAlgodInDevMode() {
     return new Promise((resolve) => setTimeout(resolve, 500));
@@ -885,10 +885,10 @@ module.exports = function getSteps(options) {
 
   Then('the transaction should go through', async function () {
     waitForAlgodInDevMode();
-    let info = await this.acl.pendingTransactionInformation(this.txid);
+    const info = await this.acl.pendingTransactionInformation(this.txid);
     assert.deepStrictEqual(true, 'type' in info);
-    info = await this.acl.transactionById(this.txid);
-    assert.deepStrictEqual(true, 'type' in info);
+    // info = await this.acl.transactionById(this.txid);
+    // assert.deepStrictEqual(true, 'type' in info);
   });
 
   Then('I can get the transaction by ID', async function () {

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -127,58 +127,6 @@ module.exports = function getSteps(options) {
 
   const { algod_token: algodToken, kmd_token: kmdToken } = options;
 
-  async function sendZeroTransaction() {
-    // TODO: Refactor this and pass in the client objects.
-    if (this.v2Client == null) {
-      this.v2Client = new algosdk.Algodv2(
-        algodToken,
-        'http://localhost',
-        60000
-      );
-    }
-    if (this.kcl == null) {
-      this.kcl = new algosdk.Kmd(kmdToken, 'http://localhost', 60001);
-      this.wallet_name = 'unencrypted-default-wallet';
-      this.wallet_pswd = '';
-
-      const result = await this.kcl.listWallets();
-      for (let i = 0; i < result.wallets.length; i++) {
-        const w = result.wallets[i];
-        if (w.name === this.wallet_name) {
-          this.wallet_id = w.id;
-          break;
-        }
-      }
-      this.handle = await this.kcl.initWalletHandle(
-        this.wallet_id,
-        this.wallet_pswd
-      );
-      this.handle = this.handle.wallet_handle_token;
-      this.accounts = await this.kcl.listKeys(this.handle);
-      this.accounts = this.accounts.addresses;
-    }
-    const sp = await this.v2Client.getTransactionParams().do();
-    if (sp.firstRound === 0) sp.firstRound = 1;
-    const fundingTxnArgs = {
-      from: this.accounts[0],
-      to: this.accounts[0],
-      amount: 0,
-      suggestedParams: sp,
-    };
-    const stxKmd = await this.kcl.signTransaction(
-      this.handle,
-      this.wallet_pswd,
-      fundingTxnArgs
-    );
-    const fundingResponse = await this.v2Client.sendRawTransaction(stxKmd).do();
-    const info = await algosdk.waitForConfirmation(
-      this.v2Client,
-      fundingResponse.txId,
-      1
-    );
-    assert.ok(info['confirmed-round'] > 0);
-  }
-
   Given('an algod client', async function () {
     this.acl = new algosdk.Algod(algodToken, 'http://localhost', 60000);
     this.v2Client = new algosdk.Algodv2(algodToken, 'http://localhost', 60000);
@@ -238,7 +186,28 @@ module.exports = function getSteps(options) {
   });
 
   When('I get status after this block', async function () {
-    sendZeroTransaction();
+    // Send a transaction to advance blocks in dev mode.
+    const sp = await this.v2Client.getTransactionParams().do();
+    if (sp.firstRound === 0) sp.firstRound = 1;
+    const fundingTxnArgs = {
+      from: this.accounts[0],
+      to: this.accounts[0],
+      amount: 0,
+      suggestedParams: sp,
+    };
+    const stxKmd = await this.kcl.signTransaction(
+      this.handle,
+      this.wallet_pswd,
+      fundingTxnArgs
+    );
+    const fundingResponse = await this.v2Client.sendRawTransaction(stxKmd).do();
+    const info = await algosdk.waitForConfirmation(
+      this.v2Client,
+      fundingResponse.txId,
+      1
+    );
+    assert.ok(info['confirmed-round'] > 0);
+
     this.statusAfter = await this.acl.statusAfterBlock(this.status.lastRound);
     return this.statusAfter;
   });


### PR DESCRIPTION
This PR aims to allow Dev mode network to be used in cucumber tests to speed up testing time. 

Cucumber's `this` and `World` objects seem to be bound to the steps, so I refrained from using helper methods that rely on state associated with the cucumber's world/this object. This PR also removes some `statusAfterBlock` v1 API calls, as they seem to be more flaky in dev mode, and often a redundant step in the scheme of the entire cucumber scenario. 
