### PR TITLE
Simulate unsigned transactions

### DIFF
--- a/.test-env
+++ b/.test-env
@@ -1,6 +1,6 @@
 # Configs for testing repo download:
 SDK_TESTING_URL="https://github.com/algorand/algorand-sdk-testing"
-SDK_TESTING_BRANCH="master"
+SDK_TESTING_BRANCH="simulate-endpoint-tests"
 SDK_TESTING_HARNESS="test-harness"
 
 INSTALL_ONLY=0

--- a/src/client/v2/algod/algod.ts
+++ b/src/client/v2/algod/algod.ts
@@ -586,8 +586,6 @@ export default class AlgodClient extends ServiceClient {
    * ```
    *
    * [Response data schema details](https://developer.algorand.org/docs/rest-apis/algod/v2/#post-v2transactionssimulate)
-   * @remarks
-   * This endpoint is only enabled when a node's configuration file sets `EnableExperimentalAPI` to true.
    * @param stxOrStxs
    * @category POST
    */

--- a/src/client/v2/algod/algod.ts
+++ b/src/client/v2/algod/algod.ts
@@ -31,6 +31,7 @@ import {
 import LightBlockHeaderProof from './lightBlockHeaderProof';
 import StateProof from './stateproof';
 import Disassemble from './disassemble';
+import SimulateRawTransaction from './simulateTransaction';
 
 /**
  * Algod client connects an application to the Algorand blockchain. The algod client requires a valid algod REST endpoint IP address and algod token from an Algorand node that is connected to the network you plan to interact with.
@@ -574,5 +575,23 @@ export default class AlgodClient extends ServiceClient {
    */
   getStateProof(round: number) {
     return new StateProof(this.c, this.intDecoding, round);
+  }
+
+  /**
+   * Simulate a list of a signed transaction objects being sent to the network.
+   *
+   * #### Example
+   * ```typescript
+   * const resp = await client.simulateRawTransaction([signedTxn1, signedTxn2]).do();
+   * ```
+   *
+   * [Response data schema details](https://developer.algorand.org/docs/rest-apis/algod/v2/#post-v2transactionssimulate)
+   * @remarks
+   * This endpoint is only enabled when a node's configuration file sets `EnableExperimentalAPI` to true.
+   * @param stxOrStxs
+   * @category POST
+   */
+  simulateRawTransaction(stxOrStxs: Uint8Array | Uint8Array[]) {
+    return new SimulateRawTransaction(this.c, stxOrStxs);
   }
 }

--- a/src/client/v2/algod/algod.ts
+++ b/src/client/v2/algod/algod.ts
@@ -31,7 +31,7 @@ import {
 import LightBlockHeaderProof from './lightBlockHeaderProof';
 import StateProof from './stateproof';
 import Disassemble from './disassemble';
-import SimulateRawTransaction from './simulateTransaction';
+import SimulateRawTransactions from './simulateTransaction';
 
 /**
  * Algod client connects an application to the Algorand blockchain. The algod client requires a valid algod REST endpoint IP address and algod token from an Algorand node that is connected to the network you plan to interact with.
@@ -582,7 +582,7 @@ export default class AlgodClient extends ServiceClient {
    *
    * #### Example
    * ```typescript
-   * const resp = await client.simulateRawTransaction([signedTxn1, signedTxn2]).do();
+   * const resp = await client.simulateRawTransactions([signedTxn1, signedTxn2]).do();
    * ```
    *
    * [Response data schema details](https://developer.algorand.org/docs/rest-apis/algod/v2/#post-v2transactionssimulate)
@@ -591,7 +591,7 @@ export default class AlgodClient extends ServiceClient {
    * @param stxOrStxs
    * @category POST
    */
-  simulateRawTransaction(stxOrStxs: Uint8Array | Uint8Array[]) {
-    return new SimulateRawTransaction(this.c, stxOrStxs);
+  simulateRawTransactions(stxOrStxs: Uint8Array | Uint8Array[]) {
+    return new SimulateRawTransactions(this.c, stxOrStxs);
   }
 }

--- a/src/client/v2/algod/models/types.ts
+++ b/src/client/v2/algod/models/types.ts
@@ -3085,6 +3085,95 @@ export class PostTransactionsResponse extends BaseModel {
 }
 
 /**
+ * Result of a transaction group simulation.
+ */
+export class SimulateResponse extends BaseModel {
+  /**
+   * The round immediately preceding this simulation. State changes through this
+   * round were used to run this simulation.
+   */
+  public lastRound: number | bigint;
+
+  /**
+   * A result object for each transaction group that was simulated.
+   */
+  public txnGroups: SimulateTransactionGroupResult[];
+
+  /**
+   * The version of this response object.
+   */
+  public version: number | bigint;
+
+  /**
+   * Indicates whether the simulated transactions would have succeeded during an
+   * actual submission.
+   */
+  public wouldSucceed: boolean;
+
+  /**
+   * Creates a new `SimulateResponse` object.
+   * @param lastRound - The round immediately preceding this simulation. State changes through this
+   * round were used to run this simulation.
+   * @param txnGroups - A result object for each transaction group that was simulated.
+   * @param version - The version of this response object.
+   * @param wouldSucceed - Indicates whether the simulated transactions would have succeeded during an
+   * actual submission.
+   */
+  constructor({
+    lastRound,
+    txnGroups,
+    version,
+    wouldSucceed,
+  }: {
+    lastRound: number | bigint;
+    txnGroups: SimulateTransactionGroupResult[];
+    version: number | bigint;
+    wouldSucceed: boolean;
+  }) {
+    super();
+    this.lastRound = lastRound;
+    this.txnGroups = txnGroups;
+    this.version = version;
+    this.wouldSucceed = wouldSucceed;
+
+    this.attribute_map = {
+      lastRound: 'last-round',
+      txnGroups: 'txn-groups',
+      version: 'version',
+      wouldSucceed: 'would-succeed',
+    };
+  }
+
+  // eslint-disable-next-line camelcase
+  static from_obj_for_encoding(data: Record<string, any>): SimulateResponse {
+    /* eslint-disable dot-notation */
+    if (typeof data['last-round'] === 'undefined')
+      throw new Error(
+        `Response is missing required field 'last-round': ${data}`
+      );
+    if (!Array.isArray(data['txn-groups']))
+      throw new Error(
+        `Response is missing required array field 'txn-groups': ${data}`
+      );
+    if (typeof data['version'] === 'undefined')
+      throw new Error(`Response is missing required field 'version': ${data}`);
+    if (typeof data['would-succeed'] === 'undefined')
+      throw new Error(
+        `Response is missing required field 'would-succeed': ${data}`
+      );
+    return new SimulateResponse({
+      lastRound: data['last-round'],
+      txnGroups: data['txn-groups'].map(
+        SimulateTransactionGroupResult.from_obj_for_encoding
+      ),
+      version: data['version'],
+      wouldSucceed: data['would-succeed'],
+    });
+    /* eslint-enable dot-notation */
+  }
+}
+
+/**
  * Simulation result for an atomic transaction group
  */
 export class SimulateTransactionGroupResult extends BaseModel {

--- a/src/client/v2/algod/models/types.ts
+++ b/src/client/v2/algod/models/types.ts
@@ -3106,7 +3106,8 @@ export class SimulateResponse extends BaseModel {
 
   /**
    * Indicates whether the simulated transactions would have succeeded during an
-   * actual submission.
+   * actual submission. If any transaction fails or is missing a signature, this will
+   * be false.
    */
   public wouldSucceed: boolean;
 
@@ -3117,7 +3118,8 @@ export class SimulateResponse extends BaseModel {
    * @param txnGroups - A result object for each transaction group that was simulated.
    * @param version - The version of this response object.
    * @param wouldSucceed - Indicates whether the simulated transactions would have succeeded during an
-   * actual submission.
+   * actual submission. If any transaction fails or is missing a signature, this will
+   * be false.
    */
   constructor({
     lastRound,
@@ -3183,7 +3185,10 @@ export class SimulateTransactionGroupResult extends BaseModel {
   public txnResults: SimulateTransactionResult[];
 
   /**
-   * If present, indicates which transaction in this group caused the failure
+   * If present, indicates which transaction in this group caused the failure. This
+   * array represents the path to the failing transaction. Indexes are zero based,
+   * the first element indicates the top-level transaction, and successive elements
+   * indicate deeper inner transactions.
    */
   public failedAt?: (number | bigint)[];
 
@@ -3196,7 +3201,10 @@ export class SimulateTransactionGroupResult extends BaseModel {
   /**
    * Creates a new `SimulateTransactionGroupResult` object.
    * @param txnResults - Simulation result for individual transactions
-   * @param failedAt - If present, indicates which transaction in this group caused the failure
+   * @param failedAt - If present, indicates which transaction in this group caused the failure. This
+   * array represents the path to the failing transaction. Indexes are zero based,
+   * the first element indicates the top-level transaction, and successive elements
+   * indicate deeper inner transactions.
    * @param failureMessage - If present, indicates that the transaction group failed and specifies why that
    * happened
    */

--- a/src/client/v2/algod/models/types.ts
+++ b/src/client/v2/algod/models/types.ts
@@ -3087,11 +3087,11 @@ export class PostTransactionsResponse extends BaseModel {
 /**
  * Simulation result for an atomic transaction group
  */
-export class SimulationTransactionGroupResult extends BaseModel {
+export class SimulateTransactionGroupResult extends BaseModel {
   /**
    * Simulation result for individual transactions
    */
-  public txnResults: SimulationTransactionResult[];
+  public txnResults: SimulateTransactionResult[];
 
   /**
    * If present, indicates which transaction in this group caused the failure
@@ -3105,7 +3105,7 @@ export class SimulationTransactionGroupResult extends BaseModel {
   public failureMessage?: string;
 
   /**
-   * Creates a new `SimulationTransactionGroupResult` object.
+   * Creates a new `SimulateTransactionGroupResult` object.
    * @param txnResults - Simulation result for individual transactions
    * @param failedAt - If present, indicates which transaction in this group caused the failure
    * @param failureMessage - If present, indicates that the transaction group failed and specifies why that
@@ -3116,7 +3116,7 @@ export class SimulationTransactionGroupResult extends BaseModel {
     failedAt,
     failureMessage,
   }: {
-    txnResults: SimulationTransactionResult[];
+    txnResults: SimulateTransactionResult[];
     failedAt?: (number | bigint)[];
     failureMessage?: string;
   }) {
@@ -3135,15 +3135,15 @@ export class SimulationTransactionGroupResult extends BaseModel {
   // eslint-disable-next-line camelcase
   static from_obj_for_encoding(
     data: Record<string, any>
-  ): SimulationTransactionGroupResult {
+  ): SimulateTransactionGroupResult {
     /* eslint-disable dot-notation */
     if (!Array.isArray(data['txn-results']))
       throw new Error(
         `Response is missing required array field 'txn-results': ${data}`
       );
-    return new SimulationTransactionGroupResult({
+    return new SimulateTransactionGroupResult({
       txnResults: data['txn-results'].map(
-        SimulationTransactionResult.from_obj_for_encoding
+        SimulateTransactionResult.from_obj_for_encoding
       ),
       failedAt: data['failed-at'],
       failureMessage: data['failure-message'],
@@ -3155,7 +3155,7 @@ export class SimulationTransactionGroupResult extends BaseModel {
 /**
  * Simulation result for an individual transaction
  */
-export class SimulationTransactionResult extends BaseModel {
+export class SimulateTransactionResult extends BaseModel {
   /**
    * Details about a pending transaction. If the transaction was recently confirmed,
    * includes confirmation details like the round and reward details.
@@ -3168,7 +3168,7 @@ export class SimulationTransactionResult extends BaseModel {
   public missingSignature?: boolean;
 
   /**
-   * Creates a new `SimulationTransactionResult` object.
+   * Creates a new `SimulateTransactionResult` object.
    * @param txnResult - Details about a pending transaction. If the transaction was recently confirmed,
    * includes confirmation details like the round and reward details.
    * @param missingSignature - A boolean indicating whether this transaction is missing signatures
@@ -3193,13 +3193,13 @@ export class SimulationTransactionResult extends BaseModel {
   // eslint-disable-next-line camelcase
   static from_obj_for_encoding(
     data: Record<string, any>
-  ): SimulationTransactionResult {
+  ): SimulateTransactionResult {
     /* eslint-disable dot-notation */
     if (typeof data['txn-result'] === 'undefined')
       throw new Error(
         `Response is missing required field 'txn-result': ${data}`
       );
-    return new SimulationTransactionResult({
+    return new SimulateTransactionResult({
       txnResult: PendingTransactionResponse.from_obj_for_encoding(
         data['txn-result']
       ),

--- a/src/client/v2/algod/models/types.ts
+++ b/src/client/v2/algod/models/types.ts
@@ -3085,6 +3085,131 @@ export class PostTransactionsResponse extends BaseModel {
 }
 
 /**
+ * Simulation result for an atomic transaction group
+ */
+export class SimulationTransactionGroupResult extends BaseModel {
+  /**
+   * Simulation result for individual transactions
+   */
+  public txnResults: SimulationTransactionResult[];
+
+  /**
+   * If present, indicates which transaction in this group caused the failure
+   */
+  public failedAt?: (number | bigint)[];
+
+  /**
+   * If present, indicates that the transaction group failed and specifies why that
+   * happened
+   */
+  public failureMessage?: string;
+
+  /**
+   * Creates a new `SimulationTransactionGroupResult` object.
+   * @param txnResults - Simulation result for individual transactions
+   * @param failedAt - If present, indicates which transaction in this group caused the failure
+   * @param failureMessage - If present, indicates that the transaction group failed and specifies why that
+   * happened
+   */
+  constructor({
+    txnResults,
+    failedAt,
+    failureMessage,
+  }: {
+    txnResults: SimulationTransactionResult[];
+    failedAt?: (number | bigint)[];
+    failureMessage?: string;
+  }) {
+    super();
+    this.txnResults = txnResults;
+    this.failedAt = failedAt;
+    this.failureMessage = failureMessage;
+
+    this.attribute_map = {
+      txnResults: 'txn-results',
+      failedAt: 'failed-at',
+      failureMessage: 'failure-message',
+    };
+  }
+
+  // eslint-disable-next-line camelcase
+  static from_obj_for_encoding(
+    data: Record<string, any>
+  ): SimulationTransactionGroupResult {
+    /* eslint-disable dot-notation */
+    if (!Array.isArray(data['txn-results']))
+      throw new Error(
+        `Response is missing required array field 'txn-results': ${data}`
+      );
+    return new SimulationTransactionGroupResult({
+      txnResults: data['txn-results'].map(
+        SimulationTransactionResult.from_obj_for_encoding
+      ),
+      failedAt: data['failed-at'],
+      failureMessage: data['failure-message'],
+    });
+    /* eslint-enable dot-notation */
+  }
+}
+
+/**
+ * Simulation result for an individual transaction
+ */
+export class SimulationTransactionResult extends BaseModel {
+  /**
+   * Details about a pending transaction. If the transaction was recently confirmed,
+   * includes confirmation details like the round and reward details.
+   */
+  public txnResult: PendingTransactionResponse;
+
+  /**
+   * A boolean indicating whether this transaction is missing signatures
+   */
+  public missingSignature?: boolean;
+
+  /**
+   * Creates a new `SimulationTransactionResult` object.
+   * @param txnResult - Details about a pending transaction. If the transaction was recently confirmed,
+   * includes confirmation details like the round and reward details.
+   * @param missingSignature - A boolean indicating whether this transaction is missing signatures
+   */
+  constructor({
+    txnResult,
+    missingSignature,
+  }: {
+    txnResult: PendingTransactionResponse;
+    missingSignature?: boolean;
+  }) {
+    super();
+    this.txnResult = txnResult;
+    this.missingSignature = missingSignature;
+
+    this.attribute_map = {
+      txnResult: 'txn-result',
+      missingSignature: 'missing-signature',
+    };
+  }
+
+  // eslint-disable-next-line camelcase
+  static from_obj_for_encoding(
+    data: Record<string, any>
+  ): SimulationTransactionResult {
+    /* eslint-disable dot-notation */
+    if (typeof data['txn-result'] === 'undefined')
+      throw new Error(
+        `Response is missing required field 'txn-result': ${data}`
+      );
+    return new SimulationTransactionResult({
+      txnResult: PendingTransactionResponse.from_obj_for_encoding(
+        data['txn-result']
+      ),
+      missingSignature: data['missing-signature'],
+    });
+    /* eslint-enable dot-notation */
+  }
+}
+
+/**
  * Represents a state proof and its corresponding message
  */
 export class StateProof extends BaseModel {

--- a/src/client/v2/algod/simulateTransaction.ts
+++ b/src/client/v2/algod/simulateTransaction.ts
@@ -1,0 +1,61 @@
+import { Buffer } from 'buffer';
+import JSONRequest from '../jsonrequest';
+import HTTPClient from '../../client';
+import { concatArrays } from '../../../utils/utils';
+
+/**
+ * Sets the default header (if not previously set) for simulating a raw
+ * transaction.
+ * @param headers - A headers object
+ */
+export function setSimulateTransactionHeaders(headers = {}) {
+  let hdrs = headers;
+  if (Object.keys(hdrs).every((key) => key.toLowerCase() !== 'content-type')) {
+    hdrs = { ...headers };
+    hdrs['Content-Type'] = 'application/x-binary';
+  }
+  return hdrs;
+}
+
+function isByteArray(array: any): array is Uint8Array {
+  return array && array.byteLength !== undefined;
+}
+
+/**
+ * Simulates signed txns.
+ */
+export default class SimulateRawTransaction extends JSONRequest {
+  private txnBytesToPost: Uint8Array;
+
+  constructor(c: HTTPClient, stxOrStxs: Uint8Array | Uint8Array[]) {
+    super(c);
+    this.query.format = 'msgpack';
+
+    let forPosting = stxOrStxs;
+    if (Array.isArray(stxOrStxs)) {
+      if (!stxOrStxs.every(isByteArray)) {
+        throw new TypeError('Array elements must be byte arrays');
+      }
+      // Flatten into a single Uint8Array
+      forPosting = concatArrays(...stxOrStxs);
+    } else if (!isByteArray(forPosting)) {
+      throw new TypeError('Argument must be byte array');
+    }
+    this.txnBytesToPost = forPosting;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  path() {
+    return '/v2/transactions/simulate';
+  }
+
+  async do(headers = {}) {
+    const txHeaders = setSimulateTransactionHeaders(headers);
+    const res = await this.c.post(
+      this.path(),
+      Buffer.from(this.txnBytesToPost),
+      txHeaders
+    );
+    return res.body;
+  }
+}

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -1,32 +1,32 @@
 import { Buffer } from 'buffer';
 import {
-  ABIType,
-  ABITupleType,
-  ABIUintType,
   ABIAddressType,
-  ABIValue,
+  abiCheckTransactionType,
   ABIMethod,
   ABIReferenceType,
-  abiTypeIsTransaction,
-  abiCheckTransactionType,
+  ABITupleType,
+  ABIType,
   abiTypeIsReference,
+  abiTypeIsTransaction,
+  ABIUintType,
+  ABIValue,
 } from './abi';
-import { Transaction, decodeSignedTransaction } from './transaction';
-import { makeApplicationCallTxnFromObject } from './makeTxn';
-import { assignGroupID } from './group';
-import { waitForConfirmation } from './wait';
 import Algodv2 from './client/v2/algod/algod';
+import { SimulateResponse } from './client/v2/algod/models/types';
+import { assignGroupID } from './group';
+import { makeApplicationCallTxnFromObject } from './makeTxn';
 import {
+  isTransactionWithSigner,
   TransactionSigner,
   TransactionWithSigner,
-  isTransactionWithSigner,
 } from './signer';
+import { decodeSignedTransaction, Transaction } from './transaction';
 import {
   BoxReference,
   OnApplicationComplete,
   SuggestedParams,
 } from './types/transactions/base';
-import { SimulateResponse } from './client/v2/algod/models/types';
+import { waitForConfirmation } from './wait';
 
 // First 4 bytes of SHA-512/256 hash of "return"
 const RETURN_PREFIX = Buffer.from([21, 31, 124, 117]);
@@ -606,6 +606,7 @@ export class AtomicTransactionComposer {
    *
    * The composer will try to sign any transactions in the group, then simulate
    * the results.
+   * Simulating the group will not change the composer's status.
    *
    * @param client - An Algodv2 client
    *

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -614,7 +614,7 @@ export class AtomicTransactionComposer {
   async simulate(client: Algodv2): Promise<SimulateResponse> {
     if (this.status > AtomicTransactionComposerStatus.SUBMITTED) {
       throw new Error(
-        'Transaction group has already been submitted to the network'
+        'Simulated Transaction group has already been submitted to the network'
       );
     }
 

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -609,7 +609,9 @@ export class AtomicTransactionComposer {
    *
    * @param client - An Algodv2 client
    *
-   * @returns A promise that, upon success, resolves to a SimulateResponse object.
+   * @returns A promise that, upon success, resolves to an object containing an
+   *   array of results containing one element for each method call transaction
+   *   in this group (ABIResult[]) and the SimulateResponse object.
    */
   async simulate(
     client: Algodv2

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -736,6 +736,14 @@ export class AtomicTransactionComposer {
     };
   }
 
+  /**
+   * Parses a single ABI Method transaction log into a ABI result object.
+   *
+   * @param method
+   * @param methodResult
+   * @param pendingInfo
+   * @returns An ABIResult object
+   */
   static parseMethodResponse(
     method: ABIMethod,
     methodResult: ABIResult,

--- a/src/encoding/encoding.ts
+++ b/src/encoding/encoding.ts
@@ -34,6 +34,18 @@ function containsEmpty(obj: Record<string | number | symbol, any>) {
 }
 
 /**
+ * rawEncode encodes objects using msgpack, regardless of whether there are
+ * empty or 0 value fields.
+ * @param obj - a dictionary to be encoded. May or may not contain empty or 0 values.
+ * @returns msgpack representation of the object
+ */
+export function rawEncode(obj: Record<string | number | symbol, any>) {
+  // enable the canonical option
+  const options = { sortKeys: true };
+  return msgpack.encode(obj, options);
+}
+
+/**
  * encode encodes objects using msgpack
  * @param obj - a dictionary to be encoded. Must not contain empty or 0 values.
  * @returns msgpack representation of the object
@@ -47,8 +59,7 @@ export function encode(obj: Record<string | number | symbol, any>) {
   }
 
   // enable the canonical option
-  const options = { sortKeys: true };
-  return msgpack.encode(obj, options);
+  return rawEncode(obj);
 }
 
 export function decode(buffer: ArrayLike<number>) {

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -1,4 +1,4 @@
-import { Transaction } from './transaction';
+import { encodeNoSigTransaction, Transaction } from './transaction';
 import Account from './types/account';
 import { LogicSigAccount, signLogicSigTransactionObject } from './logicsig';
 import { MultisigMetadata } from './types/multisig';
@@ -77,6 +77,23 @@ export function makeMultiSigAccountTransactionSigner(
     }
 
     return Promise.resolve(signed);
+  };
+}
+
+/**
+ * Create a makeNoSigTransactionSigner that does not specify any signer or
+ * signing capabilities. This should only be used to simulate transactions.
+ */
+export function makeNoSigTransactionSigner(): TransactionSigner {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  return (txnGroup: Transaction[], indexesToSign: number[]) => {
+    const unsigned: Uint8Array[] = [];
+
+    for (const txn of txnGroup) {
+      unsigned.push(encodeNoSigTransaction(txn));
+    }
+
+    return Promise.resolve(unsigned);
   };
 }
 

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -1279,6 +1279,22 @@ export class Transaction implements TransactionStorageStructure {
 }
 
 /**
+ * encodeNoSigTransaction takes a txnBuilder.Transaction object, converts it
+ * into a SignedTransaction-like object, and converts it to a Buffer.
+ *
+ * Note: this function should only be used to simulate unsigned transactions.
+ *
+ * @param transactionObject - Transaction object to simulate.
+ */
+export function encodeNoSigTransaction(transactionObject: Transaction) {
+  const objToEncode: EncodedSignedTransaction = {
+    sig: null,
+    txn: transactionObject.get_obj_for_encoding(),
+  };
+  return encoding.rawEncode(objToEncode);
+}
+
+/**
  * encodeUnsignedTransaction takes a completed txnBuilder.Transaction object, such as from the makeFoo
  * family of transactions, and converts it to a Buffer
  * @param transactionObject - the completed Transaction object

--- a/tests/cucumber/integration.tags
+++ b/tests/cucumber/integration.tags
@@ -13,3 +13,4 @@
 @rekey_v1
 @send
 @send.keyregtxn
+@simulate

--- a/tests/cucumber/integration.tags
+++ b/tests/cucumber/integration.tags
@@ -1,1 +1,16 @@
+@abi
+@algod
+@applications.boxes
+@applications.verified
+@assets
+@auction
+@c2c
+@compile
+@compile.disassemble
+@compile.sourcemap
+@dryrun
+@kmd
+@rekey_v1
+@send
+@send.keyregtxn
 @simulate

--- a/tests/cucumber/integration.tags
+++ b/tests/cucumber/integration.tags
@@ -1,16 +1,1 @@
-@abi
-@algod
-@applications.boxes
-@applications.verified
-@assets
-@auction
-@c2c
-@compile
-@compile.disassemble
-@compile.sourcemap
-@dryrun
-@kmd
-@rekey_v1
-@send
-@send.keyregtxn
 @simulate

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -4634,7 +4634,6 @@ module.exports = function getSteps(options) {
   Then(
     'the simulation should fail at path {string} with message {string}',
     async function (failAt, errorMsg) {
-      console.warn(`AH ${JSON.stringify(this.simulateResponse, null, 2)}`);
       // Parse the path ("0,0") into a list of numbers ([0, 0])
       const stringPath = failAt.split(',');
       const failPath = stringPath.map((n) => parseInt(n, 10));

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -3720,6 +3720,13 @@ module.exports = function getSteps(options) {
   });
 
   When(
+    'I make a dummy transaction signer for the transient account.',
+    function () {
+      this.transactionSigner = algosdk.makeDummyTransactionSigner();
+    }
+  );
+
+  When(
     'I create a transaction with signer with the current transaction.',
     function () {
       this.transactionWithSigner = {
@@ -4635,17 +4642,22 @@ module.exports = function getSteps(options) {
   );
 
   Then(
-    'the simulation should report a failure at path {string} with message {string}',
-    async function (failAt, errorMsg) {
+    'the simulation should report a failure at group {string}, path {string} with message {string}',
+    async function (txnGroupIndex, failAt, errorMsg) {
+      // Parse transaction group number
+      const groupNum = parseInt(txnGroupIndex, 10);
+
       // Parse the path ("0,0") into a list of numbers ([0, 0])
       const stringPath = failAt.split(',');
       const failPath = stringPath.map((n) => parseInt(n, 10));
 
-      const msg = this.simulateResponse['txn-groups'][0]['failure-message'];
+      const msg = this.simulateResponse['txn-groups'][groupNum][
+        'failure-message'
+      ];
       assert.deepStrictEqual(false, this.simulateResponse['would-succeed']);
       assert.deepStrictEqual(
         failPath,
-        this.simulateResponse['txn-groups'][0]['failed-at']
+        this.simulateResponse['txn-groups'][groupNum]['failed-at']
       );
       const errorContainsString = msg.includes(errorMsg);
       assert.deepStrictEqual(true, errorContainsString);

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -383,7 +383,7 @@ module.exports = function getSteps(options) {
       const sp = await this.v2Client.getTransactionParams().do();
       if (sp.firstRound === 0) sp.firstRound = 1;
       const fundingTxnArgs = {
-        from: this.accounts[0],
+        from: this.accounts[1],
         to: this.rekey,
         amount: DEV_MODE_INITIAL_MICROALGOS,
         fee: sp.fee,
@@ -2917,6 +2917,7 @@ module.exports = function getSteps(options) {
       );
 
       const fundingResponse = await this.v2Client.sendRawTransaction(stxn).do();
+      await new Promise((r) => setTimeout(r, 500));
       const info = await algosdk.waitForConfirmation(
         this.v2Client,
         fundingResponse.txId,
@@ -3260,7 +3261,7 @@ module.exports = function getSteps(options) {
       const sp = await this.v2Client.getTransactionParams().do();
       if (sp.firstRound === 0) sp.firstRound = 1;
       const fundingTxnArgs = {
-        from: this.accounts[0],
+        from: this.accounts[1],
         to: this.transientAccount.addr,
         amount: fundingAmount,
         suggestedParams: sp,
@@ -3273,6 +3274,7 @@ module.exports = function getSteps(options) {
       const fundingResponse = await this.v2Client
         .sendRawTransaction(stxKmd)
         .do();
+      await new Promise((r) => setTimeout(r, 500));
       const info = await algosdk.waitForConfirmation(
         this.v2Client,
         fundingResponse.txId,
@@ -3385,6 +3387,7 @@ module.exports = function getSteps(options) {
     'I sign and submit the transaction, saving the txid. If there is an error it is {string}.',
     async function (errorString) {
       try {
+        await new Promise((r) => setTimeout(r, 500));
         const appStx = this.txn.signTxn(this.transientAccount.sk);
         this.appTxid = await this.v2Client.sendRawTransaction(appStx).do();
       } catch (err) {
@@ -3401,6 +3404,7 @@ module.exports = function getSteps(options) {
   );
 
   Given('I wait for the transaction to be confirmed.', async function () {
+    await new Promise((r) => setTimeout(r, 500));
     const info = await algosdk.waitForConfirmation(
       this.v2Client,
       this.appTxid.txId,

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -3720,13 +3720,6 @@ module.exports = function getSteps(options) {
   });
 
   When(
-    'I make a dummy transaction signer for the transient account.',
-    function () {
-      this.transactionSigner = algosdk.makeDummyTransactionSigner();
-    }
-  );
-
-  When(
     'I create a transaction with signer with the current transaction.',
     function () {
       this.transactionWithSigner = {

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -178,12 +178,12 @@ module.exports = function getSteps(options) {
   }
 
   Given('a kmd client', function () {
-    this.kcl = new algosdk.Kmd(kmdToken, 'http://localhost', 4002);
+    this.kcl = new algosdk.Kmd(kmdToken, 'http://localhost', 60001);
     return this.kcl;
   });
 
   Given('an algod v2 client', function () {
-    this.v2Client = new algosdk.Algodv2(algodToken, 'http://localhost', 4001);
+    this.v2Client = new algosdk.Algodv2(algodToken, 'http://localhost', 60000);
   });
 
   Given('an indexer v2 client', function () {
@@ -4608,11 +4608,18 @@ module.exports = function getSteps(options) {
     }
   );
 
-  When('I simulate the transaction', async function () {
+  Then('I simulate the transaction', async function () {
     this.simulateResponse = await this.v2Client
       .simulateRawTransactions(this.stx)
       .do();
   });
+
+  Then(
+    'I simulate the current transaction group with the composer',
+    async function () {
+      this.simulateResponse = await this.composer.simulate(this.v2Client);
+    }
+  );
 
   Then('the simulation should succeed', async function () {
     assert.deepStrictEqual(true, this.simulateResponse['would-succeed']);
@@ -4630,13 +4637,6 @@ module.exports = function getSteps(options) {
       );
       const errorContainsString = msg.includes(errorMsg);
       assert.deepStrictEqual(true, errorContainsString);
-    }
-  );
-
-  Then(
-    'I simulate the current transaction group with the composer',
-    async function () {
-      this.simulateResponse = await this.composer.simulate(this.v2Client);
     }
   );
 

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -3728,6 +3728,16 @@ module.exports = function getSteps(options) {
     }
   );
 
+  When(
+    'I create a transaction with an empty signer with the current transaction.',
+    function () {
+      this.transactionWithSigner = {
+        txn: this.txn,
+        signer: algosdk.makeNoSigTransactionSigner(),
+      };
+    }
+  );
+
   When('I create a new method arguments array.', function () {
     this.encodedMethodArguments = [];
   });

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -4627,12 +4627,15 @@ module.exports = function getSteps(options) {
     }
   );
 
-  Then('the simulation should succeed', async function () {
-    assert.deepStrictEqual(true, this.simulateResponse['would-succeed']);
-  });
+  Then(
+    'the simulation should succeed without any failure message',
+    async function () {
+      assert.deepStrictEqual(true, this.simulateResponse['would-succeed']);
+    }
+  );
 
   Then(
-    'the simulation should fail at path {string} with message {string}',
+    'the simulation should report a failure at path {string} with message {string}',
     async function (failAt, errorMsg) {
       // Parse the path ("0,0") into a list of numbers ([0, 0])
       const stringPath = failAt.split(',');


### PR DESCRIPTION
This PR allows unsigned transactions to be encoded and sent to the `simulate` endpoint. 

Also implements tests defined in https://github.com/algorand/algorand-sdk-testing/pull/270