### PR TITLE
algod: Minor improvements to simulation support

### DIFF
--- a/src/client/v2/algod/simulateTransaction.ts
+++ b/src/client/v2/algod/simulateTransaction.ts
@@ -1,4 +1,5 @@
 import { Buffer } from 'buffer';
+import * as encoding from '../../../encoding/encoding';
 import { concatArrays } from '../../../utils/utils';
 import HTTPClient from '../../client';
 import JSONRequest from '../jsonrequest';
@@ -58,13 +59,16 @@ export default class SimulateRawTransactions extends JSONRequest<
     const res = await this.c.post(
       this.path(),
       Buffer.from(this.txnBytesToPost),
-      txHeaders
+      txHeaders,
+      this.query,
+      false
     );
     return this.prepare(res.body);
   }
 
   // eslint-disable-next-line class-methods-use-this
   prepare(body: Uint8Array): SimulateResponse {
-    return SimulateResponse.from_obj_for_encoding(body);
+    const decoded = encoding.decode(body);
+    return SimulateResponse.from_obj_for_encoding(decoded);
   }
 }

--- a/src/client/v2/algod/simulateTransaction.ts
+++ b/src/client/v2/algod/simulateTransaction.ts
@@ -61,14 +61,12 @@ export default class SimulateRawTransactions extends JSONRequest<
       Buffer.from(this.txnBytesToPost),
       txHeaders
     );
-    return res.body;
+    return this.prepare(res.body);
   }
 
   // eslint-disable-next-line class-methods-use-this
-  prepare(body: Uint8Array) {
-    if (body && body.byteLength > 0) {
-      return encoding.decode(body) as SimulateResponse;
-    }
-    return undefined;
+  prepare(body: Uint8Array): SimulateResponse {
+    const decoded = encoding.decode(body);
+    return SimulateResponse.from_obj_for_encoding(decoded);
   }
 }

--- a/src/client/v2/algod/simulateTransaction.ts
+++ b/src/client/v2/algod/simulateTransaction.ts
@@ -1,5 +1,4 @@
 import { Buffer } from 'buffer';
-import * as encoding from '../../../encoding/encoding';
 import { concatArrays } from '../../../utils/utils';
 import HTTPClient from '../../client';
 import JSONRequest from '../jsonrequest';
@@ -66,7 +65,6 @@ export default class SimulateRawTransactions extends JSONRequest<
 
   // eslint-disable-next-line class-methods-use-this
   prepare(body: Uint8Array): SimulateResponse {
-    const decoded = encoding.decode(body);
-    return SimulateResponse.from_obj_for_encoding(decoded);
+    return SimulateResponse.from_obj_for_encoding(body);
   }
 }

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -4644,7 +4644,7 @@ module.exports = function getSteps(options) {
   Then(
     'the simulation should succeed without any failure message',
     async function () {
-      assert.deepStrictEqual(true, this.simulateResponse['would-succeed']);
+      assert.deepStrictEqual(true, this.simulateResponse.wouldSucceed);
     }
   );
 
@@ -4656,14 +4656,13 @@ module.exports = function getSteps(options) {
       const txnIndexes = stringPath.map((n) => parseInt(n, 10));
       const groupNum = parseInt(txnGroupIndex, 10);
 
-      assert.deepStrictEqual(false, this.simulateResponse['would-succeed']);
+      assert.deepStrictEqual(false, this.simulateResponse.wouldSucceed);
       // Check for missing signature flag
       for (const txnIndex of txnIndexes) {
         assert.deepStrictEqual(
           true,
-          this.simulateResponse['txn-groups'][groupNum]['txn-results'][
-            txnIndex
-          ]['missing-signature']
+          this.simulateResponse.txnGroups[groupNum].txnResults[txnIndex]
+            .missingSignature
         );
       }
     }
@@ -4679,18 +4678,15 @@ module.exports = function getSteps(options) {
       const stringPath = failAt.split(',');
       const failPath = stringPath.map((n) => parseInt(n, 10));
 
-      const failedMessage = this.simulateResponse['txn-groups'][groupNum][
-        'failure-message'
-      ];
-      assert.deepStrictEqual(false, this.simulateResponse['would-succeed']);
+      const failedMessage = this.simulateResponse.txnGroups[groupNum]
+        .failureMessage;
+      assert.deepStrictEqual(false, this.simulateResponse.wouldSucceed);
       const errorContainsString = failedMessage.includes(errorMsg);
       assert.deepStrictEqual(true, errorContainsString);
 
       // Check path array
       // deepStrictEqual fails for firefox tests, so compare array manually.
-      const failedAt = this.simulateResponse['txn-groups'][groupNum][
-        'failed-at'
-      ];
+      const { failedAt } = this.simulateResponse.txnGroups[groupNum];
       assert.strictEqual(failPath.length, failedAt.length);
       for (let i = 0; i < failPath.length; i++) {
         assert.strictEqual(failPath[i], failedAt[i]);


### PR DESCRIPTION
This PR makes some minor, but important changes to the simulate support introduced in #743. They are:

1. `SimulateRawTransactions` was returning a raw object instead of an instance of `SimulateResponse`. Based on the code I think we wanted a `SimulateResponse`
2. An operation which can error was moved outside of a try-catch block in `AtomicTransactionComposer.execute`. I made a new try-catch block to include it again. This is especially important because it can be dangerous if a client thinks a transaction was rejected due to an error observing its result, but in reality the transaction succeeded.