### PR TITLE
Tidy:  Ignore algorand-sdk-testing test-harness dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ temp
 # Environment information
 examples/.env
 
+test-harness/
 tests/cucumber/features/
 tests/cucumber/browser/build
 tests/browser/bundle.*


### PR DESCRIPTION
Adds a `.gitignore` entry for directory created by algorand-sdk-testing:  `test-harness/` matching the convention in other SDKs.