### PR TITLE
Add missing await for async function calls

### DIFF
--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -881,11 +881,13 @@ module.exports = function getSteps(options) {
   });
 
   Then('the transaction should go through', async function () {
-    waitForAlgodInDevMode();
-    const info = await this.acl.pendingTransactionInformation(this.txid);
+    let info = await this.acl.pendingTransactionInformation(this.txid);
     assert.deepStrictEqual(true, 'type' in info);
-    // info = await this.acl.transactionById(this.txid);
-    // assert.deepStrictEqual(true, 'type' in info);
+    // let localParams = await this.acl.getTransactionParams();
+    // this.lastRound = localParams.lastRound;
+    waitForAlgodInDevMode();
+    info = await this.acl.transactionById(this.txid);
+    assert.deepStrictEqual(true, 'type' in info);
   });
 
   Then('I can get the transaction by ID', async function () {

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -885,13 +885,13 @@ module.exports = function getSteps(options) {
     assert.deepStrictEqual(true, 'type' in info);
     // let localParams = await this.acl.getTransactionParams();
     // this.lastRound = localParams.lastRound;
-    waitForAlgodInDevMode();
+    await waitForAlgodInDevMode();
     info = await this.acl.transactionById(this.txid);
     assert.deepStrictEqual(true, 'type' in info);
   });
 
   Then('I can get the transaction by ID', async function () {
-    waitForAlgodInDevMode();
+    await waitForAlgodInDevMode();
     const info = await this.acl.transactionById(this.txid);
     assert.deepStrictEqual(true, 'type' in info);
   });


### PR DESCRIPTION
Extends #614 to add `await` to `waitForAlgodInDevMode` invocations.  Webstorm IDE warnings pointed out the async call is missing `await`.

Additionally, the PR reverts interactions in _the transaction should go through_ to mirror prior to #614.  I think the shuffling in #614 is not necessary. 