### PR TITLE
Adds typeVersions to package.json …

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,19 @@
     "crypto": false
   },
   "types": "dist/types/index.d.ts",
+  "typesVersions": {
+    "*": {
+      ".": [
+        "dist/types/index.d.ts"
+      ],
+      "dist/cjs/*": [
+        "dist/types/*"
+      ],
+      "dist/esm/*": [
+        "dist/types/*"
+      ]
+    }
+  },
   "files": [
     "dist/",
     "src/"


### PR DESCRIPTION
Adds typeVersions to package.json so imports that don't target the root index.js file still have correct typings.

Currently having only the `types` property set means we only get typings when importing from file specified by the `main` property. Imports from sub-paths do not pick up correct typings.

eg.
![image](https://github.com/algorand/js-algorand-sdk/assets/6836315/80224447-34be-4213-ad41-6c6c107f1987)

Including this typeVersions section results in the imports being correctly typed.

![image](https://github.com/algorand/js-algorand-sdk/assets/6836315/12c56705-0783-4684-9e4a-c64afa00cf41)

An alternative solution would be to generate a full `exports` section then we could omit the `dist/esm` or `dist/cjs` section from the imports but this would be a breaking change for any existing usages and I'm hoping we can push this out as a patch release. 


