### PR TITLE
Client: Don't send auth header when token is empty

### DIFF
--- a/.test-env
+++ b/.test-env
@@ -1,6 +1,6 @@
 # Configs for testing repo download:
-SDK_TESTING_URL="https://github.com/algorand/algorand-sdk-testing"
-SDK_TESTING_BRANCH="master"
+SDK_TESTING_URL="https://github.com/Eric-Warehime/algorand-sdk-testing"
+SDK_TESTING_BRANCH="client-no-header-tests"
 SDK_TESTING_HARNESS="test-harness"
 
 INSTALL_ONLY=0

--- a/.test-env
+++ b/.test-env
@@ -1,6 +1,6 @@
 # Configs for testing repo download:
-SDK_TESTING_URL="https://github.com/Eric-Warehime/algorand-sdk-testing"
-SDK_TESTING_BRANCH="client-no-header-tests"
+SDK_TESTING_URL="https://github.com/algorand/algorand-sdk-testing"
+SDK_TESTING_BRANCH="master"
 SDK_TESTING_HARNESS="test-harness"
 
 INSTALL_ONLY=0

--- a/src/client/v2/serviceClient.ts
+++ b/src/client/v2/serviceClient.ts
@@ -19,6 +19,9 @@ function convertTokenStringToTokenHeader(
   headerIdentifier: TokenHeaderIdentifier
 ): TokenHeader {
   const tokenHeader = {};
+  if (token === '') {
+    return tokenHeader
+  }
   tokenHeader[headerIdentifier] = token;
   return tokenHeader as TokenHeader;
 }

--- a/src/client/v2/serviceClient.ts
+++ b/src/client/v2/serviceClient.ts
@@ -20,7 +20,7 @@ function convertTokenStringToTokenHeader(
 ): TokenHeader {
   const tokenHeader = {};
   if (token === '') {
-    return tokenHeader
+    return tokenHeader;
   }
   tokenHeader[headerIdentifier] = token;
   return tokenHeader as TokenHeader;

--- a/tests/9.Client.ts
+++ b/tests/9.Client.ts
@@ -161,6 +161,12 @@ describe('client', () => {
       assert.strictEqual(client.c['bc']['baseURL']['port'], '456');
     });
 
+    it('should not provide auth request headers when the token is empty', () => {
+      const client = new AlgodClient('', `${baseServer}:${123}`, 456);
+      assert.deepStrictEqual({...client.c['bc']['tokenHeaders'], ...client.c['bc']['defaultHeaders']}, {})
+
+    })
+
     /* eslint-disable dot-notation */
   });
 });

--- a/tests/9.Client.ts
+++ b/tests/9.Client.ts
@@ -163,9 +163,14 @@ describe('client', () => {
 
     it('should not provide auth request headers when the token is empty', () => {
       const client = new AlgodClient('', `${baseServer}:${123}`, 456);
-      assert.deepStrictEqual({...client.c['bc']['tokenHeaders'], ...client.c['bc']['defaultHeaders']}, {})
-
-    })
+      assert.deepStrictEqual(
+        {
+          ...client.c['bc']['tokenHeaders'],
+          ...client.c['bc']['defaultHeaders'],
+        },
+        {}
+      );
+    });
 
     /* eslint-disable dot-notation */
   });

--- a/tests/cucumber/steps/index.js
+++ b/tests/cucumber/steps/index.js
@@ -494,13 +494,10 @@ for (const name of Object.keys(steps.given)) {
     });
   } else if (name === 'expected headers') {
     Given(name, function (dataTable) {
-      return fn.call(
-        this,
-        dataTable
-          .rows()
-          .map((entry) => entry[0])
-          .concat(browserHeaders)
-      );
+      return fn.call(this, [
+        ...dataTable.rows().map((entry) => entry[0]),
+        ...browserHeaders,
+      ]);
     });
   } else {
     Given(name, fn);

--- a/tests/cucumber/steps/index.js
+++ b/tests/cucumber/steps/index.js
@@ -325,11 +325,11 @@ function setupMockServerForPaths(mockServer) {
   });
 }
 
