### PR TITLE
ATC: addMethodCall, addTransaction returns this

### DIFF
--- a/src/composer.ts
+++ b/src/composer.ts
@@ -169,7 +169,9 @@ export class AtomicTransactionComposer {
    * An error will be thrown if the transaction has a nonzero group ID, the composer's status is
    * not BUILDING, or if adding this transaction causes the current group to exceed MAX_GROUP_SIZE.
    */
-  addTransaction(txnAndSigner: TransactionWithSigner): void {
+  addTransaction(
+    txnAndSigner: TransactionWithSigner
+  ): AtomicTransactionComposer {
     if (this.status !== AtomicTransactionComposerStatus.BUILDING) {
       throw new Error(
         'Cannot add transactions when composer status is not BUILDING'
@@ -187,6 +189,8 @@ export class AtomicTransactionComposer {
     }
 
     this.transactions.push(txnAndSigner);
+
+    return this;
   }
 
   /**
@@ -261,7 +265,7 @@ export class AtomicTransactionComposer {
     rekeyTo?: string;
     /** A transaction signer that can authorize this application call from sender */
     signer: TransactionSigner;
-  }): void {
+  }): AtomicTransactionComposer {
     if (this.status !== AtomicTransactionComposerStatus.BUILDING) {
       throw new Error(
         'Cannot add transactions when composer status is not BUILDING'
@@ -483,6 +487,8 @@ export class AtomicTransactionComposer {
 
     this.transactions.push(...txnArgs, appCall);
     this.methodCalls.set(this.transactions.length - 1, method);
+
+    return this;
   }
 
   /**


### PR DESCRIPTION
This simply changes the return type of `addTransaction` and `addMethodCall` from `void` to `AtomicTransactionCompose` so these methods return the ATC. 

The goal is to allow chaining of methods when using the ATC rather than having to instantiate an object and call the methods on that object each time. 

For example:
```typescript
  const atc = new algosdk.AtomicTransactionComposer();
  atc.addTransaction();
  atc.addMethodCall();
  atc.execute();
```

vs

```typescript
  new algosdk.AtomicTransactionComposer()
    .addTransaction()
    .addMethodCall()
    .execute();
```

No major reason other than a nice minor QOL improvement