### PR TITLE
Add LogicSig usage disclaimer

### DIFF
--- a/src/logicsig.ts
+++ b/src/logicsig.ts
@@ -54,6 +54,8 @@ export function sanityCheckProgram(program: Uint8Array) {
 
 /**
  LogicSig implementation
+
+ LogicSig cannot sign transactions in all cases.  Instead, use LogicSigAccount as a safe, general purpose signing mechanism.  Since LogicSig does not track the provided signature's public key, LogicSig cannot sign transactions when delegated to a non-multisig account _and_ the sender is not the delegating account.
  */
 export class LogicSig implements LogicSigStorageStructure {
   tag = Buffer.from('Program');


### PR DESCRIPTION
Adds LogicSig usage disclaimer suggesting LogicSigAccount usage as a more general purpose signing mechanism.