### PR TITLE
API: verifyTealSign utility function

### DIFF
--- a/src/logicsig.ts
+++ b/src/logicsig.ts
@@ -496,6 +496,29 @@ export function tealSign(
 }
 
 /**
+ * verifyTealSign verifies a signature as would the ed25519verify opcode
+ * @param sk - uint8array with public key to verify against
+ * @param data - buffer with original signed data
+ * @param programHash - string representation of teal program hash (= contract address for LogicSigs)
+ * @param sig - uint8array with the signature to verify (produced by tealSign/tealSignFromProgram)
+ */
+export function verifyTealSign(
+  data: Uint8Array | Buffer,
+  programHash: string,
+  sig: Uint8Array,
+  pk: Uint8Array
+) {
+  const parts = utils.concatArrays(
+    address.decodeAddress(programHash).publicKey,
+    data
+  );
+  const toBeSigned = Buffer.from(
+    utils.concatArrays(SIGN_PROGRAM_DATA_PREFIX, parts)
+  );
+  return nacl.verify(toBeSigned, sig, pk);
+}
+
+/**
  * tealSignFromProgram creates a signature compatible with ed25519verify opcode from raw program bytes
  * @param sk - uint8array with secret key
  * @param data - buffer with data to sign

--- a/src/logicsig.ts
+++ b/src/logicsig.ts
@@ -497,10 +497,10 @@ export function tealSign(
 
 /**
  * verifyTealSign verifies a signature as would the ed25519verify opcode
- * @param sk - uint8array with public key to verify against
  * @param data - buffer with original signed data
  * @param programHash - string representation of teal program hash (= contract address for LogicSigs)
  * @param sig - uint8array with the signature to verify (produced by tealSign/tealSignFromProgram)
+ * @param pk - uint8array with public key to verify against
  */
 export function verifyTealSign(
   data: Uint8Array | Buffer,

--- a/src/main.ts
+++ b/src/main.ts
@@ -160,6 +160,7 @@ export {
   logicSigFromByte,
   tealSign,
   tealSignFromProgram,
+  verifyTealSign,
 } from './logicsig';
 export {
   signMultisigTransaction,

--- a/tests/7.AlgoSDK.js
+++ b/tests/7.AlgoSDK.js
@@ -967,22 +967,18 @@ describe('Algosdk (AKA end to end)', () => {
   });
 
   describe('tealSign', () => {
-    it('should produce verifiable signature', () => {
-      const data = Buffer.from('Ux8jntyBJQarjKGF8A==', 'base64');
-      const seed = Buffer.from(
-        '5Pf7eGMA52qfMT4R4/vYCt7con/7U3yejkdXkrcb26Q=',
-        'base64'
-      );
-      const prog = Buffer.from('ASABASI=', 'base64');
+    const data = Buffer.from('Ux8jntyBJQarjKGF8A==', 'base64');
+    const prog = Buffer.from('ASABASI=', 'base64');
+    const addr = new algosdk.LogicSig(prog).address();
 
-      const keys = nacl.keyPairFromSeed(seed);
-      const pk = keys.publicKey;
-      const sk = keys.secretKey;
-      const addr = new algosdk.LogicSig(prog).address();
-      const sig1 = algosdk.tealSign(sk, data, addr);
-      const sig2 = algosdk.tealSignFromProgram(sk, data, prog);
+    const seed = Buffer.from(
+      '5Pf7eGMA52qfMT4R4/vYCt7con/7U3yejkdXkrcb26Q=',
+      'base64'
+    );
+    const { publicKey: pk, secretKey: sk } = nacl.keyPairFromSeed(seed);
 
-      assert.deepStrictEqual(sig1, sig2);
+    it('should produce a verifiable signature', () => {
+      const sig = algosdk.tealSign(sk, data, addr);
 
       const parts = utils.concatArrays(
         algosdk.decodeAddress(addr).publicKey,
@@ -991,7 +987,21 @@ describe('Algosdk (AKA end to end)', () => {
       const toBeVerified = Buffer.from(
         utils.concatArrays(Buffer.from('ProgData'), parts)
       );
-      const verified = nacl.verify(toBeVerified, sig1, pk);
+      const verified = nacl.verify(toBeVerified, sig, pk);
+      assert.equal(verified, true);
+    });
+
+    it('should produce a verifiable signature from a program', () => {
+      const sig1 = algosdk.tealSign(sk, data, addr);
+      const sig2 = algosdk.tealSignFromProgram(sk, data, prog);
+
+      assert.deepStrictEqual(sig1, sig2);
+    });
+
+    it('should verify a valid signature', () => {
+      const sig = algosdk.tealSign(sk, data, addr);
+
+      const verified = algosdk.verifyTealSign(data, addr, sig, pk);
       assert.equal(verified, true);
     });
   });


### PR DESCRIPTION
Introduce a new function `verifyTealSign` which can be used to verify the output of its pair method, `tealSign`.

Some applications might benefit from having this utility function, either for testing purposes or not, and it would save developers the work of importing the `nacl` library and doing the verification manually by themselves.