### PR TITLE
DevOps: Add CODEOWNERS to restrict workflow editing

### DIFF
--- a/.github/workflows/pr-type-category.yml
+++ b/.github/workflows/pr-type-category.yml
@@ -17,8 +17,10 @@ jobs:
           labels: "New Feature, Enhancement, Bug-Fix, Not-Yet-Enabled, Skip-Release-Notes"
 
       - name: "Checking for PR Category in PR title. Should be like '<category>: <pr title>'."
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          if [[ ! "${{ github.event.pull_request.title }}" =~ ^.{2,}\:.{2,} ]]; then
+          if [[ ! "$PR_TITLE" =~ ^.{2,}\:.{2,} ]]; then
             echo "## PR Category is missing from PR title. Please add it like '<category>: <pr title>'." >> GITHUB_STEP_SUMMARY
             exit 1
           fi

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+.github/ @algorand/dev
+.circleci/ @algorand/dev


### PR DESCRIPTION
# Summary

Add a CODEOWNERS file to restrict edits to workflows.
