### PR TITLE
fetch: Add Cloudflare Workers support (cross-fetch v4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "algo-msgpack-with-bigint": "^2.1.1",
         "buffer": "^6.0.3",
-        "cross-fetch": "^3.1.5",
+        "cross-fetch": "^4.0.0-alpha.5",
         "hi-base32": "^0.5.1",
         "js-sha256": "^0.9.0",
         "js-sha3": "^0.8.0",
@@ -1937,11 +1937,11 @@
       "dev": true
     },
     "node_modules/cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "version": "4.0.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0-alpha.5.tgz",
+      "integrity": "sha512-JyOWYhayN5jX+vxmZC0w15BMUEVVmeHCodh5vfJQIFDF9jZZNfdQUFzZkviNtXMh+HwODYFxLnCOb7ZiztAdrw==",
       "dependencies": {
-        "node-fetch": "2.6.7"
+        "node-fetch": "^2.6.11"
       }
     },
     "node_modules/cross-spawn": {
@@ -5383,9 +5383,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -9520,11 +9520,11 @@
       "dev": true
     },
     "cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "version": "4.0.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0-alpha.5.tgz",
+      "integrity": "sha512-JyOWYhayN5jX+vxmZC0w15BMUEVVmeHCodh5vfJQIFDF9jZZNfdQUFzZkviNtXMh+HwODYFxLnCOb7ZiztAdrw==",
       "requires": {
-        "node-fetch": "2.6.7"
+        "node-fetch": "^2.6.11"
       }
     },
     "cross-spawn": {
@@ -12105,9 +12105,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
       "requires": {
         "whatwg-url": "^5.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "algo-msgpack-with-bigint": "^2.1.1",
     "buffer": "^6.0.3",
-    "cross-fetch": "^3.1.5",
+    "cross-fetch": "^4.0.0-alpha.5",
     "hi-base32": "^0.5.1",
     "js-sha256": "^0.9.0",
     "js-sha3": "^0.8.0",

--- a/src/client/urlTokenBaseHTTPClient.ts
+++ b/src/client/urlTokenBaseHTTPClient.ts
@@ -163,7 +163,6 @@ export class URLTokenBaseHTTPClient implements BaseHTTPClient {
     };
 
     const res = await fetch(this.getURL(relativePath, query), {
-      mode: 'cors',
       headers,
     });
 
@@ -185,7 +184,6 @@ export class URLTokenBaseHTTPClient implements BaseHTTPClient {
 
     const res = await fetch(this.getURL(relativePath, query), {
       method: 'POST',
-      mode: 'cors',
       body: data,
       headers,
     });
@@ -208,7 +206,6 @@ export class URLTokenBaseHTTPClient implements BaseHTTPClient {
 
     const res = await fetch(this.getURL(relativePath, query), {
       method: 'DELETE',
-      mode: 'cors',
       body: data,
       headers,
     });


### PR DESCRIPTION
at the @thencc we're using the js algosdk in cloudflare workers' v8 environment for EXTREME server-side benefits. 

by simply updating to [`cross-fetch` v4](https://www.npmjs.com/package/cross-fetch/v/4.0.0-alpha.5?activeTab=versions) (currently in alpha), `algosdk` can work in [chrome v8](https://www.cloudflare.com/learning/serverless/glossary/what-is-chrome-v8/) in addition to the usual node + browser envs. this was just recently made available as discussed here: https://github.com/lquixada/cross-fetch/pull/163 

as a byproduct, this PR removes the `mode: "cors"` arg in `algosdk`'s fetch calls as it is not supported by the fetch api available within workers. may i ask what is the real use for this arg anyway?