### PR TITLE
client: Export token header types

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -127,6 +127,13 @@ export {
   BaseHTTPClientResponse,
   BaseHTTPClientError,
 } from './client/baseHTTPClient';
+export {
+  AlgodTokenHeader,
+  IndexerTokenHeader,
+  KMDTokenHeader,
+  CustomTokenHeader,
+  TokenHeader,
+} from './client/urlTokenBaseHTTPClient';
 export { waitForConfirmation } from './wait';
 export {
   isValidAddress,


### PR DESCRIPTION
Exports token header types for all of the existing clients.

Resolves #437 