-function getMockServerRequestUrlsMethods(mockServer) {
+function getMockServerRequestUrlsMethodsHeaders(mockServer) {
   return mockServer
     .requests()
     .filter((req) => req.method !== 'OPTIONS') // ignore cors preflight requests from the browser
-    .map((req) => ({ method: req.method, url: req.url }));
+    .map((req) => ({ method: req.method, url: req.url, headers: req.headers }));
 }
 
 function isFunction(functionToCheck) {
@@ -478,10 +478,10 @@ for (const name of Object.keys(steps.then)) {
   if (name === 'expect the path used to be {string}') {
     Then(name, function (expectedRequestPath) {
       // get all requests the mockservers have seen since reset
-      const algodSeenRequests = getMockServerRequestUrlsMethods(
+      const algodSeenRequests = getMockServerRequestUrlsMethodsHeaders(
         algodMockServerPathRecorder
       );
-      const indexerSeenRequests = getMockServerRequestUrlsMethods(
+      const indexerSeenRequests = getMockServerRequestUrlsMethodsHeaders(
         indexerMockServerPathRecorder
       );
       return fn.call(
@@ -494,10 +494,10 @@ for (const name of Object.keys(steps.then)) {
   } else if (name === 'expect the request to be {string} {string}') {
     Then(name, function (expectedRequestType, expectedRequestPath) {
       // get all requests the mockservers have seen since reset
-      const algodSeenRequests = getMockServerRequestUrlsMethods(
+      const algodSeenRequests = getMockServerRequestUrlsMethodsHeaders(
         algodMockServerPathRecorder
       );
-      const indexerSeenRequests = getMockServerRequestUrlsMethods(
+      const indexerSeenRequests = getMockServerRequestUrlsMethodsHeaders(
         indexerMockServerPathRecorder
       );
       return fn.call(
@@ -511,10 +511,10 @@ for (const name of Object.keys(steps.then)) {
   } else if (name === 'we expect the path used to be {string}') {
     Then(name, function (expectedRequestPath) {
       // get all requests the mockservers have seen since reset
-      const algodSeenRequests = getMockServerRequestUrlsMethods(
+      const algodSeenRequests = getMockServerRequestUrlsMethodsHeaders(
         algodMockServerPathRecorder
       );
-      const indexerSeenRequests = getMockServerRequestUrlsMethods(
+      const indexerSeenRequests = getMockServerRequestUrlsMethodsHeaders(
         indexerMockServerPathRecorder
       );
       return fn.call(
@@ -522,6 +522,21 @@ for (const name of Object.keys(steps.then)) {
         algodSeenRequests,
         indexerSeenRequests,
         expectedRequestPath
+      );
+    });
+  } else if (name === 'expect the observed header keys to equal the expected header keys') {
+    Then(name, function () {
+      // get all requests the mockservers have seen since reset
+      const algodSeenRequests = getMockServerRequestUrlsMethodsHeaders(
+        algodMockServerPathRecorder
+      );
+      const indexerSeenRequests = getMockServerRequestUrlsMethodsHeaders(
+        indexerMockServerPathRecorder
+      );
+      return fn.call(
+        this,
+        algodSeenRequests,
+        indexerSeenRequests,
       );
     });
   } else if (

--- a/tests/cucumber/steps/index.js
+++ b/tests/cucumber/steps/index.js
@@ -54,7 +54,6 @@ if (browser) {
   } else if (browser === 'chrome') {
     require('chromedriver');
     browserHeaders = [
-      'accept-language',
       'origin',
       'referer',
       'sec-ch-ua',
@@ -70,9 +69,6 @@ if (browser) {
       'accept-language',
       'origin',
       'referer',
-      'sec-ch-ua',
-      'sec-ch-ua-mobile',
-      'sec-ch-ua-platform',
       'sec-fetch-dest',
       'sec-fetch-mode',
       'sec-fetch-site',

--- a/tests/cucumber/steps/index.js
+++ b/tests/cucumber/steps/index.js
@@ -524,7 +524,9 @@ for (const name of Object.keys(steps.then)) {
         expectedRequestPath
       );
     });
-  } else if (name === 'expect the observed header keys to equal the expected header keys') {
+  } else if (
+    name === 'expect the observed header keys to equal the expected header keys'
+  ) {
     Then(name, function () {
       // get all requests the mockservers have seen since reset
       const algodSeenRequests = getMockServerRequestUrlsMethodsHeaders(
@@ -533,11 +535,7 @@ for (const name of Object.keys(steps.then)) {
       const indexerSeenRequests = getMockServerRequestUrlsMethodsHeaders(
         indexerMockServerPathRecorder
       );
-      return fn.call(
-        this,
-        algodSeenRequests,
-        indexerSeenRequests,
-      );
+      return fn.call(this, algodSeenRequests, indexerSeenRequests);
     });
   } else if (
     name === 'the produced json should equal {string} loaded from {string}'

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -1604,8 +1604,8 @@ module.exports = function getSteps(options) {
     );
   });
 
-  Given('expected headers', (headersTable) => {
-    this.expectedHeaders = headersTable.hashes();
+  Given('expected headers', (tableRows) => {
+    this.expectedHeaders = tableRows;
   });
 
   Then(
@@ -1621,7 +1621,7 @@ module.exports = function getSteps(options) {
       }
       assert.deepStrictEqual(
         Object.keys(actualRequests.headers).sort(),
-        this.expectedHeaders.map((entry) => entry.key).sort()
+        this.expectedHeaders.sort()
       );
     }
   );

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -1604,6 +1604,25 @@ module.exports = function getSteps(options) {
     );
   });
 
+  Given('expected headers', (headersTable) => {
+    this.expectedHeaders = headersTable.hashes()
+  })
+
+  Then('expect the observed header keys to equal the expected header keys', (algodSeenRequests, indexerSeenRequests) => {
+    let actualRequests;
+    if (algodSeenRequests.length !== 0) {
+      [actualRequests] = algodSeenRequests;
+    } else if (indexerSeenRequests.length !== 0) {
+      [actualRequests] = indexerSeenRequests;
+    } else {
+      throw new Error("no requests observed.")
+    }
+    assert.deepStrictEqual(
+      Object.keys(actualRequests.headers).sort(),
+      this.expectedHeaders.map((entry) => entry.key).sort()
+    );
+  })
+
   Then(
     'expect the path used to be {string}',
     (algodSeenRequests, indexerSeenRequests, expectedRequestPath) => {
@@ -3270,6 +3289,20 @@ module.exports = function getSteps(options) {
   );
 
   Given(
+    'an algod v2 client connected to mock server with token {string}',
+    function (token) {
+      this.v2Client = new algosdk.Algodv2(token, `http://${mockAlgodPathRecorderHost}`, mockAlgodPathRecorderPort, {});
+    }
+  );
+
+  Given(
+    'an indexer v2 client connected to mock server with token {string}',
+    function (token) {
+      this.indexerV2client = new algosdk.Indexer(token, `http://${mockIndexerPathRecorderHost}`, mockIndexerPathRecorderPort, {});
+    }
+  );
+
+  Given(
     'I create a new transient account and fund it with {int} microalgos.',
     async function (fundingAmount) {
       this.transientAccount = algosdk.generateAccount();
@@ -4779,6 +4812,14 @@ module.exports = function getSteps(options) {
 
   When('we make a UnsetSyncRound call', async function () {
     await this.v2Client.unsetSyncRound().do();
+  });
+
+  When('we make an arbitrary algod call', async function () {
+    await this.v2Client.healthCheck().do();
+  });
+
+  When('we make an arbitrary indexer call', async function () {
+    await this.indexerV2client.makeHealthCheck().do();
   });
 
   if (!options.ignoreReturn) {

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -1605,23 +1605,26 @@ module.exports = function getSteps(options) {
   });
 
   Given('expected headers', (headersTable) => {
-    this.expectedHeaders = headersTable.hashes()
-  })
+    this.expectedHeaders = headersTable.hashes();
+  });
 
-  Then('expect the observed header keys to equal the expected header keys', (algodSeenRequests, indexerSeenRequests) => {
-    let actualRequests;
-    if (algodSeenRequests.length !== 0) {
-      [actualRequests] = algodSeenRequests;
-    } else if (indexerSeenRequests.length !== 0) {
-      [actualRequests] = indexerSeenRequests;
-    } else {
-      throw new Error("no requests observed.")
+  Then(
+    'expect the observed header keys to equal the expected header keys',
+    (algodSeenRequests, indexerSeenRequests) => {
+      let actualRequests;
+      if (algodSeenRequests.length !== 0) {
+        [actualRequests] = algodSeenRequests;
+      } else if (indexerSeenRequests.length !== 0) {
+        [actualRequests] = indexerSeenRequests;
+      } else {
+        throw new Error('no requests observed.');
+      }
+      assert.deepStrictEqual(
+        Object.keys(actualRequests.headers).sort(),
+        this.expectedHeaders.map((entry) => entry.key).sort()
+      );
     }
-    assert.deepStrictEqual(
-      Object.keys(actualRequests.headers).sort(),
-      this.expectedHeaders.map((entry) => entry.key).sort()
-    );
-  })
+  );
 
   Then(
     'expect the path used to be {string}',
@@ -3291,14 +3294,24 @@ module.exports = function getSteps(options) {
   Given(
     'an algod v2 client connected to mock server with token {string}',
     function (token) {
-      this.v2Client = new algosdk.Algodv2(token, `http://${mockAlgodPathRecorderHost}`, mockAlgodPathRecorderPort, {});
+      this.v2Client = new algosdk.Algodv2(
+        token,
+        `http://${mockAlgodPathRecorderHost}`,
+        mockAlgodPathRecorderPort,
+        {}
+      );
     }
   );
 
   Given(
     'an indexer v2 client connected to mock server with token {string}',
     function (token) {
-      this.indexerV2client = new algosdk.Indexer(token, `http://${mockIndexerPathRecorderHost}`, mockIndexerPathRecorderPort, {});
+      this.indexerV2client = new algosdk.Indexer(
+        token,
+        `http://${mockIndexerPathRecorderHost}`,
+        mockIndexerPathRecorderPort,
+        {}
+      );
     }
   );
 

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -1619,10 +1619,16 @@ module.exports = function getSteps(options) {
       } else {
         throw new Error('no requests observed.');
       }
-      assert.deepStrictEqual(
-        Object.keys(actualRequests.headers).sort(),
-        this.expectedHeaders.sort()
+      const actualHeaders = Object.keys(actualRequests.headers).sort();
+      const expectedHeaders = this.expectedHeaders.sort();
+      assert.strictEqual(
+        actualHeaders.length,
+        expectedHeaders.length,
+        `expected headers ${expectedHeaders}, got ${actualHeaders}`
       );
+      for (let i = 0; i < actualHeaders.length; i++) {
+        assert.deepStrictEqual(actualHeaders[i], expectedHeaders[i]);
+      }
     }
   );
 

--- a/tests/cucumber/unit.tags
+++ b/tests/cucumber/unit.tags
@@ -6,6 +6,7 @@
 @unit.applications.boxes
 @unit.atomic_transaction_composer
 @unit.blocksummary
+@unit.client-no-headers
 @unit.dryrun
 @unit.dryrun.trace.application
 @unit.feetest


### PR DESCRIPTION
Implements #635 

This change removes the custom auth headers from requests for all of kmd, algod, and indexer clients. 

After removing this we should be sending only standard headers in requests which should avoid the preflight queries mentioned in 635.

I've added cucumber tests in https://github.com/algorand/algorand-sdk-testing/pull/282 and one test in `tests/9.Client.ts`