### PR TITLE
New Feature: able to generate wallets deterministically

### DIFF
--- a/src/account.ts
+++ b/src/account.ts
@@ -10,3 +10,12 @@ export default function generateAccount(): Account {
   const encodedPk = address.encodeAddress(keys.publicKey);
   return { addr: encodedPk, sk: keys.secretKey };
 }
+
+/**
+ * generateAccountFromSeed returns a new Algorand address and its corresponding secret key deterministically given a Uint8Array seed value
+ */
+export function generateAccountFromSeed(seed: Uint8Array): Account {
+  const keys = nacl.keyPairFromSeed(seed);
+  const encodedPk = address.encodeAddress(keys.publicKey);
+  return { addr: encodedPk, sk: keys.secretKey };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -135,7 +135,7 @@ export {
 } from './encoding/address';
 export { bytesToBigInt, bigIntToBytes } from './encoding/bigint';
 export { encodeUint64, decodeUint64 } from './encoding/uint64';
-export { default as generateAccount } from './account';
+export { default as generateAccount, generateAccountFromSeed } from './account';
 export * as modelsv2 from './client/v2/algod/models/types';
 export * as indexerModels from './client/v2/indexer/models/types';
 export {


### PR DESCRIPTION
Iv ran into a case where I need to be able to generate accounts in a deterministic way. I have seen other people keep a JSON file of Accounts before. That sounds like a pain, and it would be much cleaner to just have people come up with their own pre-determined seed generation and generate accounts using this function.

```
const deterministicAccounts = [];
for (let i = 0; i < 32; i++) {
  const bytesArr = new Uint8Array(new Array(32).fill(0));
  bytesArr.set(encodeUint64(i), 24);
  deterministicAccounts.push(algosdk.generateAccountFromSeed(bytesArr));
}
//deterministicAccounts now contains 32 accounts that are the same accounts every time I run my unit tests.
```
