### PR TITLE
CI:  Upgrade node.js from v12 to v14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ commands:
             << parameters.sudo >> apt -y update
             << parameters.sudo >> apt -y install curl make git build-essential jq unzip
       - node/install:
-          node-version: '12'
+          node-version: '14'
       - run:
           name: npm ci
           command: |

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -80,5 +80,8 @@
     "example": "ts-node"
   },
   "author": "Algorand, llc",
-  "license": "MIT"
+  "license": "MIT",
+  "engines": {
+    "node": ">=14.0.0"
+  }
 }

--- a/tests/cucumber/docker/Dockerfile
+++ b/tests/cucumber/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
   && apt-get -qqy --no-install-recommends install google-chrome-stable firefox
 
 # install node
-RUN wget -q -O - https://deb.nodesource.com/setup_12.x | bash \
+RUN wget -q -O - https://deb.nodesource.com/setup_14.x | bash \
   && apt-get -qqy --no-install-recommends install nodejs \
   && echo "node version: $(node --version)" \
   && echo "npm version: $(npm --version)"


### PR DESCRIPTION
Upgrades node.js from v12 to v14 for several reasons:
* Per https://endoflife.date/nodejs, v14 is the oldest actively supported version.  v12 is EOL.
* https://github.com/giggio/node-chromedriver no longer supports < v14 as evidenced by the following failed build:   https://app.circleci.com/pipelines/github/algorand/js-algorand-sdk/689/workflows/c78c8140-c32d-4706-abee-f0ec8f88b837/jobs/3993.  A quick scan shows the project no longer builds against v12:  https://github.com/giggio/node-chromedriver/commit/ebe7524dcf334a7277a1ac2aed7a6f59389a5b0f.