### PR TITLE
CI: Remove unneeded dependency & update package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,9 @@
         "webpack": "^5.38.1",
         "webpack-cli": "^4.7.2"
       },
+      "engines": {
+        "node": ">=14.0.0"
+      },
       "optionalDependencies": {
         "fsevents": "2.1.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,9 +58,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.1.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3344,20 +3341,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "node_modules/fsevents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
-      "deprecated": "\"Please update to latest v2.3 or v2.2\"",
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -10838,12 +10821,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "fsevents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
-      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -28,9 +28,6 @@
     "tweetnacl": "^1.0.3",
     "vlq": "^2.0.4"
   },
-  "optionalDependencies": {
-    "fsevents": "2.1.2"
-  },
   "devDependencies": {
     "@types/json-bigint": "^1.0.0",
     "@types/mocha": "^8.2.2",


### PR DESCRIPTION
This PR does two things:
* Update `package-lock.json` with the `engines` property introduced by #680
* Remove the `fsevents` optional dependency unintentionally introduced in #590