### PR TITLE
Enhancement: Add foreign array objects to ATC `addMethodCall`

### DIFF
--- a/src/composer.ts
+++ b/src/composer.ts
@@ -379,10 +379,12 @@ export class AtomicTransactionComposer {
     }
 
     const resolvedRefIndexes: number[] = [];
-    const foreignAccounts: string[] = appAccounts == null ? [] : appAccounts;
-    const foreignApps: number[] = appForeignApps == null ? [] : appForeignApps;
+    const foreignAccounts: string[] =
+      appAccounts == null ? [] : appAccounts.slice();
+    const foreignApps: number[] =
+      appForeignApps == null ? [] : appForeignApps.slice();
     const foreignAssets: number[] =
-      appForeignAssets == null ? [] : appForeignAssets;
+      appForeignAssets == null ? [] : appForeignAssets.slice();
     for (let i = 0; i < refArgTypes.length; i++) {
       const refType = refArgTypes[i];
       const refValue = refArgValues[i];

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -202,6 +202,9 @@ export class AtomicTransactionComposer {
     numLocalInts,
     numLocalByteSlices,
     extraPages,
+    appAccounts,
+    appForeignApps,
+    appForeignAssets,
     boxes,
     note,
     lease,
@@ -234,6 +237,12 @@ export class AtomicTransactionComposer {
     numLocalByteSlices?: number;
     /** The number of extra pages to allocate for the application's programs. Only set this if this is an application creation call. If omitted, defaults to 0. */
     extraPages?: number;
+    /** Array of Address strings that represent external accounts supplied to this application. If accounts are provided here, the accounts specified in the method args will appear after these. */
+    appAccounts?: string[];
+    /** Array of App ID numbers that represent external apps supplied to this application. If apps are provided here, the apps specified in the method args will appear after these. */
+    appForeignApps?: number[];
+    /** Array of Asset ID numbers that represent external assets supplied to this application. If assets are provided here, the assets specified in the method args will appear after these. */
+    appForeignAssets?: number[];
     /** The box references for this application call */
     boxes?: BoxReference[];
     /** The note value for this application call */
@@ -370,9 +379,10 @@ export class AtomicTransactionComposer {
     }
 
     const resolvedRefIndexes: number[] = [];
-    const foreignAccounts: string[] = [];
-    const foreignApps: number[] = [];
-    const foreignAssets: number[] = [];
+    const foreignAccounts: string[] = appAccounts == null ? [] : appAccounts;
+    const foreignApps: number[] = appForeignApps == null ? [] : appForeignApps;
+    const foreignAssets: number[] =
+      appForeignAssets == null ? [] : appForeignAssets;
     for (let i = 0; i < refArgTypes.length; i++) {
       const refType = refArgTypes[i];
       const refValue = refArgValues[i];


### PR DESCRIPTION
This PR adds foreign array objects as arguments in `addMethodCall()` for the atomic transaction composer.

Adds a test that mirrors the Go SDK: https://github.com/algorand/go-algorand-sdk/pull/318. Currently written as a unit test, but could also benefit from a cucumber test since all the other SDKs implement this. 

Addresses #653 