### PR TITLE
Enhancement: Verbose Harness

### DIFF
--- a/.test-env
+++ b/.test-env
@@ -5,7 +5,7 @@ SDK_TESTING_HARNESS="test-harness"
 
 INSTALL_ONLY=0
 
-VERBOSE_HARNESS=0
+VERBOSE_HARNESS=1
 
 # WARNING: If set to 1, new features will be LOST when downloading the test harness.
 # REGARDLESS: modified features are ALWAYS overwritten.


### PR DESCRIPTION
## Summary

To improve visibility of C.I. build failures, utilize new logging capabilities in the sandbox (https://github.com/algorand/sandbox/pull/181) and set `VERBOSE_HARNESS=1`.

In particular we can now see:
* traces of the `docker compose up` command
* dumped `docker-compose logs` for:
  * indexer-db
  * algod
  * indexer

### TODO

- [ ] Wait for https://github.com/algorand/algorand-sdk-testing/pull/288 to get merged

For more information about the effects of this PR on testing in C.I. see the sibling go-sdk pr: https://github.com/algorand/go-algorand-sdk/pull/540