### PR TITLE
API: Fix docs typo

### DIFF
--- a/src/client/v2/algod/algod.ts
+++ b/src/client/v2/algod/algod.ts
@@ -172,7 +172,7 @@ export default class AlgodClient extends ServiceClient {
    * ```typescript
    * const address = "XBYLS2E6YI6XXL5BWCAMOA4GTWHXWENZMX5UHXMRNWWUQ7BXCY5WC5TEPA";
    * const index = 60553466;
-   * const accountInfo = await algodClient.accountApplicationInformation(address).do();
+   * const accountInfo = await algodClient.accountApplicationInformation(address, index).do();
    * ```
    *
    * [Response data schema details](https://developer.algorand.org/docs/rest-apis/algod/v2/#get-v2accountsaddress)


### PR DESCRIPTION
I found another typo in your docs😂. I tested that it's not overloaded throwing this error `Invalid format for parameter application-id: error binding string parameter: strconv.ParseUint: parsing "undefined": invalid syntax`