### PR TITLE
Fix: createMultisigTransaction name in comments

### DIFF
--- a/src/multisig.ts
+++ b/src/multisig.ts
@@ -42,7 +42,7 @@ interface MultisigMetadataWithPks extends Omit<MultisigMetadata, 'addrs'> {
 }
 
 /**
- * createRawMultisigTransaction creates a raw, unsigned multisig transaction blob.
+ * createMultisigTransaction creates a raw, unsigned multisig transaction blob.
  * @param txn - the actual transaction.
  * @param version - multisig version
  * @param threshold - multisig threshold


### PR DESCRIPTION
I didn't see this function in the docs, is it because the name doesn't match?