### PR TITLE
Docs: Update README & FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -10,56 +10,6 @@ In prior versions, the browser bundles were made available in the `dist` directo
 
 Yes! If you would instead prefer to host the package yourself, a minified browser bundle can be found in the `dist/browser/` folder of the published npm package starting with version 1.9.0.
 
-## It says `Error: Can't resolve....` in the sdk
-
-This kind of errors is usually seen in Webpack 5 or Vite projects. You will need to install additional polyfill packages.
-
-#### Webpack 5 projects
-
-Typically, with Webpack 5 you would see:
-
-```
-Module not found: Error: Can't resolve 'crypto'
-ERROR in ./node_modules/algosdk/dist/browser/algosdk.min.js 7471:55-72
-```
-
-Webpack 5 no longer auto-polyfills some of the node modules used by this sdk. You will have to polyfill them to fix any errors regarding missing modules.
-
-#### Vite projects
-
-With Vite, you would see:
-
-```
-Uncaught ReferenceError: Buffer is not defined
-```
-
-You will have to install `buffer` as dependency.
-
-In `index.html`, add the following:
-
-```html
-<script type="module">
-  import { Buffer } from 'buffer';
-  window.Buffer = Buffer;
-</script>
-```
-
-To utilize the Buffer polyfill in production builds, in `vite.config.js`, add:
-
-```js
-import inject from '@rollup/plugin-inject';
-
-export default defineConfig({
-  ...,
-  build: {
-    rollupOptions: {
-      plugins: [inject({ Buffer: ['buffer', 'Buffer'] })],
-    },
-  },
-  ...
-});
-```
-
 ## How do I generate the SRI hash of `algosdk.min.js`?
 
 The SRI hash of `algosdk.min.js` is the base64 string after `sha384-` in the `integrity` attribute of the `<script>` tag used to import `algosdk.min.js`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # js-algorand-sdk
 
-[![Build Status](https://travis-ci.com/algorand/js-algorand-sdk.svg?branch=master)](https://travis-ci.com/algorand/js-algorand-sdk) [![npm version](https://badge.fury.io/js/algosdk.svg)](https://www.npmjs.com/package/algosdk)
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/algorand/js-algorand-sdk/tree/develop.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/algorand/js-algorand-sdk/tree/develop) [![npm version](https://badge.fury.io/js/algosdk.svg)](https://www.npmjs.com/package/algosdk)
 
 AlgoSDK is the official JavaScript library for communicating with the Algorand network. It's designed for modern browsers and Node.js.
 
@@ -13,8 +13,6 @@ $ npm install algosdk
 ```
 
 > This package provides TypeScript types, but you will need [TypeScript](https://www.typescriptlang.org/) version 4.2 or higher to use them properly.
-
-For errors in Webpack 5 or Vite projects, you will need to [install extra dependencies](FAQ.md#it-says-error-cant-resolve-in-the-sdk).
 
 ### Browser
 


### PR DESCRIPTION
Updates our status badge from Travis to Circle in the README, and remove old guidance for webpack v5 compatibility that was resolved in #707 and #733