### PR TITLE
Packaging: Don't use global `Buffer` object

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,17 +1,31 @@
 module.exports = {
   env: {
-    browser: true,
     es2021: true,
-    node: true,
-    mocha: true,
+    'shared-node-browser': true,
   },
-  extends: ['airbnb-base', 'prettier', 'plugin:import/typescript'],
+  extends: [
+    'airbnb-base',
+    'prettier',
+    'plugin:import/typescript',
+    'eslint:recommended',
+  ],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 12,
   },
   plugins: ['@typescript-eslint', 'eslint-plugin-tsdoc'],
   rules: {
+    'no-restricted-globals': [
+      'error',
+      {
+        // This is to ensure that we use the 'buffer' package in the browser. In Node it doesn't
+        // make a difference.
+        name: 'Buffer',
+        message:
+          "Explictly import Buffer with `import { Buffer } from 'buffer'`",
+      },
+    ],
+    'no-constant-condition': ['error', { checkLoops: false }],
     'no-restricted-syntax': ['error', 'LabeledStatement', 'WithStatement'],
     'no-plusplus': ['error', { allowForLoopAfterthoughts: true }],
     'max-classes-per-file': 'off',

--- a/examples/app_transaction_examples.js
+++ b/examples/app_transaction_examples.js
@@ -5,6 +5,7 @@
 // makeApplicationCreateTxnFromObject, makeApplicationOptInTxnFromObject, etc.
 // counterparts in your code for readability.
 
+const { Buffer } = require('buffer');
 const algosdk = require('../src');
 const utils = require('./utils');
 

--- a/examples/asset_create_example.js
+++ b/examples/asset_create_example.js
@@ -1,5 +1,6 @@
 // Example: creating an asset
 
+const { Buffer } = require('buffer');
 const algosdk = require('../src');
 const utils = require('./utils');
 

--- a/examples/logic_sig_example.js
+++ b/examples/logic_sig_example.js
@@ -1,5 +1,6 @@
 // Example: creating a LogicSig transaction signed by a program that never approves the transfer.
 
+const { Buffer } = require('buffer');
 const algosdk = require('../src');
 const utils = require('./utils');
 

--- a/examples/notefield_example.js
+++ b/examples/notefield_example.js
@@ -5,6 +5,7 @@
  * want in the "note" field.
  */
 
+const { Buffer } = require('buffer');
 const algosdk = require('../src');
 const utils = require('./utils');
 

--- a/examples/typescript_example.ts
+++ b/examples/typescript_example.ts
@@ -1,5 +1,6 @@
 // Example: with TypeScript
 
+import { Buffer } from 'buffer';
 import algosdk from '../src';
 import utils from './utils';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "algo-msgpack-with-bigint": "^2.1.1",
-        "buffer": "^6.0.2",
+        "buffer": "^6.0.3",
         "cross-fetch": "^3.1.5",
         "hi-base32": "^0.5.1",
         "js-sha256": "^0.9.0",
@@ -23,7 +23,6 @@
       "devDependencies": {
         "@types/json-bigint": "^1.0.0",
         "@types/mocha": "^8.2.2",
-        "@types/url-parse": "^1.4.3",
         "@typescript-eslint/eslint-plugin": "^4.26.1",
         "@typescript-eslint/parser": "^4.26.1",
         "assert": "^2.0.0",
@@ -454,12 +453,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/url-parse": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@types/url-parse/-/url-parse-1.4.3.tgz",
-      "integrity": "sha512-4kHAkbV/OfW2kb5BLVUuUMoumB3CP8rHqlw48aHvFy5tf9ER0AfOonBlX29l/DD68G70DmyhRlSYfQPSYpC5Vw==",
-      "dev": true
     },
     "node_modules/@types/yauzl": {
       "version": "2.9.1",
@@ -8525,12 +8518,6 @@
       "requires": {
         "@types/node": "*"
       }
-    },
-    "@types/url-parse": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@types/url-parse/-/url-parse-1.4.3.tgz",
-      "integrity": "sha512-4kHAkbV/OfW2kb5BLVUuUMoumB3CP8rHqlw48aHvFy5tf9ER0AfOonBlX29l/DD68G70DmyhRlSYfQPSYpC5Vw==",
-      "dev": true
     },
     "@types/yauzl": {
       "version": "2.9.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "algo-msgpack-with-bigint": "^2.1.1",
-    "buffer": "^6.0.2",
+    "buffer": "^6.0.3",
     "cross-fetch": "^3.1.5",
     "hi-base32": "^0.5.1",
     "js-sha256": "^0.9.0",
@@ -35,7 +35,6 @@
   "devDependencies": {
     "@types/json-bigint": "^1.0.0",
     "@types/mocha": "^8.2.2",
-    "@types/url-parse": "^1.4.3",
     "@typescript-eslint/eslint-plugin": "^4.26.1",
     "@typescript-eslint/parser": "^4.26.1",
     "assert": "^2.0.0",

--- a/src/abi/abi_type.ts
+++ b/src/abi/abi_type.ts
@@ -13,6 +13,7 @@
     // | string
     // | (T1, ..., Tn)
 */
+import { Buffer } from 'buffer';
 import { encodeAddress, decodeAddress } from '../encoding/address';
 import { bigIntToBytes, bytesToBigInt } from '../encoding/bigint';
 import { concatArrays } from '../utils/utils';

--- a/src/bid.ts
+++ b/src/bid.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import * as address from './encoding/address';
 import * as encoding from './encoding/encoding';
 import * as nacl from './nacl/naclWrappers';

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import * as utils from '../utils/utils';
 import {
   BaseHTTPClient,

--- a/src/client/kmd.ts
+++ b/src/client/kmd.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import ServiceClient from './v2/serviceClient';
 import * as txn from '../transaction';
 import { CustomTokenHeader, KMDTokenHeader } from './urlTokenBaseHTTPClient';

--- a/src/client/urlTokenBaseHTTPClient.ts
+++ b/src/client/urlTokenBaseHTTPClient.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import { fetch, Response, Headers } from 'cross-fetch';
 import {
   BaseHTTPClient,

--- a/src/client/v2/algod/compile.ts
+++ b/src/client/v2/algod/compile.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import JSONRequest from '../jsonrequest';
 import HTTPClient from '../../client';
 

--- a/src/client/v2/algod/dryrun.ts
+++ b/src/client/v2/algod/dryrun.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import JSONRequest from '../jsonrequest';
 import HTTPClient from '../../client';
 import * as modelsv2 from './models/types';

--- a/src/client/v2/algod/getApplicationBoxByName.ts
+++ b/src/client/v2/algod/getApplicationBoxByName.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import JSONRequest from '../jsonrequest';
 import HTTPClient from '../../client';
 import IntDecoding from '../../../types/intDecoding';

--- a/src/client/v2/algod/models/types.ts
+++ b/src/client/v2/algod/models/types.ts
@@ -3,6 +3,7 @@
  */
 
 /* eslint-disable no-use-before-define */
+import { Buffer } from 'buffer';
 import BaseModel from '../../basemodel';
 import { EncodedSignedTransaction } from '../../../../types/transactions/encoded';
 import BlockHeader from '../../../../types/blockHeader';

--- a/src/client/v2/algod/sendRawTransaction.ts
+++ b/src/client/v2/algod/sendRawTransaction.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import JSONRequest from '../jsonrequest';
 import HTTPClient from '../../client';
 import { concatArrays } from '../../../utils/utils';

--- a/src/client/v2/basemodel.ts
+++ b/src/client/v2/basemodel.ts
@@ -1,3 +1,5 @@
+import { Buffer } from 'buffer';
+
 /**
  * Base class for models
  */

--- a/src/client/v2/indexer/lookupAccountTransactions.ts
+++ b/src/client/v2/indexer/lookupAccountTransactions.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import JSONRequest from '../jsonrequest';
 import HTTPClient from '../../client';
 import IntDecoding from '../../../types/intDecoding';

--- a/src/client/v2/indexer/lookupApplicationBoxByIDandName.ts
+++ b/src/client/v2/indexer/lookupApplicationBoxByIDandName.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import JSONRequest from '../jsonrequest';
 import HTTPClient from '../../client';
 import IntDecoding from '../../../types/intDecoding';

--- a/src/client/v2/indexer/models/types.ts
+++ b/src/client/v2/indexer/models/types.ts
@@ -3,6 +3,7 @@
  */
 
 /* eslint-disable no-use-before-define */
+import { Buffer } from 'buffer';
 import BaseModel from '../../basemodel';
 
 /**

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import {
   ABIType,
   ABITupleType,

--- a/src/dryrun.ts
+++ b/src/dryrun.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import AlgodClient from './client/v2/algod/algod';
 import {
   AccountStateDelta,

--- a/src/encoding/address.ts
+++ b/src/encoding/address.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import base32 from 'hi-base32';
 import * as nacl from '../nacl/naclWrappers';
 import * as utils from '../utils/utils';

--- a/src/encoding/bigint.ts
+++ b/src/encoding/bigint.ts
@@ -1,3 +1,5 @@
+import { Buffer } from 'buffer';
+
 /**
  * bigIntToBytes converts a BigInt to a big-endian Uint8Array for encoding.
  * @param bi - The bigint to convert.

--- a/src/encoding/uint64.ts
+++ b/src/encoding/uint64.ts
@@ -1,9 +1,9 @@
 import { concatArrays } from '../utils/utils';
 
 // NOTE: at the moment we specifically do not use Buffer.writeBigUInt64BE and
-// Buffer.getBigUint64. This is because projects using webpack v4 automatically
-// include an old version of the npm `buffer` package (v4.9.2 at the time of
-// writing), and this old version does not have these methods.
+// Buffer.readBigUInt64BE. This is because projects using webpack v4
+// automatically include an old version of the npm `buffer` package (v4.9.2 at
+// the time of writing), and this old version does not have these methods.
 
 /**
  * encodeUint64 converts an integer to its binary representation.

--- a/src/encoding/uint64.ts
+++ b/src/encoding/uint64.ts
@@ -1,3 +1,5 @@
+import { Buffer } from 'buffer';
+
 /**
  * encodeUint64 converts an integer to its binary representation.
  * @param num - The number to convert. This must be an unsigned integer less than
@@ -65,7 +67,7 @@ export function decodeUint64(data: any, decodingMode: any = 'safe') {
   const buf = Buffer.concat([padding, Buffer.from(data)]);
 
   const num = buf.readBigUInt64BE();
-  const isBig = num > Number.MAX_SAFE_INTEGER;
+  const isBig = num > BigInt(Number.MAX_SAFE_INTEGER);
 
   if (decodingMode === 'safe') {
     if (isBig) {

--- a/src/group.ts
+++ b/src/group.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import * as txnBuilder from './transaction';
 import * as nacl from './nacl/naclWrappers';
 import * as encoding from './encoding/encoding';

--- a/src/logicsig.ts
+++ b/src/logicsig.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import * as nacl from './nacl/naclWrappers';
 import * as address from './encoding/address';
 import * as encoding from './encoding/encoding';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import * as nacl from './nacl/naclWrappers';
 import * as address from './encoding/address';
 import * as encoding from './encoding/encoding';

--- a/src/multisig.ts
+++ b/src/multisig.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import * as nacl from './nacl/naclWrappers';
 import * as address from './encoding/address';
 import * as encoding from './encoding/encoding';

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import base32 from 'hi-base32';
 import * as address from './encoding/address';
 import * as encoding from './encoding/encoding';

--- a/src/types/transactions/encoded.ts
+++ b/src/types/transactions/encoded.ts
@@ -1,3 +1,5 @@
+import { Buffer } from 'buffer';
+
 /**
  * Interfaces for the encoded transaction object. Every property is labelled with its associated Transaction type property
  */

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -114,8 +114,11 @@ export function removeUndefinedProperties(
  */
 export function isNode() {
   return (
+    // @ts-ignore
     typeof process === 'object' &&
+    // @ts-ignore
     typeof process.versions === 'object' &&
+    // @ts-ignore
     typeof process.versions.node !== 'undefined'
   );
 }

--- a/tests/1.Mnemonics_test.js
+++ b/tests/1.Mnemonics_test.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 const assert = require('assert');
 const algosdk = require('../src/index');
 const nacl = require('../src/nacl/naclWrappers');

--- a/tests/10.ABI.ts
+++ b/tests/10.ABI.ts
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 import assert from 'assert';
 import {
   ABIAddressType,

--- a/tests/2.Encoding.js
+++ b/tests/2.Encoding.js
@@ -1,3 +1,5 @@
+/* eslint-env mocha */
+const { Buffer } = require('buffer');
 const assert = require('assert');
 const algosdk = require('../src/index');
 const utils = require('../src/utils/utils');

--- a/tests/3.Address.js
+++ b/tests/3.Address.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 const assert = require('assert');
 const nacl = require('../src/nacl/naclWrappers');
 const algosdk = require('../src/index');

--- a/tests/4.Utils.ts
+++ b/tests/4.Utils.ts
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 import assert from 'assert';
 import * as utils from '../src/utils/utils';
 import * as nacl from '../src/nacl/naclWrappers';

--- a/tests/5.Transaction.js
+++ b/tests/5.Transaction.js
@@ -1,3 +1,5 @@
+/* eslint-env mocha */
+const { Buffer } = require('buffer');
 const assert = require('assert');
 const algosdk = require('../src/index');
 const { translateBoxReferences } = require('../src/boxStorage');

--- a/tests/6.Multisig.ts
+++ b/tests/6.Multisig.ts
@@ -1,3 +1,5 @@
+/* eslint-env mocha */
+import { Buffer } from 'buffer';
 import assert from 'assert';
 import algosdk from '../src/index';
 import {

--- a/tests/7.AlgoSDK.js
+++ b/tests/7.AlgoSDK.js
@@ -1,3 +1,5 @@
+/* eslint-env mocha */
+const { Buffer } = require('buffer');
 const assert = require('assert');
 const algosdk = require('../src/index');
 const nacl = require('../src/nacl/naclWrappers');

--- a/tests/8.LogicSig.ts
+++ b/tests/8.LogicSig.ts
@@ -1,3 +1,5 @@
+/* eslint-env mocha */
+import { Buffer } from 'buffer';
 import assert from 'assert';
 import algosdk from '../src/index';
 

--- a/tests/9.Client.ts
+++ b/tests/9.Client.ts
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 import assert from 'assert';
 import HTTPClient from '../src/client/client';
 import { URLTokenBaseHTTPClient } from '../src/client/urlTokenBaseHTTPClient';

--- a/tests/cucumber/browser/test.js
+++ b/tests/cucumber/browser/test.js
@@ -1,3 +1,5 @@
+/* eslint-env browser */
+const { Buffer } = require('buffer');
 const assert = require('assert');
 const sha512 = require('js-sha512');
 const nacl = require('tweetnacl');

--- a/tests/cucumber/browser/webpack.config.js
+++ b/tests/cucumber/browser/webpack.config.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const webpack = require('webpack');
 
 module.exports = {
   entry: path.resolve(__dirname, 'test.js'),
@@ -8,9 +7,4 @@ module.exports = {
     path: path.resolve(__dirname, 'build'),
   },
   devtool: 'source-map',
-  plugins: [
-    new webpack.ProvidePlugin({
-      Buffer: ['buffer', 'Buffer'],
-    }),
-  ],
 };

--- a/tests/cucumber/steps/index.js
+++ b/tests/cucumber/steps/index.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-console,global-require,no-loop-func,func-names */
+const { Buffer } = require('buffer');
 const path = require('path');
 const fs = require('fs');
 const {
@@ -363,8 +364,8 @@ if (browser) {
               const done = rest[rest.length - 1];
               try {
                 const testArgs = rest.slice(0, rest.length - 1);
-                const test = window.getStep(scopedType, scopedName);
-                await test.apply(window.testWorld, testArgs);
+                const test = window.getStep(scopedType, scopedName); // eslint-disable-line no-undef
+                await test.apply(window.testWorld, testArgs); // eslint-disable-line no-undef
                 done({ error: null });
               } catch (err) {
                 console.error(err);

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -1,4 +1,5 @@
 /* eslint-disable func-names,radix */
+const { Buffer } = require('buffer');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');

--- a/tests/mocha.js
+++ b/tests/mocha.js
@@ -1,3 +1,4 @@
+/* eslint-env node, mocha */
 /* eslint-disable no-console */
 const Mocha = require('mocha');
 const webpack = require('webpack');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const webpack = require('webpack');
 
 module.exports = {
   mode: 'production',
@@ -17,11 +16,6 @@ module.exports = {
     // Add '.ts' as resolvable extensions
     extensions: ['.ts', '.js'],
   },
-  plugins: [
-    new webpack.ProvidePlugin({
-      Buffer: ['buffer', 'Buffer'],
-    }),
-  ],
   module: {
     rules: [
       // All files with a '.ts' extension will be handled by 'ts-loader'.


### PR DESCRIPTION
## Summary

This PR makes the SDK no longer rely on a global `Buffer` object. See #708 for more context and for why this caused undesirable behavior.

I'm proud to report that this PR allows the SDK to be installed in a `create-react-app` project without ejecting or any additional configuration changes.*

## Specifics

My comment in https://github.com/algorand/js-algorand-sdk/pull/730#issuecomment-1379639585 expands on how our previous behavior causes problems for `create-react-app`.

Now, instead of using the global `Buffer` variable in our code and relying on a webpack plugin to set it up properly, we explicitly import `Buffer` from the `buffer` package. On node, this gives us the same thing as the global `Buffer` variable, and on the browser, this gives us our in-browser [buffer](https://www.npmjs.com/package/buffer) package.

> Note: the fact that the npm browser package is named `buffer` is convenient but not necessary. We could move to a differently named package if we wanted to (and we might, since [buffer](https://www.npmjs.com/package/buffer) has not been updated in some time). We'd just need to add the field `"buffer": "other_package_name"` to the `browser` object in our `package.json` and webpack will be able to substitute the new package when we import `buffer`.

In order to enforce this change in our repo, I made some changes to our eslint rules. The new rule `no-restricted-globals` causes eslint to fail if it detects any reference to the global `Buffer` variable, which should catch any problems going forward.

--- 

*There's one situation which unfortunately we can't solve in this SDK. Webpack v4 projects forcibly import an old version of the npm `buffer` package. Despite npm installing the higher version of `buffer` that we've specified in our package.json, webpack gives us the old one. I've given up trying to get around this for now, and I've changed the offending code causing #730 to use DataViews instead of Buffer. This solves the immediate problem, but it's possible other issues may arise from using an older version of `buffer` with our library.

I've opened #734 as a possible longer term solution to this problem.