### PR TITLE
Align transaction fields to transaction reference spec

### DIFF
--- a/examples/accounts.ts
+++ b/examples/accounts.ts
@@ -42,8 +42,8 @@ async function main() {
   // example: MULTISIG_CREATE
 
   const fundMsigTxn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-    from: funder.addr,
-    to: multisigAddr,
+    sender: funder.addr,
+    receiver: multisigAddr,
     amount: 1_000_000,
     suggestedParams,
   });
@@ -53,8 +53,8 @@ async function main() {
 
   // example: MULTISIG_SIGN
   const msigTxn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-    from: multisigAddr,
-    to: funder.addr,
+    sender: multisigAddr,
+    receiver: funder.addr,
     amount: 100,
     suggestedParams,
   });
@@ -88,8 +88,8 @@ async function main() {
   // rekey the original account to the new signer via a payment transaction
   // Note any transaction type can be used to rekey an account
   const rekeyTxn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-    from: acct1.addr,
-    to: acct1.addr,
+    sender: acct1.addr,
+    receiver: acct1.addr,
     amount: 0,
     suggestedParams,
     rekeyTo: acct2.addr, // set the rekeyTo field to the new signer
@@ -110,8 +110,8 @@ async function main() {
   // the transaction is from originalAccount, but signed with newSigner private key
 
   const rekeyBack = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-    from: acct1.addr,
-    to: acct1.addr,
+    sender: acct1.addr,
+    receiver: acct1.addr,
     amount: 0,
     suggestedParams,
     rekeyTo: acct1.addr,

--- a/examples/app.ts
+++ b/examples/app.ts
@@ -49,7 +49,7 @@ async function main() {
 
   // example: APP_CREATE
   const appCreateTxn = algosdk.makeApplicationCreateTxnFromObject({
-    from: creator.addr,
+    sender: creator.addr,
     approvalProgram: new Uint8Array(compiledApprovalProgram),
     clearProgram: new Uint8Array(compiledClearProgram),
     numGlobalByteSlices,
@@ -78,7 +78,7 @@ async function main() {
 
   // example: APP_OPTIN
   const appOptInTxn = algosdk.makeApplicationOptInTxnFromObject({
-    from: caller.addr,
+    sender: caller.addr,
     appIndex: appId,
     suggestedParams,
   });
@@ -95,7 +95,7 @@ async function main() {
 
   // example: APP_NOOP
   const appNoOpTxn = algosdk.makeApplicationNoOpTxnFromObject({
-    from: caller.addr,
+    sender: caller.addr,
     appIndex: appId,
     suggestedParams,
   });
@@ -113,7 +113,7 @@ async function main() {
   const anotherCaller = accounts[2];
 
   const anotherAppOptInTxn = algosdk.makeApplicationOptInTxnFromObject({
-    from: anotherCaller.addr,
+    sender: anotherCaller.addr,
     appIndex: appId,
     suggestedParams,
   });
@@ -130,7 +130,7 @@ async function main() {
   // example: APP_CALL
   const now = new Date().toString();
   const simpleAddTxn = algosdk.makeApplicationNoOpTxnFromObject({
-    from: caller.addr,
+    sender: caller.addr,
     suggestedParams,
     appIndex: appId,
     appArgs: [new TextEncoder().encode(now)],
@@ -177,7 +177,7 @@ async function main() {
 
   // example: APP_CLOSEOUT
   const appCloseOutTxn = algosdk.makeApplicationCloseOutTxnFromObject({
-    from: caller.addr,
+    sender: caller.addr,
     appIndex: appId,
     suggestedParams,
   });
@@ -200,7 +200,7 @@ async function main() {
   const compiledNewProgram = await compileProgram(algodClient, newProgram);
 
   const appUpdateTxn = algosdk.makeApplicationUpdateTxnFromObject({
-    from: creator.addr,
+    sender: creator.addr,
     suggestedParams,
     appIndex: appId,
     // updates must define both approval and clear programs, even if unchanged
@@ -220,7 +220,7 @@ async function main() {
 
   // example: APP_CLEAR
   const appClearTxn = algosdk.makeApplicationClearStateTxnFromObject({
-    from: anotherCaller.addr,
+    sender: anotherCaller.addr,
     suggestedParams,
     appIndex: appId,
   });
@@ -237,7 +237,7 @@ async function main() {
 
   // example: APP_DELETE
   const appDeleteTxn = algosdk.makeApplicationDeleteTxnFromObject({
-    from: creator.addr,
+    sender: creator.addr,
     suggestedParams,
     appIndex: appId,
   });

--- a/examples/asa.ts
+++ b/examples/asa.ts
@@ -118,8 +118,8 @@ async function main() {
     from: manager.addr,
     suggestedParams,
     assetIndex,
-    // freezeState: false would unfreeze the account's asset holding
-    freezeState: true,
+    // assetFrozen: false would unfreeze the account's asset holding
+    assetFrozen: true,
     // freezeTarget is the account that is being frozen or unfrozen
     freezeTarget: receiver.addr,
   });

--- a/examples/asa.ts
+++ b/examples/asa.ts
@@ -138,8 +138,8 @@ async function main() {
     {
       sender: manager.addr,
       receiver: creator.addr,
-      // revocationTarget is the account that is being clawed back from
-      revocationTarget: receiver.addr,
+      // assetSender is the account that is being clawed back from
+      assetSender: receiver.addr,
       suggestedParams,
       assetIndex,
       amount: 1,

--- a/examples/asa.ts
+++ b/examples/asa.ts
@@ -17,7 +17,7 @@ async function main() {
   // example: ASSET_CREATE
   const suggestedParams = await algodClient.getTransactionParams().do();
   const txn = algosdk.makeAssetCreateTxnWithSuggestedParamsFromObject({
-    from: creator.addr,
+    sender: creator.addr,
     suggestedParams,
     defaultFrozen: false,
     unitName: 'rug',
@@ -61,7 +61,7 @@ async function main() {
   const manager = accounts[1];
 
   const configTxn = algosdk.makeAssetConfigTxnWithSuggestedParamsFromObject({
-    from: creator.addr,
+    sender: creator.addr,
     manager: manager.addr,
     freeze: manager.addr,
     clawback: manager.addr,
@@ -87,8 +87,8 @@ async function main() {
 
   // opt-in is simply a 0 amount transfer of the asset to oneself
   const optInTxn = algosdk.makeAssetTransferTxnWithSuggestedParamsFromObject({
-    from: receiver.addr,
-    to: receiver.addr,
+    sender: receiver.addr,
+    receiver: receiver.addr,
     suggestedParams,
     assetIndex,
     amount: 0,
@@ -101,8 +101,8 @@ async function main() {
 
   // example: ASSET_XFER
   const xferTxn = algosdk.makeAssetTransferTxnWithSuggestedParamsFromObject({
-    from: creator.addr,
-    to: receiver.addr,
+    sender: creator.addr,
+    receiver: receiver.addr,
     suggestedParams,
     assetIndex,
     amount: 1,
@@ -115,7 +115,7 @@ async function main() {
 
   // example: ASSET_FREEZE
   const freezeTxn = algosdk.makeAssetFreezeTxnWithSuggestedParamsFromObject({
-    from: manager.addr,
+    sender: manager.addr,
     suggestedParams,
     assetIndex,
     // assetFrozen: false would unfreeze the account's asset holding
@@ -136,8 +136,8 @@ async function main() {
   // example: ASSET_CLAWBACK
   const clawbackTxn = algosdk.makeAssetTransferTxnWithSuggestedParamsFromObject(
     {
-      from: manager.addr,
-      to: creator.addr,
+      sender: manager.addr,
+      receiver: creator.addr,
       // revocationTarget is the account that is being clawed back from
       revocationTarget: receiver.addr,
       suggestedParams,
@@ -161,8 +161,8 @@ async function main() {
   // any account that can receive the asset.
   // note that closing to the asset creator will always succeed
   const optOutTxn = algosdk.makeAssetTransferTxnWithSuggestedParamsFromObject({
-    from: receiver.addr,
-    to: creator.addr,
+    sender: receiver.addr,
+    receiver: creator.addr,
     closeRemainderTo: creator.addr,
     suggestedParams,
     assetIndex,
@@ -180,7 +180,7 @@ async function main() {
 
   // example: ASSET_DELETE
   const deleteTxn = algosdk.makeAssetDestroyTxnWithSuggestedParamsFromObject({
-    from: manager.addr,
+    sender: manager.addr,
     suggestedParams,
     assetIndex,
   });

--- a/examples/atc.ts
+++ b/examples/atc.ts
@@ -27,7 +27,7 @@ async function main() {
   const compiledClearProgram = await compileProgram(client, clearProgram);
 
   const createTxn = algosdk.makeApplicationCreateTxnFromObject({
-    from: sender.addr,
+    sender: sender.addr,
     suggestedParams,
     onComplete: algosdk.OnApplicationComplete.NoOpOC,
     approvalProgram: compiledApprovalProgram,
@@ -61,9 +61,9 @@ async function main() {
   // example: ATC_ADD_TRANSACTION
   // construct a transaction
   const paymentTxn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-    from: sender.addr,
+    sender: sender.addr,
     suggestedParams,
-    to: sender.addr,
+    receiver: sender.addr,
     amount: 1000,
   });
 

--- a/examples/atomics.ts
+++ b/examples/atomics.ts
@@ -16,15 +16,15 @@ async function main() {
   const suggestedParams = await client.getTransactionParams().do();
 
   const alicesTxn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-    from: acct1.addr,
-    to: acct2.addr,
+    sender: acct1.addr,
+    receiver: acct2.addr,
     amount: 1e6,
     suggestedParams,
   });
 
   const bobsTxn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-    from: acct2.addr,
-    to: acct1.addr,
+    sender: acct2.addr,
+    receiver: acct1.addr,
     amount: 1e6,
     suggestedParams,
   });

--- a/examples/codec.ts
+++ b/examples/codec.ts
@@ -35,8 +35,8 @@ async function main() {
 
   // example: CODEC_TRANSACTION_UNSIGNED
   const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-    from: sender.addr,
-    to: receiver.addr,
+    sender: sender.addr,
+    receiver: receiver.addr,
     amount: 1e6,
     suggestedParams,
   });

--- a/examples/indexer.ts
+++ b/examples/indexer.ts
@@ -64,8 +64,8 @@ async function main() {
   const sender = accounts[0];
 
   const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-    from: sender.addr,
-    to: sender.addr,
+    sender: sender.addr,
+    receiver: sender.addr,
     amount: 1e6,
     note: new TextEncoder().encode('Hello World!'),
     suggestedParams,

--- a/examples/lsig.ts
+++ b/examples/lsig.ts
@@ -33,8 +33,8 @@ async function main() {
   // example: LSIG_PASS_ARGS
 
   const fundSmartSigTxn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-    from: funder.addr,
-    to: smartSig.address(),
+    sender: funder.addr,
+    receiver: smartSig.address(),
     amount: 1e6,
     suggestedParams,
   });
@@ -50,8 +50,8 @@ async function main() {
 
   // example: LSIG_SIGN_FULL
   const smartSigTxn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-    from: smartSig.address(),
-    to: funder.addr,
+    sender: smartSig.address(),
+    receiver: funder.addr,
     amount: 0.1e6,
     suggestedParams,
   });
@@ -72,8 +72,8 @@ async function main() {
   smartSig.sign(userAccount.privateKey);
 
   const delegatedTxn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-    from: userAccount.addr,
-    to: funder.addr,
+    sender: userAccount.addr,
+    receiver: funder.addr,
     amount: 0.1e6,
     suggestedParams,
   });

--- a/examples/overview.ts
+++ b/examples/overview.ts
@@ -22,9 +22,9 @@ async function main() {
   // example: TRANSACTION_PAYMENT_CREATE
   const suggestedParams = await algodClient.getTransactionParams().do();
   const ptxn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-    from: acct.addr,
+    sender: acct.addr,
     suggestedParams,
-    to: acct2.addr,
+    receiver: acct2.addr,
     amount: 10000,
     note: new TextEncoder().encode('hello world'),
   });

--- a/examples/participation.ts
+++ b/examples/participation.ts
@@ -27,7 +27,7 @@ async function main() {
   // create transaction
   const onlineKeyreg = algosdk.makeKeyRegistrationTxnWithSuggestedParamsFromObject(
     {
-      from: addr,
+      sender: addr,
       voteKey,
       selectionKey,
       stateProofKey,
@@ -47,7 +47,7 @@ async function main() {
   // create keyreg transaction to take this account offline
   const offlineKeyReg = algosdk.makeKeyRegistrationTxnWithSuggestedParamsFromObject(
     {
-      from: addr,
+      sender: addr,
       suggestedParams,
       nonParticipation: true,
     }

--- a/examples/participation.ts
+++ b/examples/participation.ts
@@ -31,8 +31,8 @@ async function main() {
       voteKey,
       selectionKey,
       stateProofKey,
-      voteFirst: params.firstRound,
-      voteLast: params.firstRound + numRounds,
+      voteFirst: params.firstValid,
+      voteLast: params.firstValid + numRounds,
       voteKeyDilution: keyDilution,
       suggestedParams: params,
     }

--- a/examples/utils.ts
+++ b/examples/utils.ts
@@ -110,7 +110,7 @@ export async function deployCalculatorApp(
   const clearBin = await compileProgram(algodClient, clearProgram);
   const suggestedParams = await algodClient.getTransactionParams().do();
   const appCreateTxn = algosdk.makeApplicationCreateTxnFromObject({
-    from: creator.addr,
+    sender: creator.addr,
     approvalProgram: approvalBin,
     clearProgram: clearBin,
     numGlobalByteSlices: 0,

--- a/src/client/v2/algod/algod.ts
+++ b/src/client/v2/algod/algod.ts
@@ -358,8 +358,8 @@ export default class AlgodClient extends ServiceClient {
    * const suggestedParams = await algodClient.getTransactionParams().do();
    * const amountInMicroAlgos = algosdk.algosToMicroalgos(2); // 2 Algos
    * const unsignedTxn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-   *   from: senderAddress,
-   *   to: receiverAddress,
+   *   sender: senderAddress,
+   *   receiver: receiverAddress,
    *   amount: amountInMicroAlgos,
    *   suggestedParams: suggestedParams,
    * });

--- a/src/client/v2/algod/suggestedParams.ts
+++ b/src/client/v2/algod/suggestedParams.ts
@@ -14,8 +14,8 @@ export default class SuggestedParamsRequest extends JSONRequest<SuggestedParamsW
     return {
       flatFee: false,
       fee: body.fee,
-      firstRound: body['last-round'],
-      lastRound: body['last-round'] + 1000,
+      firstValid: body['last-round'],
+      lastValid: body['last-round'] + 1000,
       genesisID: body['genesis-id'],
       genesisHash: body['genesis-hash'],
       minFee: body['min-fee'],

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -458,7 +458,7 @@ export class AtomicTransactionComposer {
 
     const appCall = {
       txn: makeApplicationCallTxnFromObject({
-        from: sender,
+        sender,
         appIndex: appID,
         appArgs: appArgsEncoded,
         accounts: foreignAccounts,

--- a/src/dryrun.ts
+++ b/src/dryrun.ts
@@ -74,7 +74,7 @@ export async function createDryrun({
 
   for (const t of txns) {
     if (t.txn.type === TransactionType.appl) {
-      accts.push(encodeAddress(t.txn.from.publicKey));
+      accts.push(encodeAddress(t.txn.sender.publicKey));
 
       if (t.txn.appAccounts)
         accts.push(...t.txn.appAccounts.map((a) => encodeAddress(a.publicKey)));
@@ -94,7 +94,7 @@ export async function createDryrun({
           new Application({
             id: defaultAppId,
             params: new ApplicationParams({
-              creator: encodeAddress(t.txn.from.publicKey),
+              creator: encodeAddress(t.txn.sender.publicKey),
               approvalProgram: t.txn.appApprovalProgram,
               clearStateProgram: t.txn.appClearProgram,
               localStateSchema: new ApplicationStateSchema({

--- a/src/group.ts
+++ b/src/group.ts
@@ -75,18 +75,18 @@ export function computeGroupID(txns: txnBuilder.TransactionLike[]) {
 /**
  * assignGroupID assigns group id to a given list of unsigned transactions
  * @param txns - array of transactions (every element is a dict or Transaction)
- * @param from - optional sender address specifying which transaction return
+ * @param sender - optional sender address specifying which transaction return
  * @returns possible list of matching transactions
  */
 export function assignGroupID(
   txns: txnBuilder.TransactionLike[],
-  from?: string
+  sender?: string
 ) {
   const gid = computeGroupID(txns);
   const result: txnBuilder.Transaction[] = [];
   for (const txn of txns) {
     const tx = txnBuilder.instantiateTxnIfNeeded(txn);
-    if (!from || address.encodeAddress(tx.from.publicKey) === from) {
+    if (!sender || address.encodeAddress(tx.sender.publicKey) === sender) {
       tx.group = gid;
       result.push(tx);
     }

--- a/src/logicsig.ts
+++ b/src/logicsig.ts
@@ -391,7 +391,7 @@ function signLogicSigTransactionWithAddress(
     txn: txn.get_obj_for_encoding(),
   };
 
-  if (!nacl.bytesEqual(lsigAddress, txn.from.publicKey)) {
+  if (!nacl.bytesEqual(lsigAddress, txn.sender.publicKey)) {
     signedTxn.sgnr = lsigAddress;
   }
 
@@ -428,7 +428,7 @@ export function signLogicSigTransactionObject(
       // the address of that account from only its signature, so assume the
       // delegating account is the sender. If that's not the case, the signing
       // will fail.
-      lsigAddress = txn.from.publicKey;
+      lsigAddress = txn.sender.publicKey;
     } else if (lsig.msig) {
       const msigMetadata = {
         version: lsig.msig.v,

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,10 +16,10 @@ export const MULTISIG_BAD_SENDER_ERROR_MSG =
  * signTransaction takes an object with either payment or key registration fields and
  * a secret key and returns a signed blob.
  *
- * Payment transaction fields: from, to, amount, fee, firstRound, lastRound, genesisHash,
+ * Payment transaction fields: from, to, amount, fee, firstValid, lastValid, genesisHash,
  * note(optional), GenesisID(optional), closeRemainderTo(optional)
  *
- * Key registration fields: fee, firstRound, lastRound, voteKey, selectionKey, voteFirst,
+ * Key registration fields: fee, firstValid, lastValid, voteKey, selectionKey, voteFirst,
  * voteLast, voteKeyDilution, genesisHash, note(optional), GenesisID(optional)
  *
  * If flatFee is not set and the final calculated fee is lower than the protocol minimum fee, the fee will be increased to match the minimum.

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,11 +31,11 @@ export function signTransaction(
   txn: txnBuilder.TransactionLike,
   sk: Uint8Array
 ) {
-  if (typeof txn.from === 'undefined') {
+  if (typeof txn.sender === 'undefined') {
     // Get pk from sk if no sender specified
     const key = nacl.keyPairFromSecretKey(sk);
     // eslint-disable-next-line no-param-reassign
-    txn.from = address.encodeAddress(key.publicKey);
+    txn.sender = address.encodeAddress(key.publicKey);
   }
   const algoTxn = txnBuilder.instantiateTxnIfNeeded(txn);
 

--- a/src/makeTxn.ts
+++ b/src/makeTxn.ts
@@ -25,8 +25,8 @@ import { RenameProperties, RenameProperty, Expand } from './types/utils';
 
 /**
  * makePaymentTxnWithSuggestedParams takes payment arguments and returns a Transaction object
- * @param from - string representation of Algorand address of sender
- * @param to - string representation of Algorand address of recipient
+ * @param sender - string representation of Algorand address of sender
+ * @param receiver - string representation of Algorand address of recipient
  * @param amount - integer amount to send, in microAlgos
  * @param closeRemainderTo - optionally close out remaining account balance to this account, represented as string rep of Algorand address
  * @param note - uint8array of arbitrary data for sender to store
@@ -41,8 +41,8 @@ import { RenameProperties, RenameProperty, Expand } from './types/utils';
  * @param rekeyTo - rekeyTo address, optional
  */
 export function makePaymentTxnWithSuggestedParams(
-  from: PaymentTxn['from'],
-  to: PaymentTxn['to'],
+  sender: PaymentTxn['sender'],
+  receiver: PaymentTxn['receiver'],
   amount: PaymentTxn['amount'],
   closeRemainderTo: PaymentTxn['closeRemainderTo'],
   note: PaymentTxn['note'],
@@ -50,8 +50,8 @@ export function makePaymentTxnWithSuggestedParams(
   rekeyTo?: PaymentTxn['reKeyTo']
 ) {
   const o: PaymentTxn = {
-    from,
-    to,
+    sender,
+    receiver,
     amount,
     closeRemainderTo,
     note,
@@ -67,8 +67,8 @@ export function makePaymentTxnWithSuggestedParamsFromObject(
   o: Expand<
     Pick<
       RenameProperty<MustHaveSuggestedParams<PaymentTxn>, 'reKeyTo', 'rekeyTo'>,
-      | 'from'
-      | 'to'
+      | 'sender'
+      | 'receiver'
       | 'amount'
       | 'closeRemainderTo'
       | 'note'
@@ -78,8 +78,8 @@ export function makePaymentTxnWithSuggestedParamsFromObject(
   >
 ) {
   return makePaymentTxnWithSuggestedParams(
-    o.from,
-    o.to,
+    o.sender,
+    o.receiver,
     o.amount,
     o.closeRemainderTo,
     o.note,
@@ -92,7 +92,7 @@ export function makePaymentTxnWithSuggestedParamsFromObject(
  * makeKeyRegistrationTxnWithSuggestedParams takes key registration arguments and returns a Transaction object for
  * that key registration operation
  *
- * @param from - string representation of Algorand address of sender
+ * @param sender - string representation of Algorand address of sender
  * @param note - uint8array of arbitrary data for sender to store
  * @param voteKey - voting key. for key deregistration, leave undefined
  * @param selectionKey - selection key. for key deregistration, leave undefined
@@ -113,7 +113,7 @@ export function makePaymentTxnWithSuggestedParamsFromObject(
  * @param stateProofKey - state proof key. for key deregistration, leave undefined
  */
 export function makeKeyRegistrationTxnWithSuggestedParams(
-  from: KeyRegistrationTxn['from'],
+  sender: KeyRegistrationTxn['sender'],
   note: KeyRegistrationTxn['note'],
   voteKey: KeyRegistrationTxn['voteKey'],
   selectionKey: KeyRegistrationTxn['selectionKey'],
@@ -126,7 +126,7 @@ export function makeKeyRegistrationTxnWithSuggestedParams(
   stateProofKey?: KeyRegistrationTxn['stateProofKey']
 ): txnBuilder.Transaction;
 export function makeKeyRegistrationTxnWithSuggestedParams(
-  from: KeyRegistrationTxn['from'],
+  sender: KeyRegistrationTxn['sender'],
   note: KeyRegistrationTxn['note'],
   voteKey: undefined,
   selectionKey: undefined,
@@ -139,7 +139,7 @@ export function makeKeyRegistrationTxnWithSuggestedParams(
   stateProofKey?: undefined
 ): txnBuilder.Transaction;
 export function makeKeyRegistrationTxnWithSuggestedParams(
-  from: any,
+  sender: any,
   note: any,
   voteKey: any,
   selectionKey: any,
@@ -152,7 +152,7 @@ export function makeKeyRegistrationTxnWithSuggestedParams(
   stateProofKey: any = undefined
 ) {
   const o: KeyRegistrationTxn = {
-    from,
+    sender,
     note,
     voteKey,
     selectionKey,
@@ -177,7 +177,7 @@ export function makeKeyRegistrationTxnWithSuggestedParamsFromObject(
         'reKeyTo',
         'rekeyTo'
       >,
-      | 'from'
+      | 'sender'
       | 'note'
       | 'voteKey'
       | 'selectionKey'
@@ -200,13 +200,13 @@ export function makeKeyRegistrationTxnWithSuggestedParamsFromObject(
         'reKeyTo',
         'rekeyTo'
       >,
-      'from' | 'note' | 'suggestedParams' | 'rekeyTo' | 'nonParticipation'
+      'sender' | 'note' | 'suggestedParams' | 'rekeyTo' | 'nonParticipation'
     >
   >
 ): txnBuilder.Transaction;
 export function makeKeyRegistrationTxnWithSuggestedParamsFromObject(o: any) {
   return makeKeyRegistrationTxnWithSuggestedParams(
-    o.from,
+    o.sender,
     o.note,
     o.voteKey,
     o.selectionKey,
@@ -223,7 +223,7 @@ export function makeKeyRegistrationTxnWithSuggestedParamsFromObject(o: any) {
 /** makeAssetCreateTxnWithSuggestedParams takes asset creation arguments and returns a Transaction object
  * for creating that asset
  *
- * @param from - string representation of Algorand address of sender
+ * @param sender - string representation of Algorand address of sender
  * @param note - uint8array of arbitrary data for sender to store
  * @param total - integer total supply of the asset
  * @param decimals - integer number of decimals for asset unit calculation
@@ -247,7 +247,7 @@ export function makeKeyRegistrationTxnWithSuggestedParamsFromObject(o: any) {
  * @param rekeyTo - rekeyTo address, optional
  */
 export function makeAssetCreateTxnWithSuggestedParams(
-  from: AssetCreateTxn['from'],
+  sender: AssetCreateTxn['sender'],
   note: AssetCreateTxn['note'],
   total: AssetCreateTxn['assetTotal'],
   decimals: AssetCreateTxn['assetDecimals'],
@@ -264,7 +264,7 @@ export function makeAssetCreateTxnWithSuggestedParams(
   rekeyTo?: AssetCreateTxn['reKeyTo']
 ) {
   const o: AssetCreateTxn = {
-    from,
+    sender,
     note,
     suggestedParams,
     assetTotal: total,
@@ -302,7 +302,7 @@ export function makeAssetCreateTxnWithSuggestedParamsFromObject(
           assetUnitName: 'unitName';
         }
       >,
-      | 'from'
+      | 'sender'
       | 'note'
       | 'total'
       | 'decimals'
@@ -321,7 +321,7 @@ export function makeAssetCreateTxnWithSuggestedParamsFromObject(
   >
 ) {
   return makeAssetCreateTxnWithSuggestedParams(
-    o.from,
+    o.sender,
     o.note,
     o.total,
     o.decimals,
@@ -343,7 +343,7 @@ export function makeAssetCreateTxnWithSuggestedParamsFromObject(
  * you must respecify existing addresses to keep them the same; leaving a field blank is the same as turning
  * that feature off for this asset
  *
- * @param from - string representation of Algorand address of sender
+ * @param sender - string representation of Algorand address of sender
  * @param note - uint8array of arbitrary data for sender to store
  * @param assetIndex - int asset index uniquely specifying the asset
  * @param manager - string representation of new asset manager Algorand address
@@ -362,7 +362,7 @@ export function makeAssetCreateTxnWithSuggestedParamsFromObject(
  * @param rekeyTo - rekeyTo address, optional
  */
 export function makeAssetConfigTxnWithSuggestedParams(
-  from: AssetConfigTxn['from'],
+  sender: AssetConfigTxn['sender'],
   note: AssetConfigTxn['note'],
   assetIndex: AssetConfigTxn['assetIndex'],
   manager: AssetConfigTxn['assetManager'],
@@ -385,7 +385,7 @@ export function makeAssetConfigTxnWithSuggestedParams(
     );
   }
   const o: AssetConfigTxn = {
-    from,
+    sender,
     suggestedParams,
     assetIndex,
     assetManager: manager,
@@ -413,7 +413,7 @@ export function makeAssetConfigTxnWithSuggestedParamsFromObject(
           assetClawback: 'clawback';
         }
       >,
-      | 'from'
+      | 'sender'
       | 'note'
       | 'assetIndex'
       | 'manager'
@@ -428,7 +428,7 @@ export function makeAssetConfigTxnWithSuggestedParamsFromObject(
   >
 ) {
   return makeAssetConfigTxnWithSuggestedParams(
-    o.from,
+    o.sender,
     o.note,
     o.assetIndex,
     o.manager,
@@ -444,7 +444,7 @@ export function makeAssetConfigTxnWithSuggestedParamsFromObject(
 /** makeAssetDestroyTxnWithSuggestedParams will allow the asset's manager to remove this asset from the ledger, so long
  * as all outstanding assets are held by the creator.
  *
- * @param from - string representation of Algorand address of sender
+ * @param sender - string representation of Algorand address of sender
  * @param note - uint8array of arbitrary data for sender to store
  * @param assetIndex - int asset index uniquely specifying the asset
  * @param suggestedParams - a dict holding common-to-all-txns args:
@@ -458,14 +458,14 @@ export function makeAssetConfigTxnWithSuggestedParamsFromObject(
  * @param rekeyTo - rekeyTo address, optional
  */
 export function makeAssetDestroyTxnWithSuggestedParams(
-  from: AssetDestroyTxn['from'],
+  sender: AssetDestroyTxn['sender'],
   note: AssetDestroyTxn['note'],
   assetIndex: AssetDestroyTxn['assetIndex'],
   suggestedParams: MustHaveSuggestedParams<AssetDestroyTxn>['suggestedParams'],
   rekeyTo?: AssetDestroyTxn['reKeyTo']
 ) {
   const o: AssetDestroyTxn = {
-    from,
+    sender,
     suggestedParams,
     assetIndex,
     type: TransactionType.acfg,
@@ -484,12 +484,12 @@ export function makeAssetDestroyTxnWithSuggestedParamsFromObject(
         'reKeyTo',
         'rekeyTo'
       >,
-      'from' | 'note' | 'assetIndex' | 'suggestedParams' | 'rekeyTo'
+      'sender' | 'note' | 'assetIndex' | 'suggestedParams' | 'rekeyTo'
     >
   >
 ) {
   return makeAssetDestroyTxnWithSuggestedParams(
-    o.from,
+    o.sender,
     o.note,
     o.assetIndex,
     o.suggestedParams,
@@ -500,7 +500,7 @@ export function makeAssetDestroyTxnWithSuggestedParamsFromObject(
 /** makeAssetFreezeTxnWithSuggestedParams will allow the asset's freeze manager to freeze or un-freeze an account,
  * blocking or allowing asset transfers to and from the targeted account.
  *
- * @param from - string representation of Algorand address of sender
+ * @param sender - string representation of Algorand address of sender
  * @param note - uint8array of arbitrary data for sender to store
  * @param assetIndex - int asset index uniquely specifying the asset
  * @param freezeTarget - string representation of Algorand address being frozen or unfrozen
@@ -516,7 +516,7 @@ export function makeAssetDestroyTxnWithSuggestedParamsFromObject(
  * @param rekeyTo - rekeyTo address, optional
  */
 export function makeAssetFreezeTxnWithSuggestedParams(
-  from: AssetFreezeTxn['from'],
+  sender: AssetFreezeTxn['sender'],
   note: AssetFreezeTxn['note'],
   assetIndex: AssetFreezeTxn['assetIndex'],
   freezeTarget: AssetFreezeTxn['freezeAccount'],
@@ -525,7 +525,7 @@ export function makeAssetFreezeTxnWithSuggestedParams(
   rekeyTo?: AssetFreezeTxn['reKeyTo']
 ) {
   const o: AssetFreezeTxn = {
-    from,
+    sender,
     type: TransactionType.afrz,
     freezeAccount: freezeTarget,
     assetIndex,
@@ -548,7 +548,7 @@ export function makeAssetFreezeTxnWithSuggestedParamsFromObject(
           reKeyTo: 'rekeyTo';
         }
       >,
-      | 'from'
+      | 'sender'
       | 'note'
       | 'assetIndex'
       | 'freezeTarget'
@@ -559,7 +559,7 @@ export function makeAssetFreezeTxnWithSuggestedParamsFromObject(
   >
 ) {
   return makeAssetFreezeTxnWithSuggestedParams(
-    o.from,
+    o.sender,
     o.note,
     o.assetIndex,
     o.freezeTarget,
@@ -570,14 +570,14 @@ export function makeAssetFreezeTxnWithSuggestedParamsFromObject(
 }
 
 /** makeAssetTransferTxnWithSuggestedParams allows for the creation of an asset transfer transaction.
- * Special case: to begin accepting assets, set amount=0 and from=to.
+ * Special case: to begin accepting assets, set amount=0 and sender=receiver.
  *
- * @param from - string representation of Algorand address of sender
- * @param to - string representation of Algorand address of asset recipient
+ * @param sender - string representation of Algorand address of sender
+ * @param receiver - string representation of Algorand address of asset recipient
  * @param closeRemainderTo - optional - string representation of Algorand address - if provided,
- * send all remaining assets after transfer to the "closeRemainderTo" address and close "from"'s asset holdings
+ * send all remaining assets after transfer to the "closeRemainderTo" address and close "sender"'s asset holdings
  * @param revocationTarget - optional - string representation of Algorand address - if provided,
- * and if "from" is the asset's revocation manager, then deduct from "revocationTarget" rather than "from"
+ * and if "sender" is the asset's revocation manager, then deduct from "revocationTarget" rather than "sender"
  * @param amount - integer amount of assets to send
  * @param note - uint8array of arbitrary data for sender to store
  * @param assetIndex - int asset index uniquely specifying the asset
@@ -594,8 +594,8 @@ export function makeAssetFreezeTxnWithSuggestedParamsFromObject(
  * @param rekeyTo - rekeyTo address, optional
  */
 export function makeAssetTransferTxnWithSuggestedParams(
-  from: AssetTransferTxn['from'],
-  to: AssetTransferTxn['to'],
+  sender: AssetTransferTxn['sender'],
+  receiver: AssetTransferTxn['receiver'],
   closeRemainderTo: AssetTransferTxn['closeRemainderTo'],
   revocationTarget: AssetTransferTxn['assetRevocationTarget'],
   amount: AssetTransferTxn['amount'],
@@ -606,8 +606,8 @@ export function makeAssetTransferTxnWithSuggestedParams(
 ) {
   const o: AssetTransferTxn = {
     type: TransactionType.axfer,
-    from,
-    to,
+    sender,
+    receiver,
     amount,
     suggestedParams,
     assetIndex,
@@ -630,8 +630,8 @@ export function makeAssetTransferTxnWithSuggestedParamsFromObject(
           reKeyTo: 'rekeyTo';
         }
       >,
-      | 'from'
-      | 'to'
+      | 'sender'
+      | 'receiver'
       | 'closeRemainderTo'
       | 'revocationTarget'
       | 'amount'
@@ -643,8 +643,8 @@ export function makeAssetTransferTxnWithSuggestedParamsFromObject(
   >
 ) {
   return makeAssetTransferTxnWithSuggestedParams(
-    o.from,
-    o.to,
+    o.sender,
+    o.receiver,
     o.closeRemainderTo,
     o.revocationTarget,
     o.amount,
@@ -657,7 +657,7 @@ export function makeAssetTransferTxnWithSuggestedParamsFromObject(
 
 /**
  * Make a transaction that will create an application.
- * @param from - address of sender
+ * @param sender - address of sender
  * @param suggestedParams - a dict holding common-to-all-txns args:
  * fee - integer fee per byte, in microAlgos. for a flat fee, set flatFee to true
  * flatFee - bool optionally set this to true to specify fee as microalgos-per-txn
@@ -684,7 +684,7 @@ export function makeAssetTransferTxnWithSuggestedParamsFromObject(
  * @param boxes - Array of BoxReference, app ID and name of box to be accessed
  */
 export function makeApplicationCreateTxn(
-  from: AppCreateTxn['from'],
+  sender: AppCreateTxn['sender'],
   suggestedParams: MustHaveSuggestedParams<AppCreateTxn>['suggestedParams'],
   onComplete: AppCreateTxn['appOnComplete'],
   approvalProgram: AppCreateTxn['appApprovalProgram'],
@@ -705,7 +705,7 @@ export function makeApplicationCreateTxn(
 ) {
   const o: AppCreateTxn = {
     type: TransactionType.appl,
-    from,
+    sender,
     suggestedParams,
     appIndex: 0,
     appOnComplete: onComplete,
@@ -748,7 +748,7 @@ export function makeApplicationCreateTxnFromObject(
           reKeyTo: 'rekeyTo';
         }
       >,
-      | 'from'
+      | 'sender'
       | 'suggestedParams'
       | 'onComplete'
       | 'approvalProgram'
@@ -770,7 +770,7 @@ export function makeApplicationCreateTxnFromObject(
   >
 ) {
   return makeApplicationCreateTxn(
-    o.from,
+    o.sender,
     o.suggestedParams,
     o.onComplete,
     o.approvalProgram,
@@ -793,7 +793,7 @@ export function makeApplicationCreateTxnFromObject(
 
 /**
  * Make a transaction that changes an application's approval and clear programs
- * @param from - address of sender
+ * @param sender - address of sender
  * @param suggestedParams - a dict holding common-to-all-txns args:
  * fee - integer fee per byte, in microAlgos. for a flat fee, set flatFee to true
  * flatFee - bool optionally set this to true to specify fee as microalgos-per-txn
@@ -815,7 +815,7 @@ export function makeApplicationCreateTxnFromObject(
  * @param boxes - Array of BoxReference, app ID and name of box to be accessed
  */
 export function makeApplicationUpdateTxn(
-  from: AppUpdateTxn['from'],
+  sender: AppUpdateTxn['sender'],
   suggestedParams: MustHaveSuggestedParams<AppUpdateTxn>['suggestedParams'],
   appIndex: AppUpdateTxn['appIndex'],
   approvalProgram: AppUpdateTxn['appApprovalProgram'],
@@ -831,7 +831,7 @@ export function makeApplicationUpdateTxn(
 ) {
   const o: AppUpdateTxn = {
     type: TransactionType.appl,
-    from,
+    sender,
     suggestedParams,
     appIndex,
     appApprovalProgram: approvalProgram,
@@ -864,7 +864,7 @@ export function makeApplicationUpdateTxnFromObject(
           reKeyTo: 'rekeyTo';
         }
       >,
-      | 'from'
+      | 'sender'
       | 'suggestedParams'
       | 'appIndex'
       | 'approvalProgram'
@@ -881,7 +881,7 @@ export function makeApplicationUpdateTxnFromObject(
   >
 ) {
   return makeApplicationUpdateTxn(
-    o.from,
+    o.sender,
     o.suggestedParams,
     o.appIndex,
     o.approvalProgram,
@@ -899,7 +899,7 @@ export function makeApplicationUpdateTxnFromObject(
 
 /**
  * Make a transaction that deletes an application
- * @param from - address of sender
+ * @param sender - address of sender
  * @param suggestedParams - a dict holding common-to-all-txns args:
  * fee - integer fee per byte, in microAlgos. for a flat fee, set flatFee to true
  * flatFee - bool optionally set this to true to specify fee as microalgos-per-txn
@@ -919,7 +919,7 @@ export function makeApplicationUpdateTxnFromObject(
  * @param boxes - Array of BoxReference, app ID and name of box to be accessed
  */
 export function makeApplicationDeleteTxn(
-  from: AppDeleteTxn['from'],
+  sender: AppDeleteTxn['sender'],
   suggestedParams: MustHaveSuggestedParams<AppDeleteTxn>['suggestedParams'],
   appIndex: AppDeleteTxn['appIndex'],
   appArgs?: AppDeleteTxn['appArgs'],
@@ -933,7 +933,7 @@ export function makeApplicationDeleteTxn(
 ) {
   const o: AppDeleteTxn = {
     type: TransactionType.appl,
-    from,
+    sender,
     suggestedParams,
     appIndex,
     appOnComplete: OnApplicationComplete.DeleteApplicationOC,
@@ -962,7 +962,7 @@ export function makeApplicationDeleteTxnFromObject(
           reKeyTo: 'rekeyTo';
         }
       >,
-      | 'from'
+      | 'sender'
       | 'suggestedParams'
       | 'appIndex'
       | 'appArgs'
@@ -977,7 +977,7 @@ export function makeApplicationDeleteTxnFromObject(
   >
 ) {
   return makeApplicationDeleteTxn(
-    o.from,
+    o.sender,
     o.suggestedParams,
     o.appIndex,
     o.appArgs,
@@ -993,7 +993,7 @@ export function makeApplicationDeleteTxnFromObject(
 
 /**
  * Make a transaction that opts in to use an application
- * @param from - address of sender
+ * @param sender - address of sender
  * @param suggestedParams - a dict holding common-to-all-txns args:
  * fee - integer fee per byte, in microAlgos. for a flat fee, set flatFee to true
  * flatFee - bool optionally set this to true to specify fee as microalgos-per-txn
@@ -1013,7 +1013,7 @@ export function makeApplicationDeleteTxnFromObject(
  * @param boxes - Array of BoxReference, app ID and name of box to be accessed
  */
 export function makeApplicationOptInTxn(
-  from: AppOptInTxn['from'],
+  sender: AppOptInTxn['sender'],
   suggestedParams: MustHaveSuggestedParams<AppOptInTxn>['suggestedParams'],
   appIndex: AppOptInTxn['appIndex'],
   appArgs?: AppOptInTxn['appArgs'],
@@ -1027,7 +1027,7 @@ export function makeApplicationOptInTxn(
 ) {
   const o: AppOptInTxn = {
     type: TransactionType.appl,
-    from,
+    sender,
     suggestedParams,
     appIndex,
     appOnComplete: OnApplicationComplete.OptInOC,
@@ -1056,7 +1056,7 @@ export function makeApplicationOptInTxnFromObject(
           reKeyTo: 'rekeyTo';
         }
       >,
-      | 'from'
+      | 'sender'
       | 'suggestedParams'
       | 'appIndex'
       | 'appArgs'
@@ -1071,7 +1071,7 @@ export function makeApplicationOptInTxnFromObject(
   >
 ) {
   return makeApplicationOptInTxn(
-    o.from,
+    o.sender,
     o.suggestedParams,
     o.appIndex,
     o.appArgs,
@@ -1087,7 +1087,7 @@ export function makeApplicationOptInTxnFromObject(
 
 /**
  * Make a transaction that closes out a user's state in an application
- * @param from - address of sender
+ * @param sender - address of sender
  * @param suggestedParams - a dict holding common-to-all-txns args:
  * fee - integer fee per byte, in microAlgos. for a flat fee, set flatFee to true
  * flatFee - bool optionally set this to true to specify fee as microalgos-per-txn
@@ -1107,7 +1107,7 @@ export function makeApplicationOptInTxnFromObject(
  * @param boxes - Array of BoxReference, app ID and name of box to be accessed
  */
 export function makeApplicationCloseOutTxn(
-  from: AppCloseOutTxn['from'],
+  sender: AppCloseOutTxn['sender'],
   suggestedParams: MustHaveSuggestedParams<AppCloseOutTxn>['suggestedParams'],
   appIndex: AppCloseOutTxn['appIndex'],
   appArgs?: AppCloseOutTxn['appArgs'],
@@ -1121,7 +1121,7 @@ export function makeApplicationCloseOutTxn(
 ) {
   const o: AppCloseOutTxn = {
     type: TransactionType.appl,
-    from,
+    sender,
     suggestedParams,
     appIndex,
     appOnComplete: OnApplicationComplete.CloseOutOC,
@@ -1150,7 +1150,7 @@ export function makeApplicationCloseOutTxnFromObject(
           reKeyTo: 'rekeyTo';
         }
       >,
-      | 'from'
+      | 'sender'
       | 'suggestedParams'
       | 'appIndex'
       | 'appArgs'
@@ -1165,7 +1165,7 @@ export function makeApplicationCloseOutTxnFromObject(
   >
 ) {
   return makeApplicationCloseOutTxn(
-    o.from,
+    o.sender,
     o.suggestedParams,
     o.appIndex,
     o.appArgs,
@@ -1181,7 +1181,7 @@ export function makeApplicationCloseOutTxnFromObject(
 
 /**
  * Make a transaction that clears a user's state in an application
- * @param from - address of sender
+ * @param sender - address of sender
  * @param suggestedParams - a dict holding common-to-all-txns args:
  * fee - integer fee per byte, in microAlgos. for a flat fee, set flatFee to true
  * flatFee - bool optionally set this to true to specify fee as microalgos-per-txn
@@ -1201,7 +1201,7 @@ export function makeApplicationCloseOutTxnFromObject(
  * @param boxes - Array of BoxReference, app ID and name of box to be accessed
  */
 export function makeApplicationClearStateTxn(
-  from: AppClearStateTxn['from'],
+  sender: AppClearStateTxn['sender'],
   suggestedParams: MustHaveSuggestedParams<AppClearStateTxn>['suggestedParams'],
   appIndex: AppClearStateTxn['appIndex'],
   appArgs?: AppClearStateTxn['appArgs'],
@@ -1215,7 +1215,7 @@ export function makeApplicationClearStateTxn(
 ) {
   const o: AppClearStateTxn = {
     type: TransactionType.appl,
-    from,
+    sender,
     suggestedParams,
     appIndex,
     appOnComplete: OnApplicationComplete.ClearStateOC,
@@ -1244,7 +1244,7 @@ export function makeApplicationClearStateTxnFromObject(
           reKeyTo: 'rekeyTo';
         }
       >,
-      | 'from'
+      | 'sender'
       | 'suggestedParams'
       | 'appIndex'
       | 'appArgs'
@@ -1259,7 +1259,7 @@ export function makeApplicationClearStateTxnFromObject(
   >
 ) {
   return makeApplicationClearStateTxn(
-    o.from,
+    o.sender,
     o.suggestedParams,
     o.appIndex,
     o.appArgs,
@@ -1275,7 +1275,7 @@ export function makeApplicationClearStateTxnFromObject(
 
 /**
  * Make a transaction that just calls an application, doing nothing on completion
- * @param from - address of sender
+ * @param sender - address of sender
  * @param suggestedParams - a dict holding common-to-all-txns args:
  * fee - integer fee per byte, in microAlgos. for a flat fee, set flatFee to true
  * flatFee - bool optionally set this to true to specify fee as microalgos-per-txn
@@ -1295,7 +1295,7 @@ export function makeApplicationClearStateTxnFromObject(
  * @param boxes - Array of BoxReference, app ID and name of box to be accessed
  */
 export function makeApplicationNoOpTxn(
-  from: AppNoOpTxn['from'],
+  sender: AppNoOpTxn['sender'],
   suggestedParams: MustHaveSuggestedParams<AppNoOpTxn>['suggestedParams'],
   appIndex: AppNoOpTxn['appIndex'],
   appArgs?: AppNoOpTxn['appArgs'],
@@ -1309,7 +1309,7 @@ export function makeApplicationNoOpTxn(
 ) {
   const o: AppNoOpTxn = {
     type: TransactionType.appl,
-    from,
+    sender,
     suggestedParams,
     appIndex,
     appOnComplete: OnApplicationComplete.NoOpOC,
@@ -1338,7 +1338,7 @@ export function makeApplicationNoOpTxnFromObject(
           reKeyTo: 'rekeyTo';
         }
       >,
-      | 'from'
+      | 'sender'
       | 'suggestedParams'
       | 'appIndex'
       | 'appArgs'
@@ -1353,7 +1353,7 @@ export function makeApplicationNoOpTxnFromObject(
   >
 ) {
   return makeApplicationNoOpTxn(
-    o.from,
+    o.sender,
     o.suggestedParams,
     o.appIndex,
     o.appArgs,
@@ -1385,7 +1385,7 @@ export function makeApplicationCallTxnFromObject(
           reKeyTo: 'rekeyTo';
         }
       >,
-      | 'from'
+      | 'sender'
       | 'suggestedParams'
       | 'appIndex'
       | 'onComplete'
@@ -1424,7 +1424,7 @@ export function makeApplicationCallTxnFromObject(
 ) {
   const o: AppCreateTxn = {
     type: TransactionType.appl,
-    from: options.from,
+    sender: options.sender,
     suggestedParams: options.suggestedParams,
     appIndex: options.appIndex,
     appOnComplete: options.onComplete,

--- a/src/makeTxn.ts
+++ b/src/makeTxn.ts
@@ -34,8 +34,8 @@ import { RenameProperties, RenameProperty, Expand } from './types/utils';
  * fee - integer fee per byte, in microAlgos. for a flat fee, set flatFee to true
  * flatFee - bool optionally set this to true to specify fee as microalgos-per-txn
  *       If true, txn fee may fall below the ALGORAND_MIN_TX_FEE
- * firstRound - integer first protocol round on which this txn is valid
- * lastRound - integer last protocol round on which this txn is valid
+ * firstValid - integer first protocol round on which this txn is valid
+ * lastValid - integer last protocol round on which this txn is valid
  * genesisHash - string specifies hash genesis block of network in use
  * genesisID - string specifies genesis ID of network in use
  * @param rekeyTo - rekeyTo address, optional
@@ -103,8 +103,8 @@ export function makePaymentTxnWithSuggestedParamsFromObject(
  * fee - integer fee per byte, in microAlgos. for a flat fee, set flatFee to true
  * flatFee - bool optionally set this to true to specify fee as microalgos-per-txn
  *       If true, txn fee may fall below the ALGORAND_MIN_TX_FEE
- * firstRound - integer first protocol round on which this txn is valid
- * lastRound - integer last protocol round on which this txn is valid
+ * firstValid - integer first protocol round on which this txn is valid
+ * lastValid - integer last protocol round on which this txn is valid
  * genesisHash - string specifies hash genesis block of network in use
  * genesisID - string specifies genesis ID of network in use
  * @param rekeyTo - rekeyTo address, optional
@@ -240,8 +240,8 @@ export function makeKeyRegistrationTxnWithSuggestedParamsFromObject(o: any) {
  * fee - integer fee per byte, in microAlgos. for a flat fee, set flatFee to true
  * flatFee - bool optionally set this to true to specify fee as microalgos-per-txn
  *       If true, txn fee may fall below the ALGORAND_MIN_TX_FEE
- * firstRound - integer first protocol round on which this txn is valid
- * lastRound - integer last protocol round on which this txn is valid
+ * firstValid - integer first protocol round on which this txn is valid
+ * lastValid - integer last protocol round on which this txn is valid
  * genesisHash - string specifies hash genesis block of network in use
  * genesisID - string specifies genesis ID of network in use
  * @param rekeyTo - rekeyTo address, optional
@@ -355,8 +355,8 @@ export function makeAssetCreateTxnWithSuggestedParamsFromObject(
  * fee - integer fee per byte, in microAlgos. for a flat fee, set flatFee to true
  * flatFee - bool optionally set this to true to specify fee as microalgos-per-txn
  *       If true, txn fee may fall below the ALGORAND_MIN_TX_FEE
- * firstRound - integer first protocol round on which this txn is valid
- * lastRound - integer last protocol round on which this txn is valid
+ * firstValid - integer first protocol round on which this txn is valid
+ * lastValid - integer last protocol round on which this txn is valid
  * genesisHash - string specifies hash genesis block of network in use
  * genesisID - string specifies genesis ID of network in use
  * @param rekeyTo - rekeyTo address, optional
@@ -451,8 +451,8 @@ export function makeAssetConfigTxnWithSuggestedParamsFromObject(
  * fee - integer fee per byte, in microAlgos. for a flat fee, set flatFee to true
  * flatFee - bool optionally set this to true to specify fee as microalgos-per-txn
  *       If true, txn fee may fall below the ALGORAND_MIN_TX_FEE
- * firstRound - integer first protocol round on which this txn is valid
- * lastRound - integer last protocol round on which this txn is valid
+ * firstValid - integer first protocol round on which this txn is valid
+ * lastValid - integer last protocol round on which this txn is valid
  * genesisHash - string specifies hash genesis block of network in use
  * genesisID - string specifies genesis ID of network in use
  * @param rekeyTo - rekeyTo address, optional
@@ -509,8 +509,8 @@ export function makeAssetDestroyTxnWithSuggestedParamsFromObject(
  * fee - integer fee per byte, in microAlgos. for a flat fee, set flatFee to true
  * flatFee - bool optionally set this to true to specify fee as microalgos-per-txn
  *       If true, txn fee may fall below the ALGORAND_MIN_TX_FEE
- * firstRound - integer first protocol round on which this txn is valid
- * lastRound - integer last protocol round on which this txn is valid
+ * firstValid - integer first protocol round on which this txn is valid
+ * lastValid - integer last protocol round on which this txn is valid
  * genesisHash - string specifies hash genesis block of network in use
  * genesisID - string specifies genesis ID of network in use
  * @param rekeyTo - rekeyTo address, optional
@@ -587,8 +587,8 @@ export function makeAssetFreezeTxnWithSuggestedParamsFromObject(
  *       If true, txn fee may fall below the ALGORAND_MIN_TX_FEE
  * * flatFee - bool optionally set this to true to specify fee as microalgos-per-txn
  *       If true, txn fee may fall below the ALGORAND_MIN_TX_FEE
- * firstRound - integer first protocol round on which this txn is valid
- * lastRound - integer last protocol round on which this txn is valid
+ * firstValid - integer first protocol round on which this txn is valid
+ * lastValid - integer last protocol round on which this txn is valid
  * genesisHash - string specifies hash genesis block of network in use
  * genesisID - string specifies genesis ID of network in use
  * @param rekeyTo - rekeyTo address, optional
@@ -662,8 +662,8 @@ export function makeAssetTransferTxnWithSuggestedParamsFromObject(
  * fee - integer fee per byte, in microAlgos. for a flat fee, set flatFee to true
  * flatFee - bool optionally set this to true to specify fee as microalgos-per-txn
  *       If true, txn fee may fall below the ALGORAND_MIN_TX_FEE
- * firstRound - integer first protocol round on which this txn is valid
- * lastRound - integer last protocol round on which this txn is valid
+ * firstValid - integer first protocol round on which this txn is valid
+ * lastValid - integer last protocol round on which this txn is valid
  * genesisHash - string specifies hash genesis block of network in use
  * genesisID - string specifies genesis ID of network in use
  * @param onComplete - algosdk.OnApplicationComplete, what application should do once the program is done being run
@@ -798,8 +798,8 @@ export function makeApplicationCreateTxnFromObject(
  * fee - integer fee per byte, in microAlgos. for a flat fee, set flatFee to true
  * flatFee - bool optionally set this to true to specify fee as microalgos-per-txn
  *       If true, txn fee may fall below the ALGORAND_MIN_TX_FEE
- * firstRound - integer first protocol round on which this txn is valid
- * lastRound - integer last protocol round on which this txn is valid
+ * firstValid - integer first protocol round on which this txn is valid
+ * lastValid - integer last protocol round on which this txn is valid
  * genesisHash - string specifies hash genesis block of network in use
  * genesisID - string specifies genesis ID of network in use
  * @param appIndex - the ID of the app to be updated
@@ -904,8 +904,8 @@ export function makeApplicationUpdateTxnFromObject(
  * fee - integer fee per byte, in microAlgos. for a flat fee, set flatFee to true
  * flatFee - bool optionally set this to true to specify fee as microalgos-per-txn
  *       If true, txn fee may fall below the ALGORAND_MIN_TX_FEE
- * firstRound - integer first protocol round on which this txn is valid
- * lastRound - integer last protocol round on which this txn is valid
+ * firstValid - integer first protocol round on which this txn is valid
+ * lastValid - integer last protocol round on which this txn is valid
  * genesisHash - string specifies hash genesis block of network in use
  * genesisID - string specifies genesis ID of network in use
  * @param appIndex - the ID of the app to be deleted
@@ -998,8 +998,8 @@ export function makeApplicationDeleteTxnFromObject(
  * fee - integer fee per byte, in microAlgos. for a flat fee, set flatFee to true
  * flatFee - bool optionally set this to true to specify fee as microalgos-per-txn
  *       If true, txn fee may fall below the ALGORAND_MIN_TX_FEE
- * firstRound - integer first protocol round on which this txn is valid
- * lastRound - integer last protocol round on which this txn is valid
+ * firstValid - integer first protocol round on which this txn is valid
+ * lastValid - integer last protocol round on which this txn is valid
  * genesisHash - string specifies hash genesis block of network in use
  * genesisID - string specifies genesis ID of network in use
  * @param appIndex - the ID of the app to join
@@ -1092,8 +1092,8 @@ export function makeApplicationOptInTxnFromObject(
  * fee - integer fee per byte, in microAlgos. for a flat fee, set flatFee to true
  * flatFee - bool optionally set this to true to specify fee as microalgos-per-txn
  *       If true, txn fee may fall below the ALGORAND_MIN_TX_FEE
- * firstRound - integer first protocol round on which this txn is valid
- * lastRound - integer last protocol round on which this txn is valid
+ * firstValid - integer first protocol round on which this txn is valid
+ * lastValid - integer last protocol round on which this txn is valid
  * genesisHash - string specifies hash genesis block of network in use
  * genesisID - string specifies genesis ID of network in use
  * @param appIndex - the ID of the app to use
@@ -1186,8 +1186,8 @@ export function makeApplicationCloseOutTxnFromObject(
  * fee - integer fee per byte, in microAlgos. for a flat fee, set flatFee to true
  * flatFee - bool optionally set this to true to specify fee as microalgos-per-txn
  *       If true, txn fee may fall below the ALGORAND_MIN_TX_FEE
- * firstRound - integer first protocol round on which this txn is valid
- * lastRound - integer last protocol round on which this txn is valid
+ * firstValid - integer first protocol round on which this txn is valid
+ * lastValid - integer last protocol round on which this txn is valid
  * genesisHash - string specifies hash genesis block of network in use
  * genesisID - string specifies genesis ID of network in use
  * @param appIndex - the ID of the app to use
@@ -1280,8 +1280,8 @@ export function makeApplicationClearStateTxnFromObject(
  * fee - integer fee per byte, in microAlgos. for a flat fee, set flatFee to true
  * flatFee - bool optionally set this to true to specify fee as microalgos-per-txn
  *       If true, txn fee may fall below the ALGORAND_MIN_TX_FEE
- * firstRound - integer first protocol round on which this txn is valid
- * lastRound - integer last protocol round on which this txn is valid
+ * firstValid - integer first protocol round on which this txn is valid
+ * lastValid - integer last protocol round on which this txn is valid
  * genesisHash - string specifies hash genesis block of network in use
  * genesisID - string specifies genesis ID of network in use
  * @param appIndex - the ID of the app to use

--- a/src/makeTxn.ts
+++ b/src/makeTxn.ts
@@ -504,7 +504,7 @@ export function makeAssetDestroyTxnWithSuggestedParamsFromObject(
  * @param note - uint8array of arbitrary data for sender to store
  * @param assetIndex - int asset index uniquely specifying the asset
  * @param freezeTarget - string representation of Algorand address being frozen or unfrozen
- * @param freezeState - true if freezeTarget should be frozen, false if freezeTarget should be allowed to transact
+ * @param assetFrozen - true if freezeTarget should be frozen, false if freezeTarget should be allowed to transact
  * @param suggestedParams - a dict holding common-to-all-txns args:
  * fee - integer fee per byte, in microAlgos. for a flat fee, set flatFee to true
  * flatFee - bool optionally set this to true to specify fee as microalgos-per-txn
@@ -520,7 +520,7 @@ export function makeAssetFreezeTxnWithSuggestedParams(
   note: AssetFreezeTxn['note'],
   assetIndex: AssetFreezeTxn['assetIndex'],
   freezeTarget: AssetFreezeTxn['freezeAccount'],
-  freezeState: AssetFreezeTxn['freezeState'],
+  assetFrozen: AssetFreezeTxn['assetFrozen'],
   suggestedParams: MustHaveSuggestedParams<AssetFreezeTxn>['suggestedParams'],
   rekeyTo?: AssetFreezeTxn['reKeyTo']
 ) {
@@ -529,7 +529,7 @@ export function makeAssetFreezeTxnWithSuggestedParams(
     type: TransactionType.afrz,
     freezeAccount: freezeTarget,
     assetIndex,
-    freezeState,
+    assetFrozen,
     note,
     suggestedParams,
     reKeyTo: rekeyTo,
@@ -552,7 +552,7 @@ export function makeAssetFreezeTxnWithSuggestedParamsFromObject(
       | 'note'
       | 'assetIndex'
       | 'freezeTarget'
-      | 'freezeState'
+      | 'assetFrozen'
       | 'suggestedParams'
       | 'rekeyTo'
     >
@@ -563,7 +563,7 @@ export function makeAssetFreezeTxnWithSuggestedParamsFromObject(
     o.note,
     o.assetIndex,
     o.freezeTarget,
-    o.freezeState,
+    o.assetFrozen,
     o.suggestedParams,
     o.rekeyTo
   );

--- a/src/makeTxn.ts
+++ b/src/makeTxn.ts
@@ -576,8 +576,8 @@ export function makeAssetFreezeTxnWithSuggestedParamsFromObject(
  * @param receiver - string representation of Algorand address of asset recipient
  * @param closeRemainderTo - optional - string representation of Algorand address - if provided,
  * send all remaining assets after transfer to the "closeRemainderTo" address and close "sender"'s asset holdings
- * @param revocationTarget - optional - string representation of Algorand address - if provided,
- * and if "sender" is the asset's revocation manager, then deduct from "revocationTarget" rather than "sender"
+ * @param assetSender - optional - string representation of Algorand address - if provided,
+ * and if "sender" is the asset's revocation manager, then deduct from "assetSender" rather than "sender"
  * @param amount - integer amount of assets to send
  * @param note - uint8array of arbitrary data for sender to store
  * @param assetIndex - int asset index uniquely specifying the asset
@@ -597,7 +597,7 @@ export function makeAssetTransferTxnWithSuggestedParams(
   sender: AssetTransferTxn['sender'],
   receiver: AssetTransferTxn['receiver'],
   closeRemainderTo: AssetTransferTxn['closeRemainderTo'],
-  revocationTarget: AssetTransferTxn['assetRevocationTarget'],
+  assetSender: AssetTransferTxn['assetSender'],
   amount: AssetTransferTxn['amount'],
   note: AssetTransferTxn['note'],
   assetIndex: AssetTransferTxn['assetIndex'],
@@ -612,7 +612,7 @@ export function makeAssetTransferTxnWithSuggestedParams(
     suggestedParams,
     assetIndex,
     note,
-    assetRevocationTarget: revocationTarget,
+    assetSender,
     closeRemainderTo,
     reKeyTo: rekeyTo,
   };
@@ -626,14 +626,14 @@ export function makeAssetTransferTxnWithSuggestedParamsFromObject(
       RenameProperties<
         MustHaveSuggestedParams<AssetTransferTxn>,
         {
-          assetRevocationTarget: 'revocationTarget';
+          assetSender: 'assetSender';
           reKeyTo: 'rekeyTo';
         }
       >,
       | 'sender'
       | 'receiver'
       | 'closeRemainderTo'
-      | 'revocationTarget'
+      | 'assetSender'
       | 'amount'
       | 'note'
       | 'assetIndex'
@@ -646,7 +646,7 @@ export function makeAssetTransferTxnWithSuggestedParamsFromObject(
     o.sender,
     o.receiver,
     o.closeRemainderTo,
-    o.revocationTarget,
+    o.assetSender,
     o.amount,
     o.note,
     o.assetIndex,

--- a/src/makeTxn.ts
+++ b/src/makeTxn.ts
@@ -47,7 +47,7 @@ export function makePaymentTxnWithSuggestedParams(
   closeRemainderTo: PaymentTxn['closeRemainderTo'],
   note: PaymentTxn['note'],
   suggestedParams: MustHaveSuggestedParams<PaymentTxn>['suggestedParams'],
-  rekeyTo?: PaymentTxn['reKeyTo']
+  rekeyTo?: PaymentTxn['rekeyTo']
 ) {
   const o: PaymentTxn = {
     sender,
@@ -57,7 +57,7 @@ export function makePaymentTxnWithSuggestedParams(
     note,
     suggestedParams,
     type: TransactionType.pay,
-    reKeyTo: rekeyTo,
+    rekeyTo,
   };
   return new txnBuilder.Transaction(o);
 }
@@ -66,7 +66,7 @@ export function makePaymentTxnWithSuggestedParams(
 export function makePaymentTxnWithSuggestedParamsFromObject(
   o: Expand<
     Pick<
-      RenameProperty<MustHaveSuggestedParams<PaymentTxn>, 'reKeyTo', 'rekeyTo'>,
+      RenameProperty<MustHaveSuggestedParams<PaymentTxn>, 'rekeyTo', 'rekeyTo'>,
       | 'sender'
       | 'receiver'
       | 'amount'
@@ -121,7 +121,7 @@ export function makeKeyRegistrationTxnWithSuggestedParams(
   voteLast: KeyRegistrationTxn['voteLast'],
   voteKeyDilution: KeyRegistrationTxn['voteKeyDilution'],
   suggestedParams: MustHaveSuggestedParams<KeyRegistrationTxn>['suggestedParams'],
-  rekeyTo?: KeyRegistrationTxn['reKeyTo'],
+  rekeyTo?: KeyRegistrationTxn['rekeyTo'],
   nonParticipation?: false,
   stateProofKey?: KeyRegistrationTxn['stateProofKey']
 ): txnBuilder.Transaction;
@@ -134,7 +134,7 @@ export function makeKeyRegistrationTxnWithSuggestedParams(
   voteLast: undefined,
   voteKeyDilution: undefined,
   suggestedParams: MustHaveSuggestedParams<KeyRegistrationTxn>['suggestedParams'],
-  rekeyTo?: KeyRegistrationTxn['reKeyTo'],
+  rekeyTo?: KeyRegistrationTxn['rekeyTo'],
   nonParticipation?: true,
   stateProofKey?: undefined
 ): txnBuilder.Transaction;
@@ -161,7 +161,7 @@ export function makeKeyRegistrationTxnWithSuggestedParams(
     voteKeyDilution,
     suggestedParams,
     type: TransactionType.keyreg,
-    reKeyTo: rekeyTo,
+    rekeyTo,
     nonParticipation,
     stateProofKey,
   };
@@ -174,7 +174,7 @@ export function makeKeyRegistrationTxnWithSuggestedParamsFromObject(
     Pick<
       RenameProperty<
         MustHaveSuggestedParams<KeyRegistrationTxn>,
-        'reKeyTo',
+        'rekeyTo',
         'rekeyTo'
       >,
       | 'sender'
@@ -197,7 +197,7 @@ export function makeKeyRegistrationTxnWithSuggestedParamsFromObject(
     Pick<
       RenameProperty<
         MustHaveSuggestedParams<KeyRegistrationTxn>,
-        'reKeyTo',
+        'rekeyTo',
         'rekeyTo'
       >,
       'sender' | 'note' | 'suggestedParams' | 'rekeyTo' | 'nonParticipation'
@@ -261,7 +261,7 @@ export function makeAssetCreateTxnWithSuggestedParams(
   assetURL: AssetCreateTxn['assetURL'],
   assetMetadataHash: AssetCreateTxn['assetMetadataHash'] | undefined,
   suggestedParams: MustHaveSuggestedParams<AssetCreateTxn>['suggestedParams'],
-  rekeyTo?: AssetCreateTxn['reKeyTo']
+  rekeyTo?: AssetCreateTxn['rekeyTo']
 ) {
   const o: AssetCreateTxn = {
     sender,
@@ -279,7 +279,7 @@ export function makeAssetCreateTxnWithSuggestedParams(
     assetFreeze: freeze,
     assetClawback: clawback,
     type: TransactionType.acfg,
-    reKeyTo: rekeyTo,
+    rekeyTo,
   };
   return new txnBuilder.Transaction(o);
 }
@@ -291,7 +291,7 @@ export function makeAssetCreateTxnWithSuggestedParamsFromObject(
       RenameProperties<
         MustHaveSuggestedParams<AssetCreateTxn>,
         {
-          reKeyTo: 'rekeyTo';
+          rekeyTo: 'rekeyTo';
           assetTotal: 'total';
           assetDecimals: 'decimals';
           assetDefaultFrozen: 'defaultFrozen';
@@ -371,7 +371,7 @@ export function makeAssetConfigTxnWithSuggestedParams(
   clawback: AssetConfigTxn['assetClawback'],
   suggestedParams: MustHaveSuggestedParams<AssetConfigTxn>['suggestedParams'],
   strictEmptyAddressChecking = true,
-  rekeyTo?: AssetConfigTxn['reKeyTo']
+  rekeyTo?: AssetConfigTxn['rekeyTo']
 ) {
   if (
     strictEmptyAddressChecking &&
@@ -394,7 +394,7 @@ export function makeAssetConfigTxnWithSuggestedParams(
     assetClawback: clawback,
     type: TransactionType.acfg,
     note,
-    reKeyTo: rekeyTo,
+    rekeyTo,
   };
   return new txnBuilder.Transaction(o);
 }
@@ -406,7 +406,7 @@ export function makeAssetConfigTxnWithSuggestedParamsFromObject(
       RenameProperties<
         MustHaveSuggestedParams<AssetConfigTxn>,
         {
-          reKeyTo: 'rekeyTo';
+          rekeyTo: 'rekeyTo';
           assetManager: 'manager';
           assetReserve: 'reserve';
           assetFreeze: 'freeze';
@@ -462,7 +462,7 @@ export function makeAssetDestroyTxnWithSuggestedParams(
   note: AssetDestroyTxn['note'],
   assetIndex: AssetDestroyTxn['assetIndex'],
   suggestedParams: MustHaveSuggestedParams<AssetDestroyTxn>['suggestedParams'],
-  rekeyTo?: AssetDestroyTxn['reKeyTo']
+  rekeyTo?: AssetDestroyTxn['rekeyTo']
 ) {
   const o: AssetDestroyTxn = {
     sender,
@@ -470,7 +470,7 @@ export function makeAssetDestroyTxnWithSuggestedParams(
     assetIndex,
     type: TransactionType.acfg,
     note,
-    reKeyTo: rekeyTo,
+    rekeyTo,
   };
   return new txnBuilder.Transaction(o);
 }
@@ -481,7 +481,7 @@ export function makeAssetDestroyTxnWithSuggestedParamsFromObject(
     Pick<
       RenameProperty<
         MustHaveSuggestedParams<AssetDestroyTxn>,
-        'reKeyTo',
+        'rekeyTo',
         'rekeyTo'
       >,
       'sender' | 'note' | 'assetIndex' | 'suggestedParams' | 'rekeyTo'
@@ -522,7 +522,7 @@ export function makeAssetFreezeTxnWithSuggestedParams(
   freezeTarget: AssetFreezeTxn['freezeAccount'],
   assetFrozen: AssetFreezeTxn['assetFrozen'],
   suggestedParams: MustHaveSuggestedParams<AssetFreezeTxn>['suggestedParams'],
-  rekeyTo?: AssetFreezeTxn['reKeyTo']
+  rekeyTo?: AssetFreezeTxn['rekeyTo']
 ) {
   const o: AssetFreezeTxn = {
     sender,
@@ -532,7 +532,7 @@ export function makeAssetFreezeTxnWithSuggestedParams(
     assetFrozen,
     note,
     suggestedParams,
-    reKeyTo: rekeyTo,
+    rekeyTo,
   };
   return new txnBuilder.Transaction(o);
 }
@@ -545,7 +545,7 @@ export function makeAssetFreezeTxnWithSuggestedParamsFromObject(
         MustHaveSuggestedParams<AssetFreezeTxn>,
         {
           freezeAccount: 'freezeTarget';
-          reKeyTo: 'rekeyTo';
+          rekeyTo: 'rekeyTo';
         }
       >,
       | 'sender'
@@ -602,7 +602,7 @@ export function makeAssetTransferTxnWithSuggestedParams(
   note: AssetTransferTxn['note'],
   assetIndex: AssetTransferTxn['assetIndex'],
   suggestedParams: MustHaveSuggestedParams<AssetTransferTxn>['suggestedParams'],
-  rekeyTo?: AssetTransferTxn['reKeyTo']
+  rekeyTo?: AssetTransferTxn['rekeyTo']
 ) {
   const o: AssetTransferTxn = {
     type: TransactionType.axfer,
@@ -614,7 +614,7 @@ export function makeAssetTransferTxnWithSuggestedParams(
     note,
     assetSender,
     closeRemainderTo,
-    reKeyTo: rekeyTo,
+    rekeyTo,
   };
   return new txnBuilder.Transaction(o);
 }
@@ -627,7 +627,7 @@ export function makeAssetTransferTxnWithSuggestedParamsFromObject(
         MustHaveSuggestedParams<AssetTransferTxn>,
         {
           assetSender: 'assetSender';
-          reKeyTo: 'rekeyTo';
+          rekeyTo: 'rekeyTo';
         }
       >,
       | 'sender'
@@ -699,7 +699,7 @@ export function makeApplicationCreateTxn(
   foreignAssets?: AppCreateTxn['appForeignAssets'],
   note?: AppCreateTxn['note'],
   lease?: AppCreateTxn['lease'],
-  rekeyTo?: AppCreateTxn['reKeyTo'],
+  rekeyTo?: AppCreateTxn['rekeyTo'],
   extraPages?: AppCreateTxn['extraPages'],
   boxes?: AppCreateTxn['boxes']
 ) {
@@ -722,7 +722,7 @@ export function makeApplicationCreateTxn(
     boxes,
     note,
     lease,
-    reKeyTo: rekeyTo,
+    rekeyTo,
     extraPages,
   };
   return new txnBuilder.Transaction(o);
@@ -745,7 +745,7 @@ export function makeApplicationCreateTxnFromObject(
           appAccounts: 'accounts';
           appForeignApps: 'foreignApps';
           appForeignAssets: 'foreignAssets';
-          reKeyTo: 'rekeyTo';
+          rekeyTo: 'rekeyTo';
         }
       >,
       | 'sender'
@@ -826,7 +826,7 @@ export function makeApplicationUpdateTxn(
   foreignAssets?: AppUpdateTxn['appForeignAssets'],
   note?: AppUpdateTxn['note'],
   lease?: AppUpdateTxn['lease'],
-  rekeyTo?: AppUpdateTxn['reKeyTo'],
+  rekeyTo?: AppUpdateTxn['rekeyTo'],
   boxes?: AppUpdateTxn['boxes']
 ) {
   const o: AppUpdateTxn = {
@@ -844,7 +844,7 @@ export function makeApplicationUpdateTxn(
     boxes,
     note,
     lease,
-    reKeyTo: rekeyTo,
+    rekeyTo,
   };
   return new txnBuilder.Transaction(o);
 }
@@ -861,7 +861,7 @@ export function makeApplicationUpdateTxnFromObject(
           appAccounts: 'accounts';
           appForeignApps: 'foreignApps';
           appForeignAssets: 'foreignAssets';
-          reKeyTo: 'rekeyTo';
+          rekeyTo: 'rekeyTo';
         }
       >,
       | 'sender'
@@ -928,7 +928,7 @@ export function makeApplicationDeleteTxn(
   foreignAssets?: AppDeleteTxn['appForeignAssets'],
   note?: AppDeleteTxn['note'],
   lease?: AppDeleteTxn['lease'],
-  rekeyTo?: AppDeleteTxn['reKeyTo'],
+  rekeyTo?: AppDeleteTxn['rekeyTo'],
   boxes?: AppDeleteTxn['boxes']
 ) {
   const o: AppDeleteTxn = {
@@ -944,7 +944,7 @@ export function makeApplicationDeleteTxn(
     boxes,
     note,
     lease,
-    reKeyTo: rekeyTo,
+    rekeyTo,
   };
   return new txnBuilder.Transaction(o);
 }
@@ -959,7 +959,7 @@ export function makeApplicationDeleteTxnFromObject(
           appAccounts: 'accounts';
           appForeignApps: 'foreignApps';
           appForeignAssets: 'foreignAssets';
-          reKeyTo: 'rekeyTo';
+          rekeyTo: 'rekeyTo';
         }
       >,
       | 'sender'
@@ -1022,7 +1022,7 @@ export function makeApplicationOptInTxn(
   foreignAssets?: AppOptInTxn['appForeignAssets'],
   note?: AppOptInTxn['note'],
   lease?: AppOptInTxn['lease'],
-  rekeyTo?: AppOptInTxn['reKeyTo'],
+  rekeyTo?: AppOptInTxn['rekeyTo'],
   boxes?: AppOptInTxn['boxes']
 ) {
   const o: AppOptInTxn = {
@@ -1038,7 +1038,7 @@ export function makeApplicationOptInTxn(
     boxes,
     note,
     lease,
-    reKeyTo: rekeyTo,
+    rekeyTo,
   };
   return new txnBuilder.Transaction(o);
 }
@@ -1053,7 +1053,7 @@ export function makeApplicationOptInTxnFromObject(
           appAccounts: 'accounts';
           appForeignApps: 'foreignApps';
           appForeignAssets: 'foreignAssets';
-          reKeyTo: 'rekeyTo';
+          rekeyTo: 'rekeyTo';
         }
       >,
       | 'sender'
@@ -1116,7 +1116,7 @@ export function makeApplicationCloseOutTxn(
   foreignAssets?: AppCloseOutTxn['appForeignAssets'],
   note?: AppCloseOutTxn['note'],
   lease?: AppCloseOutTxn['lease'],
-  rekeyTo?: AppCloseOutTxn['reKeyTo'],
+  rekeyTo?: AppCloseOutTxn['rekeyTo'],
   boxes?: AppCloseOutTxn['boxes']
 ) {
   const o: AppCloseOutTxn = {
@@ -1132,7 +1132,7 @@ export function makeApplicationCloseOutTxn(
     boxes,
     note,
     lease,
-    reKeyTo: rekeyTo,
+    rekeyTo,
   };
   return new txnBuilder.Transaction(o);
 }
@@ -1147,7 +1147,7 @@ export function makeApplicationCloseOutTxnFromObject(
           appAccounts: 'accounts';
           appForeignApps: 'foreignApps';
           appForeignAssets: 'foreignAssets';
-          reKeyTo: 'rekeyTo';
+          rekeyTo: 'rekeyTo';
         }
       >,
       | 'sender'
@@ -1210,7 +1210,7 @@ export function makeApplicationClearStateTxn(
   foreignAssets?: AppClearStateTxn['appForeignAssets'],
   note?: AppClearStateTxn['note'],
   lease?: AppClearStateTxn['lease'],
-  rekeyTo?: AppClearStateTxn['reKeyTo'],
+  rekeyTo?: AppClearStateTxn['rekeyTo'],
   boxes?: AppClearStateTxn['boxes']
 ) {
   const o: AppClearStateTxn = {
@@ -1226,7 +1226,7 @@ export function makeApplicationClearStateTxn(
     boxes,
     note,
     lease,
-    reKeyTo: rekeyTo,
+    rekeyTo,
   };
   return new txnBuilder.Transaction(o);
 }
@@ -1241,7 +1241,7 @@ export function makeApplicationClearStateTxnFromObject(
           appAccounts: 'accounts';
           appForeignApps: 'foreignApps';
           appForeignAssets: 'foreignAssets';
-          reKeyTo: 'rekeyTo';
+          rekeyTo: 'rekeyTo';
         }
       >,
       | 'sender'
@@ -1304,7 +1304,7 @@ export function makeApplicationNoOpTxn(
   foreignAssets?: AppNoOpTxn['appForeignAssets'],
   note?: AppNoOpTxn['note'],
   lease?: AppNoOpTxn['lease'],
-  rekeyTo?: AppNoOpTxn['reKeyTo'],
+  rekeyTo?: AppNoOpTxn['rekeyTo'],
   boxes?: AppNoOpTxn['boxes']
 ) {
   const o: AppNoOpTxn = {
@@ -1320,7 +1320,7 @@ export function makeApplicationNoOpTxn(
     boxes,
     note,
     lease,
-    reKeyTo: rekeyTo,
+    rekeyTo,
   };
   return new txnBuilder.Transaction(o);
 }
@@ -1335,7 +1335,7 @@ export function makeApplicationNoOpTxnFromObject(
           appAccounts: 'accounts';
           appForeignApps: 'foreignApps';
           appForeignAssets: 'foreignAssets';
-          reKeyTo: 'rekeyTo';
+          rekeyTo: 'rekeyTo';
         }
       >,
       | 'sender'
@@ -1382,7 +1382,7 @@ export function makeApplicationCallTxnFromObject(
           appAccounts: 'accounts';
           appForeignApps: 'foreignApps';
           appForeignAssets: 'foreignAssets';
-          reKeyTo: 'rekeyTo';
+          rekeyTo: 'rekeyTo';
         }
       >,
       | 'sender'
@@ -1441,7 +1441,7 @@ export function makeApplicationCallTxnFromObject(
     boxes: options.boxes,
     note: options.note,
     lease: options.lease,
-    reKeyTo: options.rekeyTo,
+    rekeyTo: options.rekeyTo,
     extraPages: options.extraPages,
   };
   return new txnBuilder.Transaction(o);

--- a/src/multisig.ts
+++ b/src/multisig.ts
@@ -382,7 +382,7 @@ export function signMultisigTransaction(
   });
   if (!Object.prototype.hasOwnProperty.call(txn, 'from')) {
     // eslint-disable-next-line no-param-reassign
-    txn.from = expectedFromRaw;
+    txn.sender = expectedFromRaw;
   }
   // build pks for partialSign
   const pks = addrs.map((addr) => address.decodeAddress(addr).publicKey);

--- a/src/multisig.ts
+++ b/src/multisig.ts
@@ -380,7 +380,7 @@ export function signMultisigTransaction(
     threshold,
     addrs,
   });
-  if (!Object.prototype.hasOwnProperty.call(txn, 'from')) {
+  if (!Object.prototype.hasOwnProperty.call(txn, 'sender')) {
     // eslint-disable-next-line no-param-reassign
     txn.sender = expectedFromRaw;
   }

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -57,7 +57,7 @@ interface TransactionStorageStructure
     | 'assetReserve'
     | 'assetFreeze'
     | 'assetClawback'
-    | 'assetRevocationTarget'
+    | 'assetSender'
     | 'freezeAccount'
     | 'appAccounts'
     | 'suggestedParams'
@@ -94,7 +94,7 @@ interface TransactionStorageStructure
   assetMetadataHash?: string | Uint8Array;
   freezeAccount: string | Address;
   assetFrozen: boolean;
-  assetRevocationTarget?: string | Address;
+  assetSender?: string | Address;
   appIndex: number;
   appOnComplete: OnApplicationComplete;
   appLocalInts: number;
@@ -184,7 +184,7 @@ export class Transaction implements TransactionStorageStructure {
   assetMetadataHash?: Uint8Array;
   freezeAccount: Address;
   assetFrozen: boolean;
-  assetRevocationTarget?: Address;
+  assetSender?: Address;
   appIndex: number;
   appOnComplete: OnApplicationComplete;
   appLocalInts: number;
@@ -274,10 +274,8 @@ export class Transaction implements TransactionStorageStructure {
       txn.assetFreeze = address.decodeAddress(txn.assetFreeze as string);
     if (txn.assetClawback !== undefined)
       txn.assetClawback = address.decodeAddress(txn.assetClawback as string);
-    if (txn.assetRevocationTarget !== undefined)
-      txn.assetRevocationTarget = address.decodeAddress(
-        txn.assetRevocationTarget as string
-      );
+    if (txn.assetSender !== undefined)
+      txn.assetSender = address.decodeAddress(txn.assetSender as string);
     if (txn.freezeAccount !== undefined)
       txn.freezeAccount = address.decodeAddress(txn.freezeAccount as string);
     if (txn.reKeyTo !== undefined)
@@ -751,8 +749,7 @@ export class Transaction implements TransactionStorageStructure {
       };
       if (this.closeRemainderTo !== undefined)
         txn.aclose = this.closeRemainderTo.publicKey;
-      if (this.assetRevocationTarget !== undefined)
-        txn.asnd = this.assetRevocationTarget.publicKey;
+      if (this.assetSender !== undefined) txn.asnd = this.assetSender.publicKey;
       // allowed zero values
       if (!txn.note.length) delete txn.note;
       if (!txn.lx.length) delete txn.lx;
@@ -1023,7 +1020,7 @@ export class Transaction implements TransactionStorageStructure {
         );
       }
       if (txnForEnc.asnd !== undefined) {
-        txn.assetRevocationTarget = address.decodeAddress(
+        txn.assetSender = address.decodeAddress(
           address.encodeAddress(new Uint8Array(txnForEnc.asnd))
         );
       }
@@ -1252,9 +1249,9 @@ export class Transaction implements TransactionStorageStructure {
       forPrinting.assetClawback = address.encodeAddress(
         (forPrinting.assetClawback as Address).publicKey
       );
-    if (forPrinting.assetRevocationTarget !== undefined)
-      forPrinting.assetRevocationTarget = address.encodeAddress(
-        (forPrinting.assetRevocationTarget as Address).publicKey
+    if (forPrinting.assetSender !== undefined)
+      forPrinting.assetSender = address.encodeAddress(
+        (forPrinting.assetSender as Address).publicKey
       );
     if (forPrinting.reKeyTo !== undefined)
       forPrinting.reKeyTo = address.encodeAddress(

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -67,8 +67,8 @@ interface TransactionStorageStructure
   to: string | Address;
   fee: number;
   amount: number | bigint;
-  firstRound: number;
-  lastRound: number;
+  firstValid: number;
+  lastValid: number;
   note?: Uint8Array;
   genesisID: string;
   genesisHash: string | Uint8Array;
@@ -157,8 +157,8 @@ export class Transaction implements TransactionStorageStructure {
   to: Address;
   fee: number;
   amount: number | bigint;
-  firstRound: number;
-  lastRound: number;
+  firstValid: number;
+  lastValid: number;
   note?: Uint8Array;
   genesisID: string;
   genesisHash: Uint8Array;
@@ -250,8 +250,8 @@ export class Transaction implements TransactionStorageStructure {
       reference.fee = reference.suggestedParams.fee;
       if (reference.suggestedParams.flatFee !== undefined)
         reference.flatFee = reference.suggestedParams.flatFee;
-      reference.firstRound = reference.suggestedParams.firstRound;
-      reference.lastRound = reference.suggestedParams.lastRound;
+      reference.firstValid = reference.suggestedParams.firstValid;
+      reference.lastValid = reference.suggestedParams.lastValid;
       reference.genesisID = reference.suggestedParams.genesisID;
     }
 
@@ -300,10 +300,10 @@ export class Transaction implements TransactionStorageStructure {
       );
     if (!Number.isSafeInteger(txn.fee) || txn.fee < 0)
       throw Error('fee must be a positive number and smaller than 2^53-1');
-    if (!Number.isSafeInteger(txn.firstRound) || txn.firstRound < 0)
-      throw Error('firstRound must be a positive number');
-    if (!Number.isSafeInteger(txn.lastRound) || txn.lastRound < 0)
-      throw Error('lastRound must be a positive number');
+    if (!Number.isSafeInteger(txn.firstValid) || txn.firstValid < 0)
+      throw Error('firstValid must be a positive number');
+    if (!Number.isSafeInteger(txn.lastValid) || txn.lastValid < 0)
+      throw Error('lastValid must be a positive number');
     if (
       txn.extraPages !== undefined &&
       (!Number.isInteger(txn.extraPages) ||
@@ -580,8 +580,8 @@ export class Transaction implements TransactionStorageStructure {
       const txn: EncodedTransaction = {
         amt: this.amount,
         fee: this.fee,
-        fv: this.firstRound,
-        lv: this.lastRound,
+        fv: this.firstValid,
+        lv: this.lastValid,
         note: this.note,
         snd: this.from.publicKey,
         type: 'pay',
@@ -617,8 +617,8 @@ export class Transaction implements TransactionStorageStructure {
     if (this.type === 'keyreg') {
       const txn: EncodedTransaction = {
         fee: this.fee,
-        fv: this.firstRound,
-        lv: this.lastRound,
+        fv: this.firstValid,
+        lv: this.lastValid,
         note: this.note,
         snd: this.from.publicKey,
         type: this.type,
@@ -658,8 +658,8 @@ export class Transaction implements TransactionStorageStructure {
       // asset creation, or asset reconfigure, or asset destruction
       const txn: EncodedTransaction = {
         fee: this.fee,
-        fv: this.firstRound,
-        lv: this.lastRound,
+        fv: this.firstValid,
+        lv: this.lastValid,
         note: this.note,
         snd: this.from.publicKey,
         type: this.type,
@@ -736,8 +736,8 @@ export class Transaction implements TransactionStorageStructure {
       const txn: EncodedTransaction = {
         aamt: this.amount,
         fee: this.fee,
-        fv: this.firstRound,
-        lv: this.lastRound,
+        fv: this.firstValid,
+        lv: this.lastValid,
         note: this.note,
         snd: this.from.publicKey,
         arcv: this.to.publicKey,
@@ -773,8 +773,8 @@ export class Transaction implements TransactionStorageStructure {
       // asset freeze or unfreeze
       const txn: EncodedTransaction = {
         fee: this.fee,
-        fv: this.firstRound,
-        lv: this.lastRound,
+        fv: this.firstValid,
+        lv: this.lastValid,
         note: this.note,
         snd: this.from.publicKey,
         type: this.type,
@@ -805,8 +805,8 @@ export class Transaction implements TransactionStorageStructure {
       // application call of some kind
       const txn: EncodedTransaction = {
         fee: this.fee,
-        fv: this.firstRound,
-        lv: this.lastRound,
+        fv: this.firstValid,
+        lv: this.lastValid,
         note: this.note,
         snd: this.from.publicKey,
         type: this.type,
@@ -884,8 +884,8 @@ export class Transaction implements TransactionStorageStructure {
       // state proof txn
       const txn: EncodedTransaction = {
         fee: this.fee,
-        fv: this.firstRound,
-        lv: this.lastRound,
+        fv: this.firstValid,
+        lv: this.lastValid,
         note: this.note,
         snd: this.from.publicKey,
         type: this.type,
@@ -933,8 +933,8 @@ export class Transaction implements TransactionStorageStructure {
     }
     txn.type = txnForEnc.type;
     txn.fee = txnForEnc.fee;
-    txn.firstRound = txnForEnc.fv;
-    txn.lastRound = txnForEnc.lv;
+    txn.firstValid = txnForEnc.fv;
+    txn.lastValid = txnForEnc.lv;
     txn.note = new Uint8Array(txnForEnc.note);
     txn.lease = new Uint8Array(txnForEnc.lx);
     txn.from = address.decodeAddress(

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -61,7 +61,7 @@ interface TransactionStorageStructure
     | 'freezeAccount'
     | 'appAccounts'
     | 'suggestedParams'
-    | 'reKeyTo'
+    | 'rekeyTo'
   > {
   sender: string | Address;
   receiver: string | Address;
@@ -109,7 +109,7 @@ interface TransactionStorageStructure
   appForeignAssets?: number[];
   type?: TransactionType;
   flatFee: boolean;
-  reKeyTo?: string | Address;
+  rekeyTo?: string | Address;
   nonParticipation?: boolean;
   group?: Uint8Array;
   extraPages?: number;
@@ -200,7 +200,7 @@ export class Transaction implements TransactionStorageStructure {
   boxes?: BoxReference[];
   type?: TransactionType;
   flatFee: boolean;
-  reKeyTo?: Address;
+  rekeyTo?: Address;
   nonParticipation?: boolean;
   group?: Uint8Array;
   extraPages?: number;
@@ -278,8 +278,8 @@ export class Transaction implements TransactionStorageStructure {
       txn.assetSender = address.decodeAddress(txn.assetSender as string);
     if (txn.freezeAccount !== undefined)
       txn.freezeAccount = address.decodeAddress(txn.freezeAccount as string);
-    if (txn.reKeyTo !== undefined)
-      txn.reKeyTo = address.decodeAddress(txn.reKeyTo as string);
+    if (txn.rekeyTo !== undefined)
+      txn.rekeyTo = address.decodeAddress(txn.rekeyTo as string);
     if (txn.genesisHash === undefined)
       throw Error('genesis hash must be specified and in a base64 string.');
 
@@ -598,8 +598,8 @@ export class Transaction implements TransactionStorageStructure {
       ) {
         txn.close = this.closeRemainderTo.publicKey;
       }
-      if (this.reKeyTo !== undefined) {
-        txn.rekey = this.reKeyTo.publicKey;
+      if (this.rekeyTo !== undefined) {
+        txn.rekey = this.rekeyTo.publicKey;
       }
       // allowed zero values
       if (this.receiver !== undefined) txn.rcv = this.receiver.publicKey;
@@ -639,8 +639,8 @@ export class Transaction implements TransactionStorageStructure {
       if (!txn.fv) delete txn.fv;
       if (!txn.gen) delete txn.gen;
       if (txn.grp === undefined) delete txn.grp;
-      if (this.reKeyTo !== undefined) {
-        txn.rekey = this.reKeyTo.publicKey;
+      if (this.rekeyTo !== undefined) {
+        txn.rekey = this.rekeyTo.publicKey;
       }
       if (this.nonParticipation) {
         txn.nonpart = true;
@@ -694,8 +694,8 @@ export class Transaction implements TransactionStorageStructure {
       if (!txn.fee) delete txn.fee;
       if (!txn.fv) delete txn.fv;
       if (!txn.gen) delete txn.gen;
-      if (this.reKeyTo !== undefined) {
-        txn.rekey = this.reKeyTo.publicKey;
+      if (this.rekeyTo !== undefined) {
+        txn.rekey = this.rekeyTo.publicKey;
       }
 
       if (!txn.caid) delete txn.caid;
@@ -762,8 +762,8 @@ export class Transaction implements TransactionStorageStructure {
       if (!txn.aclose) delete txn.aclose;
       if (!txn.asnd) delete txn.asnd;
       if (!txn.rekey) delete txn.rekey;
-      if (this.reKeyTo !== undefined) {
-        txn.rekey = this.reKeyTo.publicKey;
+      if (this.rekeyTo !== undefined) {
+        txn.rekey = this.rekeyTo.publicKey;
       }
       return txn;
     }
@@ -794,8 +794,8 @@ export class Transaction implements TransactionStorageStructure {
       if (!txn.gen) delete txn.gen;
       if (!txn.afrz) delete txn.afrz;
       if (txn.grp === undefined) delete txn.grp;
-      if (this.reKeyTo !== undefined) {
-        txn.rekey = this.reKeyTo.publicKey;
+      if (this.rekeyTo !== undefined) {
+        txn.rekey = this.rekeyTo.publicKey;
       }
       return txn;
     }
@@ -831,8 +831,8 @@ export class Transaction implements TransactionStorageStructure {
           this.appIndex
         ),
       };
-      if (this.reKeyTo !== undefined) {
-        txn.rekey = this.reKeyTo.publicKey;
+      if (this.rekeyTo !== undefined) {
+        txn.rekey = this.rekeyTo.publicKey;
       }
       if (this.appApprovalProgram !== undefined) {
         txn.apap = this.appApprovalProgram;
@@ -940,7 +940,7 @@ export class Transaction implements TransactionStorageStructure {
     );
     if (txnForEnc.grp !== undefined) txn.group = txnForEnc.grp;
     if (txnForEnc.rekey !== undefined)
-      txn.reKeyTo = address.decodeAddress(
+      txn.rekeyTo = address.decodeAddress(
         address.encodeAddress(new Uint8Array(txnForEnc.rekey))
       );
 
@@ -1198,9 +1198,9 @@ export class Transaction implements TransactionStorageStructure {
 
   // add the rekey-to field to a transaction not yet having it
   // supply feePerByte to increment fee accordingly
-  addRekey(reKeyTo: string, feePerByte = 0) {
-    if (reKeyTo !== undefined) {
-      this.reKeyTo = address.decodeAddress(reKeyTo);
+  addRekey(rekeyTo: string, feePerByte = 0) {
+    if (rekeyTo !== undefined) {
+      this.rekeyTo = address.decodeAddress(rekeyTo);
     }
     if (feePerByte !== 0) {
       this.fee +=
@@ -1253,9 +1253,9 @@ export class Transaction implements TransactionStorageStructure {
       forPrinting.assetSender = address.encodeAddress(
         (forPrinting.assetSender as Address).publicKey
       );
-    if (forPrinting.reKeyTo !== undefined)
-      forPrinting.reKeyTo = address.encodeAddress(
-        (forPrinting.reKeyTo as Address).publicKey
+    if (forPrinting.rekeyTo !== undefined)
+      forPrinting.rekeyTo = address.encodeAddress(
+        (forPrinting.rekeyTo as Address).publicKey
       );
     if (typeof forPrinting.genesisHash !== 'string')
       forPrinting.genesisHash = bytesToBase64(forPrinting.genesisHash);

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -93,7 +93,7 @@ interface TransactionStorageStructure
   assetURL: string;
   assetMetadataHash?: string | Uint8Array;
   freezeAccount: string | Address;
-  freezeState: boolean;
+  assetFrozen: boolean;
   assetRevocationTarget?: string | Address;
   appIndex: number;
   appOnComplete: OnApplicationComplete;
@@ -183,7 +183,7 @@ export class Transaction implements TransactionStorageStructure {
   assetURL: string;
   assetMetadataHash?: Uint8Array;
   freezeAccount: Address;
-  freezeState: boolean;
+  assetFrozen: boolean;
   assetRevocationTarget?: Address;
   appIndex: number;
   appOnComplete: OnApplicationComplete;
@@ -783,7 +783,7 @@ export class Transaction implements TransactionStorageStructure {
         lx: this.lease,
         grp: this.group,
         faid: this.assetIndex,
-        afrz: this.freezeState,
+        afrz: this.assetFrozen,
       };
       if (this.freezeAccount !== undefined)
         txn.fadd = this.freezeAccount.publicKey;
@@ -1031,7 +1031,7 @@ export class Transaction implements TransactionStorageStructure {
       );
     } else if (txnForEnc.type === 'afrz') {
       if (txnForEnc.afrz !== undefined) {
-        txn.freezeState = txnForEnc.afrz;
+        txn.assetFrozen = txnForEnc.afrz;
       }
       if (txnForEnc.faid !== undefined) {
         txn.assetIndex = txnForEnc.faid;

--- a/src/types/transactions/asset.ts
+++ b/src/types/transactions/asset.ts
@@ -90,8 +90,8 @@ export type AssetFreezeTransaction = ConstructTransaction<
 
 type SpecificParametersForTransfer = Pick<
   TransactionParams,
-  | 'from'
-  | 'to'
+  | 'sender'
+  | 'receiver'
   | 'closeRemainderTo'
   | 'assetRevocationTarget'
   | 'amount'

--- a/src/types/transactions/asset.ts
+++ b/src/types/transactions/asset.ts
@@ -93,7 +93,7 @@ type SpecificParametersForTransfer = Pick<
   | 'sender'
   | 'receiver'
   | 'closeRemainderTo'
-  | 'assetRevocationTarget'
+  | 'assetSender'
   | 'amount'
   | 'assetIndex'
 >;

--- a/src/types/transactions/asset.ts
+++ b/src/types/transactions/asset.ts
@@ -72,7 +72,7 @@ export type AssetDestroyTransaction = ConstructTransaction<
 
 type SpecificParametersForFreeze = Pick<
   TransactionParams,
-  'assetIndex' | 'freezeAccount' | 'freezeState'
+  'assetIndex' | 'freezeAccount' | 'assetFrozen'
 >;
 
 interface OverwritesForFreeze {

--- a/src/types/transactions/base.ts
+++ b/src/types/transactions/base.ts
@@ -311,7 +311,7 @@ export interface TransactionParams {
   /**
    * true if freezeTarget should be frozen, false if freezeTarget should be allowed to transact
    */
-  freezeState: boolean;
+  assetFrozen: boolean;
 
   /**
    * String representation of Algorand address – if provided, and if "from" is

--- a/src/types/transactions/base.ts
+++ b/src/types/transactions/base.ts
@@ -162,12 +162,12 @@ export interface TransactionParams {
   /**
    * String representation of Algorand address of sender
    */
-  from: string;
+  sender: string;
 
   /**
    * String representation of Algorand address of recipient
    */
-  to: string;
+  receiver: string;
 
   /**
    * Integer fee per byte, in microAlgos. For a flat fee, set flatFee to true
@@ -314,8 +314,8 @@ export interface TransactionParams {
   assetFrozen: boolean;
 
   /**
-   * String representation of Algorand address – if provided, and if "from" is
-   * the asset's revocation manager, then deduct from "revocationTarget" rather than "from"
+   * String representation of Algorand address – if provided, and if "sender" is
+   * the asset's revocation manager, then deduct from "revocationTarget" rather than "sender"
    */
   assetRevocationTarget?: string;
 

--- a/src/types/transactions/base.ts
+++ b/src/types/transactions/base.ts
@@ -112,12 +112,12 @@ export interface SuggestedParams {
   /**
    * First protocol round on which this txn is valid
    */
-  firstRound: number;
+  firstValid: number;
 
   /**
    * Last protocol round on which this txn is valid
    */
-  lastRound: number;
+  lastValid: number;
 
   /**
    * Specifies genesis ID of network in use
@@ -182,12 +182,12 @@ export interface TransactionParams {
   /**
    * Integer first protocol round on which this txn is valid
    */
-  firstRound: number;
+  firstValid: number;
 
   /**
    * Integer last protocol round on which this txn is valid
    */
-  lastRound: number;
+  lastValid: number;
 
   /**
    * Arbitrary data for sender to store

--- a/src/types/transactions/base.ts
+++ b/src/types/transactions/base.ts
@@ -399,7 +399,7 @@ export interface TransactionParams {
   /**
    * String representation of the Algorand address that will be used to authorize all future transactions
    */
-  reKeyTo?: string;
+  rekeyTo?: string;
 
   /**
    * Set this value to true to mark this account as nonparticipating.

--- a/src/types/transactions/base.ts
+++ b/src/types/transactions/base.ts
@@ -315,9 +315,9 @@ export interface TransactionParams {
 
   /**
    * String representation of Algorand address – if provided, and if "sender" is
-   * the asset's revocation manager, then deduct from "revocationTarget" rather than "sender"
+   * the asset's revocation manager, then deduct from "assetSender" rather than "sender"
    */
-  assetRevocationTarget?: string;
+  assetSender?: string;
 
   /**
    * A unique application index

--- a/src/types/transactions/builder.ts
+++ b/src/types/transactions/builder.ts
@@ -16,8 +16,8 @@ type TransactionBaseWithoutSuggestedParams = Pick<
   TransactionParams,
   | 'flatFee'
   | 'fee'
-  | 'firstRound'
-  | 'lastRound'
+  | 'firstValid'
+  | 'lastValid'
   | 'genesisHash'
   | 'from'
   | 'type'

--- a/src/types/transactions/builder.ts
+++ b/src/types/transactions/builder.ts
@@ -6,7 +6,7 @@ import { TransactionParams, SuggestedParams } from './base';
  */
 type TransactionBaseWithSuggestedParams = Pick<
   TransactionParams,
-  'suggestedParams' | 'sender' | 'type' | 'lease' | 'note' | 'reKeyTo'
+  'suggestedParams' | 'sender' | 'type' | 'lease' | 'note' | 'rekeyTo'
 >;
 
 /**
@@ -24,7 +24,7 @@ type TransactionBaseWithoutSuggestedParams = Pick<
   | 'genesisID'
   | 'lease'
   | 'note'
-  | 'reKeyTo'
+  | 'rekeyTo'
 >;
 
 /**

--- a/src/types/transactions/builder.ts
+++ b/src/types/transactions/builder.ts
@@ -6,7 +6,7 @@ import { TransactionParams, SuggestedParams } from './base';
  */
 type TransactionBaseWithSuggestedParams = Pick<
   TransactionParams,
-  'suggestedParams' | 'from' | 'type' | 'lease' | 'note' | 'reKeyTo'
+  'suggestedParams' | 'sender' | 'type' | 'lease' | 'note' | 'reKeyTo'
 >;
 
 /**
@@ -19,7 +19,7 @@ type TransactionBaseWithoutSuggestedParams = Pick<
   | 'firstValid'
   | 'lastValid'
   | 'genesisHash'
-  | 'from'
+  | 'sender'
   | 'type'
   | 'genesisID'
   | 'lease'

--- a/src/types/transactions/encoded.ts
+++ b/src/types/transactions/encoded.ts
@@ -105,12 +105,12 @@ export interface EncodedTransaction {
   fee?: number;
 
   /**
-   * firstRound
+   * firstValid
    */
   fv?: number;
 
   /**
-   * lastRound
+   * lastValid
    */
   lv: number;
 

--- a/src/types/transactions/encoded.ts
+++ b/src/types/transactions/encoded.ts
@@ -235,7 +235,7 @@ export interface EncodedTransaction {
   faid?: number;
 
   /**
-   * freezeState
+   * assetFrozen
    */
   afrz?: boolean;
 

--- a/src/types/transactions/encoded.ts
+++ b/src/types/transactions/encoded.ts
@@ -170,7 +170,7 @@ export interface EncodedTransaction {
   aclose?: Uint8Array;
 
   /**
-   * reKeyTo
+   * rekeyTo
    */
   rekey?: Uint8Array;
 

--- a/src/types/transactions/encoded.ts
+++ b/src/types/transactions/encoded.ts
@@ -245,7 +245,7 @@ export interface EncodedTransaction {
   fadd?: Uint8Array;
 
   /**
-   * assetRevocationTarget
+   * assetSender
    */
   asnd?: Uint8Array;
 

--- a/src/types/transactions/encoded.ts
+++ b/src/types/transactions/encoded.ts
@@ -120,7 +120,7 @@ export interface EncodedTransaction {
   note?: Uint8Array;
 
   /**
-   * from
+   * sender
    */
   snd: Uint8Array;
 
@@ -175,12 +175,12 @@ export interface EncodedTransaction {
   rekey?: Uint8Array;
 
   /**
-   * to
+   * receiver
    */
   rcv?: Uint8Array;
 
   /**
-   * to (but for asset transfers)
+   * receiver (but for asset transfers)
    */
   arcv?: Uint8Array;
 
@@ -400,7 +400,7 @@ export interface EncodedSignedTransaction {
   lsig?: EncodedLogicSig;
 
   /**
-   * The signer, if signing with a different key than the Transaction type `from` property indicates
+   * The signer, if signing with a different key than the Transaction type `sender` property indicates
    */
   sgnr?: Uint8Array;
 }

--- a/src/types/transactions/payment.ts
+++ b/src/types/transactions/payment.ts
@@ -3,7 +3,7 @@ import { ConstructTransaction } from './builder';
 
 type SpecificParameters = Pick<
   TransactionParams,
-  'to' | 'amount' | 'closeRemainderTo'
+  'receiver' | 'amount' | 'closeRemainderTo'
 >;
 
 interface Overwrites {

--- a/tests/10.ABI.ts
+++ b/tests/10.ABI.ts
@@ -490,8 +490,8 @@ describe('ABI encoding', () => {
     const sender = 'DN7MBMCL5JQ3PFUQS7TMX5AH4EEKOBJVDUF4TCV6WERATKFLQF4MQUPZTA';
     const sp = {
       fee: 1000,
-      firstRound: 1,
-      lastRound: 1001,
+      firstValid: 1,
+      lastValid: 1001,
       genesisID: 'gi',
       genesisHash: 'gh',
     };

--- a/tests/5.Transaction.js
+++ b/tests/5.Transaction.js
@@ -41,8 +41,8 @@ describe('Sign', () => {
     const o = {
       from: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
       fee: 10,
-      firstRound: 51,
-      lastRound: 61,
+      firstValid: 51,
+      lastValid: 61,
       genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
       note: new Uint8Array(0),
       type: 'appl',
@@ -77,8 +77,8 @@ describe('Sign', () => {
       to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
       fee: 10,
       amount: 847,
-      firstRound: 51,
-      lastRound: 61,
+      firstValid: 51,
+      lastValid: 61,
       genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
       note: new Uint8Array(0),
     };
@@ -91,8 +91,8 @@ describe('Sign', () => {
       to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
       fee: 0,
       amount: 847,
-      firstRound: 51,
-      lastRound: 61,
+      firstValid: 51,
+      lastValid: 61,
       genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
       note: new Uint8Array([123, 12, 200]),
     };
@@ -109,8 +109,8 @@ describe('Sign', () => {
       fee: 0,
       flatFee: true,
       amount: 847,
-      firstRound: 51,
-      lastRound: 61,
+      firstValid: 51,
+      lastValid: 61,
       genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
       note: new Uint8Array([123, 12, 200]),
     };
@@ -125,8 +125,8 @@ describe('Sign', () => {
       fee: 10,
       flatFee: true,
       amount: 847,
-      firstRound: 51,
-      lastRound: 61,
+      firstValid: 51,
+      lastValid: 61,
       genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
       note: new Uint8Array([123, 12, 200]),
     };
@@ -142,8 +142,8 @@ describe('Sign', () => {
       to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
       fee: 10,
       amount: 847,
-      firstRound: 51,
-      lastRound: 61,
+      firstValid: 51,
+      lastValid: 61,
       genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
       note: new Uint8Array([123, 12, 200]),
     };
@@ -157,8 +157,8 @@ describe('Sign', () => {
       to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
       fee: 10,
       amount: 847,
-      firstRound: 51,
-      lastRound: 61,
+      firstValid: 51,
+      lastValid: 61,
       note: new Uint8Array([123, 12, 200]),
       genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
       genesisID: '',
@@ -173,8 +173,8 @@ describe('Sign', () => {
       to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
       fee: 10,
       amount: 847,
-      firstRound: 51,
-      lastRound: 61,
+      firstValid: 51,
+      lastValid: 61,
       genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
       note: 'new Uint8Array(0)',
     };
@@ -190,8 +190,8 @@ describe('Sign', () => {
       to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
       fee: 10,
       amount: 847,
-      firstRound: 51,
-      lastRound: 61,
+      firstValid: 51,
+      lastValid: 61,
       genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
       note: new Uint8Array(32),
     });
@@ -201,8 +201,8 @@ describe('Sign', () => {
       to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
       fee: 10,
       amount: 847,
-      firstRound: 51,
-      lastRound: 61,
+      firstValid: 51,
+      lastValid: 61,
       genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
     });
 
@@ -220,8 +220,8 @@ describe('Sign', () => {
       to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
       fee: 10,
       amount: 847,
-      firstRound: 51,
-      lastRound: 61,
+      firstValid: 51,
+      lastValid: 61,
       genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
       lease: new Uint8Array(32),
     });
@@ -231,8 +231,8 @@ describe('Sign', () => {
       to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
       fee: 10,
       amount: 847,
-      firstRound: 51,
-      lastRound: 61,
+      firstValid: 51,
+      lastValid: 61,
       genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
     });
 
@@ -251,8 +251,8 @@ describe('Sign', () => {
     const txnWithHash = new algosdk.Transaction({
       from: address,
       fee: 10,
-      firstRound: 322575,
-      lastRound: 323575,
+      firstValid: 322575,
+      lastValid: 323575,
       genesisHash: 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=',
       assetIndex: 1234,
       assetManager: address,
@@ -266,8 +266,8 @@ describe('Sign', () => {
     const txnWithoutHash = new algosdk.Transaction({
       from: address,
       fee: 10,
-      firstRound: 322575,
-      lastRound: 323575,
+      firstValid: 322575,
+      lastValid: 323575,
       genesisHash: 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=',
       assetIndex: 1234,
       assetManager: address,
@@ -291,8 +291,8 @@ describe('Sign', () => {
       to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
       fee: 10,
       amount: 847,
-      firstRound: 51,
-      lastRound: 61,
+      firstValid: 51,
+      lastValid: 61,
       genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
       note: new Uint8Array(0),
     };
@@ -309,8 +309,8 @@ describe('Sign', () => {
         to: 'UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM',
         fee: 10,
         amount: 847,
-        firstRound: 51,
-        lastRound: 61,
+        firstValid: 51,
+        lastValid: 61,
         note: new Uint8Array([123, 12, 200]),
         genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
         genesisID: '',
@@ -330,8 +330,8 @@ describe('Sign', () => {
         to: 'UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM',
         fee: 2063,
         amount: 847,
-        firstRound: 51,
-        lastRound: 61,
+        firstValid: 51,
+        lastValid: 61,
         note: new Uint8Array([123, 12, 200]),
         genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
         genesisID: '',
@@ -350,8 +350,8 @@ describe('Sign', () => {
       const o = {
         from: 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU',
         fee: 10,
-        firstRound: 51,
-        lastRound: 61,
+        firstValid: 51,
+        lastValid: 61,
         note: new Uint8Array([123, 12, 200]),
         genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
         voteKey: '5/D4TQaBHfnzHI2HixFV9GcdUaGFwgCQhmf0SVhwaKE=',
@@ -384,8 +384,8 @@ describe('Sign', () => {
       const o = {
         from: 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU',
         fee: 10,
-        firstRound: 51,
-        lastRound: 61,
+        firstValid: 51,
+        lastValid: 61,
         note: new Uint8Array([123, 12, 200]),
         genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
         voteKey: '5/D4TQaBHfnzHI2HixFV9GcdUaGFwgCQhmf0SVhwaKE=',
@@ -409,8 +409,8 @@ describe('Sign', () => {
       const o = {
         from: 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU',
         fee: 10,
-        firstRound: 51,
-        lastRound: 61,
+        firstValid: 51,
+        lastValid: 61,
         note: new Uint8Array([123, 12, 200]),
         genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
         genesisID: '',
@@ -429,8 +429,8 @@ describe('Sign', () => {
       const o = {
         from: 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU',
         fee: 10,
-        firstRound: 51,
-        lastRound: 61,
+        firstValid: 51,
+        lastValid: 61,
         note: new Uint8Array([123, 12, 200]),
         genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
         genesisID: '',
@@ -450,8 +450,8 @@ describe('Sign', () => {
       const o = {
         from: 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU',
         fee: 10,
-        firstRound: 51,
-        lastRound: 61,
+        firstValid: 51,
+        lastValid: 61,
         note: new Uint8Array([123, 12, 200]),
         genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
         nonParticipation: true,
@@ -473,8 +473,8 @@ describe('Sign', () => {
       const o = {
         from: address,
         fee: 10,
-        firstRound: 322575,
-        lastRound: 323575,
+        firstValid: 322575,
+        lastValid: 323575,
         genesisHash: 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=',
         assetIndex: 1234,
         assetManager: address,
@@ -498,8 +498,8 @@ describe('Sign', () => {
       const o = {
         from: address,
         fee: 10,
-        firstRound: 322575,
-        lastRound: 323575,
+        firstValid: 322575,
+        lastValid: 323575,
         genesisHash: 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=',
         assetTotal: 1000,
         assetDefaultFrozen: true,
@@ -533,8 +533,8 @@ describe('Sign', () => {
         to: address,
         amount: 100,
         fee: 10,
-        firstRound: 322575,
-        lastRound: 323575,
+        firstValid: 322575,
+        lastValid: 323575,
         genesisHash: 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=',
         assetIndex: 1234,
         assetRevocationTarget: address,
@@ -572,8 +572,8 @@ describe('Sign', () => {
         rekeyTo: 'UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM',
         suggestedParams: {
           fee: 0,
-          firstRound: 322575,
-          lastRound: 323575,
+          firstValid: 322575,
+          lastValid: 323575,
           genesisID: 'testnet-v1.0',
           genesisHash: 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=',
         },
@@ -592,8 +592,8 @@ describe('Sign', () => {
       const o = {
         from: address,
         fee: 10,
-        firstRound: 322575,
-        lastRound: 323575,
+        firstValid: 322575,
+        lastValid: 323575,
         genesisHash: 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=',
         type: 'afrz',
         freezeAccount: address,
@@ -616,8 +616,8 @@ describe('Sign', () => {
       const o = {
         from: address,
         fee: 10,
-        firstRound: 0,
-        lastRound: 1000,
+        firstValid: 0,
+        lastValid: 1000,
         genesisHash: 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=',
         type: 'afrz',
         freezeAccount: address,
@@ -640,8 +640,8 @@ describe('Sign', () => {
         to: 'UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM',
         fee: 10,
         amount: 847,
-        firstRound: 51,
-        lastRound: 61,
+        firstValid: 51,
+        lastValid: 61,
         genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
         note: new Uint8Array([123, 12, 200]),
       };
@@ -660,8 +660,8 @@ describe('Sign', () => {
         to: 'UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM',
         fee: 10,
         amount: 0,
-        firstRound: 51,
-        lastRound: 61,
+        firstValid: 51,
+        lastValid: 61,
         genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
         note: new Uint8Array([123, 12, 200]),
       };
@@ -680,8 +680,8 @@ describe('Sign', () => {
         to: 'UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM',
         fee: 10,
         amount: 0,
-        firstRound: 51,
-        lastRound: 61,
+        firstValid: 51,
+        lastValid: 61,
         genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
         note: new Uint8Array([123, 12, 200]),
       };
@@ -716,8 +716,8 @@ describe('Sign', () => {
       const to = 'UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM';
       const fee = 10;
       const amount = 847;
-      const firstRound = 51;
-      const lastRound = 61;
+      const firstValid = 51;
+      const lastValid = 61;
       const note = new Uint8Array([123, 12, 200]);
       const genesisHash = 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=';
       const genesisID = '';
@@ -730,8 +730,8 @@ describe('Sign', () => {
         fee,
         amount,
         closeRemainderTo,
-        firstRound,
-        lastRound,
+        firstValid,
+        lastValid,
         note,
         genesisHash,
         genesisID,
@@ -741,8 +741,8 @@ describe('Sign', () => {
       const suggestedParams = {
         genesisHash,
         genesisID,
-        firstRound,
-        lastRound,
+        firstValid,
+        lastValid,
         fee,
       };
       const actualTxn = algosdk.makePaymentTxnWithSuggestedParams(
@@ -762,8 +762,8 @@ describe('Sign', () => {
       const to = 'UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM';
       const fee = 10;
       const amount = 0xffffffffffffffffn;
-      const firstRound = 51;
-      const lastRound = 61;
+      const firstValid = 51;
+      const lastValid = 61;
       const note = new Uint8Array([123, 12, 200]);
       const genesisHash = 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=';
       const genesisID = '';
@@ -776,8 +776,8 @@ describe('Sign', () => {
         fee,
         amount,
         closeRemainderTo,
-        firstRound,
-        lastRound,
+        firstValid,
+        lastValid,
         note,
         genesisHash,
         genesisID,
@@ -787,8 +787,8 @@ describe('Sign', () => {
       const suggestedParams = {
         genesisHash,
         genesisID,
-        firstRound,
-        lastRound,
+        firstValid,
+        lastValid,
         fee,
       };
       const actualTxn = algosdk.makePaymentTxnWithSuggestedParams(
@@ -808,8 +808,8 @@ describe('Sign', () => {
       const to = 'UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM';
       const fee = 10;
       const amount = 0x10000000000000000n;
-      const firstRound = 51;
-      const lastRound = 61;
+      const firstValid = 51;
+      const lastValid = 61;
       const note = new Uint8Array([123, 12, 200]);
       const genesisHash = 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=';
       const genesisID = '';
@@ -822,8 +822,8 @@ describe('Sign', () => {
         fee,
         amount,
         closeRemainderTo,
-        firstRound,
-        lastRound,
+        firstValid,
+        lastValid,
         note,
         genesisHash,
         genesisID,
@@ -840,8 +840,8 @@ describe('Sign', () => {
     it('should be able to use helper to make a keyreg transaction', () => {
       const from = 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU';
       const fee = 10;
-      const firstRound = 51;
-      const lastRound = 61;
+      const firstValid = 51;
+      const lastValid = 61;
       const note = new Uint8Array([123, 12, 200]);
       const genesisHash = 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=';
       const genesisID = '';
@@ -855,8 +855,8 @@ describe('Sign', () => {
       const o = {
         from,
         fee,
-        firstRound,
-        lastRound,
+        firstValid,
+        lastValid,
         note,
         genesisHash,
         voteKey,
@@ -872,8 +872,8 @@ describe('Sign', () => {
       const suggestedParams = {
         genesisHash,
         genesisID,
-        firstRound,
-        lastRound,
+        firstValid,
+        lastValid,
         fee,
       };
       const actualTxn = algosdk.makeKeyRegistrationTxnWithSuggestedParams(
@@ -893,8 +893,8 @@ describe('Sign', () => {
     it('should be able to use helper to make an offline keyreg transaction', () => {
       const from = 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU';
       const fee = 10;
-      const firstRound = 51;
-      const lastRound = 61;
+      const firstValid = 51;
+      const lastValid = 61;
       const note = new Uint8Array([123, 12, 200]);
       const genesisHash = 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=';
       const genesisID = '';
@@ -908,8 +908,8 @@ describe('Sign', () => {
       const o = {
         from,
         fee,
-        firstRound,
-        lastRound,
+        firstValid,
+        lastValid,
         note,
         genesisHash,
         voteKey,
@@ -939,8 +939,8 @@ describe('Sign', () => {
       const suggestedParams = {
         genesisHash,
         genesisID,
-        firstRound,
-        lastRound,
+        firstValid,
+        lastValid,
         fee,
       };
       const actualTxn = algosdk.makeKeyRegistrationTxnWithSuggestedParams(
@@ -960,8 +960,8 @@ describe('Sign', () => {
     it('should be able to use helper to make a nonparticipating keyreg transaction', () => {
       const from = 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU';
       const fee = 10;
-      const firstRound = 51;
-      const lastRound = 61;
+      const firstValid = 51;
+      const lastValid = 61;
       const note = new Uint8Array([123, 12, 200]);
       const genesisHash = 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=';
       const genesisID = '';
@@ -976,8 +976,8 @@ describe('Sign', () => {
       const o = {
         from,
         fee,
-        firstRound,
-        lastRound,
+        firstValid,
+        lastValid,
         note,
         genesisHash,
         nonParticipation,
@@ -1005,8 +1005,8 @@ describe('Sign', () => {
       const suggestedParams = {
         genesisHash,
         genesisID,
-        firstRound,
-        lastRound,
+        firstValid,
+        lastValid,
         fee,
       };
       const actualTxn = algosdk.makeKeyRegistrationTxnWithSuggestedParams(
@@ -1041,16 +1041,16 @@ describe('Sign', () => {
         algosdk.base64ToBytes('dGVzdGhhc2gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=')
       );
       const genesisID = '';
-      const firstRound = 322575;
-      const lastRound = 322575;
+      const firstValid = 322575;
+      const lastValid = 322575;
       const note = new Uint8Array([123, 12, 200]);
       const rekeyTo =
         'GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM';
       const o = {
         from: addr,
         fee,
-        firstRound,
-        lastRound,
+        firstValid,
+        lastValid,
         note,
         genesisHash,
         assetTotal: total,
@@ -1072,8 +1072,8 @@ describe('Sign', () => {
       const suggestedParams = {
         genesisHash,
         genesisID,
-        firstRound,
-        lastRound,
+        firstValid,
+        lastValid,
         fee,
       };
       const actualTxn = algosdk.makeAssetCreateTxnWithSuggestedParams(
@@ -1113,16 +1113,16 @@ describe('Sign', () => {
         algosdk.base64ToBytes('dGVzdGhhc2gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=')
       );
       const genesisID = '';
-      const firstRound = 322575;
-      const lastRound = 322575;
+      const firstValid = 322575;
+      const lastValid = 322575;
       const note = new Uint8Array([123, 12, 200]);
       const rekeyTo =
         'GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM';
       const o = {
         from: addr,
         fee,
-        firstRound,
-        lastRound,
+        firstValid,
+        lastValid,
         note,
         genesisHash,
         assetTotal: total,
@@ -1144,8 +1144,8 @@ describe('Sign', () => {
       const suggestedParams = {
         genesisHash,
         genesisID,
-        firstRound,
-        lastRound,
+        firstValid,
+        lastValid,
         fee,
       };
       const actualTxn = algosdk.makeAssetCreateTxnWithSuggestedParams(
@@ -1185,16 +1185,16 @@ describe('Sign', () => {
         algosdk.base64ToBytes('dGVzdGhhc2gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=')
       );
       const genesisID = '';
-      const firstRound = 322575;
-      const lastRound = 322575;
+      const firstValid = 322575;
+      const lastValid = 322575;
       const note = new Uint8Array([123, 12, 200]);
       const rekeyTo =
         'GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM';
       const o = {
         from: addr,
         fee,
-        firstRound,
-        lastRound,
+        firstValid,
+        lastValid,
         note,
         genesisHash,
         assetTotal: total,
@@ -1234,16 +1234,16 @@ describe('Sign', () => {
       const assetName = 'testcoin';
       const assetURL = 'testURL';
       const genesisID = '';
-      const firstRound = 322575;
-      const lastRound = 322575;
+      const firstValid = 322575;
+      const lastValid = 322575;
       const note = new Uint8Array([123, 12, 200]);
       const rekeyTo =
         'GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM';
       const txnTemplate = {
         from: addr,
         fee,
-        firstRound,
-        lastRound,
+        firstValid,
+        lastValid,
         note,
         genesisHash,
         assetTotal: total,
@@ -1328,16 +1328,16 @@ describe('Sign', () => {
       const freeze = addr;
       const clawback = addr;
       const genesisID = '';
-      const firstRound = 322575;
-      const lastRound = 322575;
+      const firstValid = 322575;
+      const lastValid = 322575;
       const note = new Uint8Array([123, 12, 200]);
       const rekeyTo =
         'GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM';
       const o = {
         from: addr,
         fee,
-        firstRound,
-        lastRound,
+        firstValid,
+        lastValid,
         genesisHash,
         genesisID,
         assetIndex,
@@ -1353,8 +1353,8 @@ describe('Sign', () => {
       const suggestedParams = {
         genesisHash,
         genesisID,
-        firstRound,
-        lastRound,
+        firstValid,
+        lastValid,
         fee,
       };
       const actualTxn = algosdk.makeAssetConfigTxnWithSuggestedParams(
@@ -1382,16 +1382,16 @@ describe('Sign', () => {
       let freeze;
       const clawback = addr;
       const genesisID = '';
-      const firstRound = 322575;
-      const lastRound = 322575;
+      const firstValid = 322575;
+      const lastValid = 322575;
       const note = new Uint8Array([123, 12, 200]);
       let threw = false;
       try {
         const suggestedParams = {
           genesisHash,
           genesisID,
-          firstRound,
-          lastRound,
+          firstValid,
+          lastValid,
           fee,
         };
         algosdk.makeAssetConfigTxnWithSuggestedParams(
@@ -1416,16 +1416,16 @@ describe('Sign', () => {
       const assetIndex = 1234;
       const genesisHash = 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=';
       const genesisID = '';
-      const firstRound = 322575;
-      const lastRound = 322575;
+      const firstValid = 322575;
+      const lastValid = 322575;
       const note = new Uint8Array([123, 12, 200]);
       const rekeyTo =
         'GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM';
       const o = {
         from: addr,
         fee,
-        firstRound,
-        lastRound,
+        firstValid,
+        lastValid,
         genesisHash,
         genesisID,
         assetIndex,
@@ -1437,8 +1437,8 @@ describe('Sign', () => {
       const suggestedParams = {
         genesisHash,
         genesisID,
-        firstRound,
-        lastRound,
+        firstValid,
+        lastValid,
         fee,
       };
       const actualTxn = algosdk.makeAssetDestroyTxnWithSuggestedParams(
@@ -1462,8 +1462,8 @@ describe('Sign', () => {
       const amount = 100;
       const genesisHash = 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=';
       const genesisID = '';
-      const firstRound = 322575;
-      const lastRound = 322575;
+      const firstValid = 322575;
+      const lastValid = 322575;
       const note = new Uint8Array([123, 12, 200]);
       const rekeyTo =
         'GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM';
@@ -1473,8 +1473,8 @@ describe('Sign', () => {
         to: recipient,
         amount,
         fee,
-        firstRound,
-        lastRound,
+        firstValid,
+        lastValid,
         genesisHash,
         genesisID,
         assetIndex,
@@ -1487,8 +1487,8 @@ describe('Sign', () => {
       const suggestedParams = {
         genesisHash,
         genesisID,
-        firstRound,
-        lastRound,
+        firstValid,
+        lastValid,
         fee,
       };
 
@@ -1513,8 +1513,8 @@ describe('Sign', () => {
       const genesisHash = 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=';
       const freezeTarget = addr;
       const genesisID = '';
-      const firstRound = 322575;
-      const lastRound = 322575;
+      const firstValid = 322575;
+      const lastValid = 322575;
       const freezeState = true;
       const note = new Uint8Array([123, 12, 200]);
       const rekeyTo =
@@ -1522,8 +1522,8 @@ describe('Sign', () => {
       const o = {
         from: addr,
         fee,
-        firstRound,
-        lastRound,
+        firstValid,
+        lastValid,
         genesisHash,
         type: 'afrz',
         freezeAccount: freezeTarget,
@@ -1537,8 +1537,8 @@ describe('Sign', () => {
       const suggestedParams = {
         genesisHash,
         genesisID,
-        firstRound,
-        lastRound,
+        firstValid,
+        lastValid,
         fee,
       };
 
@@ -1557,8 +1557,8 @@ describe('Sign', () => {
       const suggestedParams = {
         genesisHash: 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=',
         genesisID: '',
-        firstRound: 322575,
-        lastRound: 322575 + 1000,
+        firstValid: 322575,
+        lastValid: 322575 + 1000,
         fee: 1000,
         flatFee: true,
       };
@@ -1578,8 +1578,8 @@ describe('Sign', () => {
         fee: 1000,
         flatFee: true,
         amount: 0,
-        firstRound: 322575,
-        lastRound: 322575 + 1000,
+        firstValid: 322575,
+        lastValid: 322575 + 1000,
         genesisID: '',
         genesisHash: 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=',
         type: 'pay',

--- a/tests/5.Transaction.js
+++ b/tests/5.Transaction.js
@@ -598,7 +598,7 @@ describe('Sign', () => {
         type: 'afrz',
         freezeAccount: address,
         assetIndex: 1,
-        freezeState: true,
+        assetFrozen: true,
       };
 
       const expectedTxn = new algosdk.Transaction(o);
@@ -622,7 +622,7 @@ describe('Sign', () => {
         type: 'afrz',
         freezeAccount: address,
         assetIndex: 1,
-        freezeState: true,
+        assetFrozen: true,
       };
 
       const expectedTxn = new algosdk.Transaction(o);
@@ -1515,7 +1515,7 @@ describe('Sign', () => {
       const genesisID = '';
       const firstValid = 322575;
       const lastValid = 322575;
-      const freezeState = true;
+      const assetFrozen = true;
       const note = new Uint8Array([123, 12, 200]);
       const rekeyTo =
         'GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM';
@@ -1528,7 +1528,7 @@ describe('Sign', () => {
         type: 'afrz',
         freezeAccount: freezeTarget,
         assetIndex,
-        freezeState,
+        assetFrozen,
         note,
         genesisID,
         reKeyTo: rekeyTo,
@@ -1547,7 +1547,7 @@ describe('Sign', () => {
         note,
         assetIndex,
         freezeTarget,
-        freezeState,
+        assetFrozen,
         suggestedParams,
         rekeyTo
       );

--- a/tests/5.Transaction.js
+++ b/tests/5.Transaction.js
@@ -39,7 +39,7 @@ describe('Sign', () => {
     const appForeignAssets = [7, 8, 9];
     const boxes = [{ appIndex: 0, name: Uint8Array.from([0]) }];
     const o = {
-      from: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      sender: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
       fee: 10,
       firstValid: 51,
       lastValid: 61,
@@ -73,8 +73,8 @@ describe('Sign', () => {
 
   it('should not complain on a missing note', () => {
     const o = {
-      from: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
-      to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      sender: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      receiver: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
       fee: 10,
       amount: 847,
       firstValid: 51,
@@ -87,8 +87,8 @@ describe('Sign', () => {
 
   it('should respect min tx fee', () => {
     const o = {
-      from: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
-      to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      sender: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      receiver: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
       fee: 0,
       amount: 847,
       firstValid: 51,
@@ -104,8 +104,8 @@ describe('Sign', () => {
 
   it('should accept 0 fee', () => {
     const o = {
-      from: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
-      to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      sender: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      receiver: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
       fee: 0,
       flatFee: true,
       amount: 847,
@@ -120,8 +120,8 @@ describe('Sign', () => {
 
   it('should accept lower than min fee', () => {
     const o = {
-      from: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
-      to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      sender: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      receiver: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
       fee: 10,
       flatFee: true,
       amount: 847,
@@ -138,8 +138,8 @@ describe('Sign', () => {
 
   it('should not complain on a missing genesisID', () => {
     const o = {
-      from: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
-      to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      sender: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      receiver: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
       fee: 10,
       amount: 847,
       firstValid: 51,
@@ -153,8 +153,8 @@ describe('Sign', () => {
 
   it('should not complain on an empty genesisID', () => {
     const o = {
-      from: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
-      to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      sender: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      receiver: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
       fee: 10,
       amount: 847,
       firstValid: 51,
@@ -169,8 +169,8 @@ describe('Sign', () => {
 
   it('should complain if note isnt Uint8Array', () => {
     const o = {
-      from: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
-      to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      sender: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      receiver: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
       fee: 10,
       amount: 847,
       firstValid: 51,
@@ -186,8 +186,8 @@ describe('Sign', () => {
 
   it('should not drop a note of all zeros', () => {
     const txnWithNote = new algosdk.Transaction({
-      from: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
-      to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      sender: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      receiver: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
       fee: 10,
       amount: 847,
       firstValid: 51,
@@ -197,8 +197,8 @@ describe('Sign', () => {
     });
 
     const txnWithoutNote = new algosdk.Transaction({
-      from: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
-      to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      sender: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      receiver: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
       fee: 10,
       amount: 847,
       firstValid: 51,
@@ -216,8 +216,8 @@ describe('Sign', () => {
 
   it('should drop a lease of all zeros', () => {
     const txnWithLease = new algosdk.Transaction({
-      from: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
-      to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      sender: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      receiver: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
       fee: 10,
       amount: 847,
       firstValid: 51,
@@ -227,8 +227,8 @@ describe('Sign', () => {
     });
 
     const txnWithoutLease = new algosdk.Transaction({
-      from: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
-      to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      sender: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      receiver: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
       fee: 10,
       amount: 847,
       firstValid: 51,
@@ -249,7 +249,7 @@ describe('Sign', () => {
       'BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4';
 
     const txnWithHash = new algosdk.Transaction({
-      from: address,
+      sender: address,
       fee: 10,
       firstValid: 322575,
       lastValid: 323575,
@@ -264,7 +264,7 @@ describe('Sign', () => {
     });
 
     const txnWithoutHash = new algosdk.Transaction({
-      from: address,
+      sender: address,
       fee: 10,
       firstValid: 322575,
       lastValid: 323575,
@@ -287,8 +287,8 @@ describe('Sign', () => {
 
   it('should be able to prettyprint and go toString without throwing', () => {
     const o = {
-      from: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
-      to: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      sender: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
+      receiver: '7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q',
       fee: 10,
       amount: 847,
       firstValid: 51,
@@ -305,8 +305,8 @@ describe('Sign', () => {
   describe('should correctly serialize and deserialize from msgpack representation', () => {
     it('should correctly serialize and deserialize from msgpack representation', () => {
       const o = {
-        from: 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU',
-        to: 'UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM',
+        sender: 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU',
+        receiver: 'UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM',
         fee: 10,
         amount: 847,
         firstValid: 51,
@@ -326,8 +326,8 @@ describe('Sign', () => {
 
     it('should correctly serialize and deserialize from msgpack representation with flat fee', () => {
       const o = {
-        from: 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU',
-        to: 'UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM',
+        sender: 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU',
+        receiver: 'UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM',
         fee: 2063,
         amount: 847,
         firstValid: 51,
@@ -348,7 +348,7 @@ describe('Sign', () => {
 
     it('should correctly serialize and deserialize a state proof transaction from msgpack representation', () => {
       const o = {
-        from: 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU',
+        sender: 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU',
         fee: 10,
         firstValid: 51,
         lastValid: 61,
@@ -382,7 +382,7 @@ describe('Sign', () => {
 
     it('should correctly serialize and deserialize a key registration transaction from msgpack representation', () => {
       const o = {
-        from: 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU',
+        sender: 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU',
         fee: 10,
         firstValid: 51,
         lastValid: 61,
@@ -407,7 +407,7 @@ describe('Sign', () => {
 
     it('should correctly serialize and deserialize an offline key registration transaction from msgpack representation', () => {
       const o = {
-        from: 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU',
+        sender: 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU',
         fee: 10,
         firstValid: 51,
         lastValid: 61,
@@ -427,7 +427,7 @@ describe('Sign', () => {
 
     it('should correctly serialize and deserialize an offline key registration transaction from msgpack representation with explicit nonParticipation=false', () => {
       const o = {
-        from: 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU',
+        sender: 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU',
         fee: 10,
         firstValid: 51,
         lastValid: 61,
@@ -448,7 +448,7 @@ describe('Sign', () => {
 
     it('should correctly serialize and deserialize a nonparticipating key registration transaction from msgpack representation', () => {
       const o = {
-        from: 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU',
+        sender: 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU',
         fee: 10,
         firstValid: 51,
         lastValid: 61,
@@ -471,7 +471,7 @@ describe('Sign', () => {
       const address =
         'BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4';
       const o = {
-        from: address,
+        sender: address,
         fee: 10,
         firstValid: 322575,
         lastValid: 323575,
@@ -496,7 +496,7 @@ describe('Sign', () => {
       const address =
         'BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4';
       const o = {
-        from: address,
+        sender: address,
         fee: 10,
         firstValid: 322575,
         lastValid: 323575,
@@ -529,8 +529,8 @@ describe('Sign', () => {
         'BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4';
       const o = {
         type: 'axfer',
-        from: address,
-        to: address,
+        sender: address,
+        receiver: address,
         amount: 100,
         fee: 10,
         firstValid: 322575,
@@ -551,7 +551,7 @@ describe('Sign', () => {
 
     it('should correctly serialize and deserialize an application create transaction from msgpack representation', () => {
       const expectedTxn = algosdk.makeApplicationCreateTxnFromObject({
-        from: 'BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4',
+        sender: 'BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4',
         approvalProgram: Uint8Array.from([1, 32, 1, 1, 34]),
         clearProgram: Uint8Array.from([2, 32, 1, 1, 34]),
         numGlobalInts: 1,
@@ -590,7 +590,7 @@ describe('Sign', () => {
       const address =
         'BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4';
       const o = {
-        from: address,
+        sender: address,
         fee: 10,
         firstValid: 322575,
         lastValid: 323575,
@@ -614,7 +614,7 @@ describe('Sign', () => {
       const address =
         'BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4';
       const o = {
-        from: address,
+        sender: address,
         fee: 10,
         firstValid: 0,
         lastValid: 1000,
@@ -636,8 +636,8 @@ describe('Sign', () => {
 
     it('reserializes correctly no genesis ID', () => {
       const o = {
-        from: 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU',
-        to: 'UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM',
+        sender: 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU',
+        receiver: 'UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM',
         fee: 10,
         amount: 847,
         firstValid: 51,
@@ -656,8 +656,8 @@ describe('Sign', () => {
 
     it('reserializes correctly zero amount', () => {
       const o = {
-        from: 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU',
-        to: 'UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM',
+        sender: 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU',
+        receiver: 'UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM',
         fee: 10,
         amount: 0,
         firstValid: 51,
@@ -676,8 +676,8 @@ describe('Sign', () => {
 
     it('should correctly serialize and deserialize group object', () => {
       const o = {
-        from: 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU',
-        to: 'UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM',
+        sender: 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU',
+        receiver: 'UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM',
         fee: 10,
         amount: 0,
         firstValid: 51,
@@ -712,8 +712,10 @@ describe('Sign', () => {
 
   describe('transaction making functions', () => {
     it('should be able to use helper to make a payment transaction', () => {
-      const from = 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU';
-      const to = 'UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM';
+      const sender =
+        'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU';
+      const receiver =
+        'UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM';
       const fee = 10;
       const amount = 847;
       const firstValid = 51;
@@ -725,8 +727,8 @@ describe('Sign', () => {
         'GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM';
       let closeRemainderTo;
       const o = {
-        from,
-        to,
+        sender,
+        receiver,
         fee,
         amount,
         closeRemainderTo,
@@ -746,8 +748,8 @@ describe('Sign', () => {
         fee,
       };
       const actualTxn = algosdk.makePaymentTxnWithSuggestedParams(
-        from,
-        to,
+        sender,
+        receiver,
         amount,
         closeRemainderTo,
         note,
@@ -758,8 +760,10 @@ describe('Sign', () => {
     });
 
     it('should be able to use helper to make a payment transaction with BigInt amount', () => {
-      const from = 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU';
-      const to = 'UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM';
+      const sender =
+        'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU';
+      const receiver =
+        'UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM';
       const fee = 10;
       const amount = 0xffffffffffffffffn;
       const firstValid = 51;
@@ -771,8 +775,8 @@ describe('Sign', () => {
         'GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM';
       let closeRemainderTo;
       const o = {
-        from,
-        to,
+        sender,
+        receiver,
         fee,
         amount,
         closeRemainderTo,
@@ -792,8 +796,8 @@ describe('Sign', () => {
         fee,
       };
       const actualTxn = algosdk.makePaymentTxnWithSuggestedParams(
-        from,
-        to,
+        sender,
+        receiver,
         amount,
         closeRemainderTo,
         note,
@@ -804,8 +808,10 @@ describe('Sign', () => {
     });
 
     it('should throw if payment amount is too large', () => {
-      const from = 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU';
-      const to = 'UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM';
+      const sender =
+        'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU';
+      const receiver =
+        'UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM';
       const fee = 10;
       const amount = 0x10000000000000000n;
       const firstValid = 51;
@@ -817,8 +823,8 @@ describe('Sign', () => {
         'GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM';
       let closeRemainderTo;
       const o = {
-        from,
-        to,
+        sender,
+        receiver,
         fee,
         amount,
         closeRemainderTo,
@@ -838,7 +844,8 @@ describe('Sign', () => {
     });
 
     it('should be able to use helper to make a keyreg transaction', () => {
-      const from = 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU';
+      const sender =
+        'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU';
       const fee = 10;
       const firstValid = 51;
       const lastValid = 61;
@@ -853,7 +860,7 @@ describe('Sign', () => {
       const voteFirst = 123;
       const voteLast = 456;
       const o = {
-        from,
+        sender,
         fee,
         firstValid,
         lastValid,
@@ -877,7 +884,7 @@ describe('Sign', () => {
         fee,
       };
       const actualTxn = algosdk.makeKeyRegistrationTxnWithSuggestedParams(
-        from,
+        sender,
         note,
         voteKey,
         selectionKey,
@@ -891,7 +898,8 @@ describe('Sign', () => {
     });
 
     it('should be able to use helper to make an offline keyreg transaction', () => {
-      const from = 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU';
+      const sender =
+        'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU';
       const fee = 10;
       const firstValid = 51;
       const lastValid = 61;
@@ -906,7 +914,7 @@ describe('Sign', () => {
       const voteFirst = undefined;
       const voteLast = undefined;
       const o = {
-        from,
+        sender,
         fee,
         firstValid,
         lastValid,
@@ -944,7 +952,7 @@ describe('Sign', () => {
         fee,
       };
       const actualTxn = algosdk.makeKeyRegistrationTxnWithSuggestedParams(
-        from,
+        sender,
         note,
         voteKey,
         selectionKey,
@@ -958,7 +966,8 @@ describe('Sign', () => {
     });
 
     it('should be able to use helper to make a nonparticipating keyreg transaction', () => {
-      const from = 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU';
+      const sender =
+        'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU';
       const fee = 10;
       const firstValid = 51;
       const lastValid = 61;
@@ -974,7 +983,7 @@ describe('Sign', () => {
       const voteLast = 456;
       const nonParticipation = true;
       const o = {
-        from,
+        sender,
         fee,
         firstValid,
         lastValid,
@@ -1010,7 +1019,7 @@ describe('Sign', () => {
         fee,
       };
       const actualTxn = algosdk.makeKeyRegistrationTxnWithSuggestedParams(
-        from,
+        sender,
         note,
         undefined,
         undefined,
@@ -1047,7 +1056,7 @@ describe('Sign', () => {
       const rekeyTo =
         'GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM';
       const o = {
-        from: addr,
+        sender: addr,
         fee,
         firstValid,
         lastValid,
@@ -1119,7 +1128,7 @@ describe('Sign', () => {
       const rekeyTo =
         'GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM';
       const o = {
-        from: addr,
+        sender: addr,
         fee,
         firstValid,
         lastValid,
@@ -1191,7 +1200,7 @@ describe('Sign', () => {
       const rekeyTo =
         'GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM';
       const o = {
-        from: addr,
+        sender: addr,
         fee,
         firstValid,
         lastValid,
@@ -1240,7 +1249,7 @@ describe('Sign', () => {
       const rekeyTo =
         'GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM';
       const txnTemplate = {
-        from: addr,
+        sender: addr,
         fee,
         firstValid,
         lastValid,
@@ -1334,7 +1343,7 @@ describe('Sign', () => {
       const rekeyTo =
         'GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM';
       const o = {
-        from: addr,
+        sender: addr,
         fee,
         firstValid,
         lastValid,
@@ -1422,7 +1431,7 @@ describe('Sign', () => {
       const rekeyTo =
         'GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM';
       const o = {
-        from: addr,
+        sender: addr,
         fee,
         firstValid,
         lastValid,
@@ -1469,8 +1478,8 @@ describe('Sign', () => {
         'GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM';
       const o = {
         type: 'axfer',
-        from: sender,
-        to: recipient,
+        sender,
+        receiver: recipient,
         amount,
         fee,
         firstValid,
@@ -1520,7 +1529,7 @@ describe('Sign', () => {
       const rekeyTo =
         'GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM';
       const o = {
-        from: addr,
+        sender: addr,
         fee,
         firstValid,
         lastValid,
@@ -1573,8 +1582,8 @@ describe('Sign', () => {
       );
 
       const dictTx = {
-        from: 'GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM',
-        to: 'GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM',
+        sender: 'GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM',
+        receiver: 'GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM',
         fee: 1000,
         flatFee: true,
         amount: 0,

--- a/tests/5.Transaction.js
+++ b/tests/5.Transaction.js
@@ -537,7 +537,7 @@ describe('Sign', () => {
         lastValid: 323575,
         genesisHash: 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=',
         assetIndex: 1234,
-        assetRevocationTarget: address,
+        assetSender: address,
         closeRemainderTo: address,
       };
       const expectedTxn = new algosdk.Transaction(o);
@@ -1465,7 +1465,7 @@ describe('Sign', () => {
       const fee = 10;
       const sender = addr;
       const recipient = addr;
-      const revocationTarget = addr;
+      const assetSender = addr;
       const closeRemainderTo = addr;
       const assetIndex = 1234;
       const amount = 100;
@@ -1488,7 +1488,7 @@ describe('Sign', () => {
         genesisID,
         assetIndex,
         note,
-        assetRevocationTarget: revocationTarget,
+        assetSender,
         closeRemainderTo,
         reKeyTo: rekeyTo,
       };
@@ -1505,7 +1505,7 @@ describe('Sign', () => {
         sender,
         recipient,
         closeRemainderTo,
-        revocationTarget,
+        assetSender,
         amount,
         note,
         assetIndex,

--- a/tests/5.Transaction.js
+++ b/tests/5.Transaction.js
@@ -737,7 +737,7 @@ describe('Sign', () => {
         note,
         genesisHash,
         genesisID,
-        reKeyTo: rekeyTo,
+        rekeyTo,
       };
       const expectedTxn = new algosdk.Transaction(o);
       const suggestedParams = {
@@ -785,7 +785,7 @@ describe('Sign', () => {
         note,
         genesisHash,
         genesisID,
-        reKeyTo: rekeyTo,
+        rekeyTo,
       };
       const expectedTxn = new algosdk.Transaction(o);
       const suggestedParams = {
@@ -833,7 +833,7 @@ describe('Sign', () => {
         note,
         genesisHash,
         genesisID,
-        reKeyTo: rekeyTo,
+        rekeyTo,
       };
       assert.throws(
         () => new algosdk.Transaction(o),
@@ -872,7 +872,7 @@ describe('Sign', () => {
         voteLast,
         voteKeyDilution,
         genesisID,
-        reKeyTo: rekeyTo,
+        rekeyTo,
         type: 'keyreg',
       };
       const expectedTxn = new algosdk.Transaction(o);
@@ -926,7 +926,7 @@ describe('Sign', () => {
         voteLast,
         voteKeyDilution,
         genesisID,
-        reKeyTo: rekeyTo,
+        rekeyTo,
         type: 'keyreg',
         nonParticipation: false,
       };
@@ -991,7 +991,7 @@ describe('Sign', () => {
         genesisHash,
         nonParticipation,
         genesisID,
-        reKeyTo: rekeyTo,
+        rekeyTo,
         type: 'keyreg',
       };
 
@@ -1074,7 +1074,7 @@ describe('Sign', () => {
         assetFreeze: freeze,
         assetClawback: clawback,
         genesisID,
-        reKeyTo: rekeyTo,
+        rekeyTo,
         type: 'acfg',
       };
       const expectedTxn = new algosdk.Transaction(o);
@@ -1146,7 +1146,7 @@ describe('Sign', () => {
         assetFreeze: freeze,
         assetClawback: clawback,
         genesisID,
-        reKeyTo: rekeyTo,
+        rekeyTo,
         type: 'acfg',
       };
       const expectedTxn = new algosdk.Transaction(o);
@@ -1218,7 +1218,7 @@ describe('Sign', () => {
         assetFreeze: freeze,
         assetClawback: clawback,
         genesisID,
-        reKeyTo: rekeyTo,
+        rekeyTo,
         type: 'acfg',
       };
       assert.throws(
@@ -1266,7 +1266,7 @@ describe('Sign', () => {
         assetFreeze: freeze,
         assetClawback: clawback,
         genesisID,
-        reKeyTo: rekeyTo,
+        rekeyTo,
         type: 'acfg',
       };
       assert.doesNotThrow(() => {
@@ -1356,7 +1356,7 @@ describe('Sign', () => {
         assetClawback: clawback,
         type: 'acfg',
         note,
-        reKeyTo: rekeyTo,
+        rekeyTo,
       };
       const expectedTxn = new algosdk.Transaction(o);
       const suggestedParams = {
@@ -1440,7 +1440,7 @@ describe('Sign', () => {
         assetIndex,
         type: 'acfg',
         note,
-        reKeyTo: rekeyTo,
+        rekeyTo,
       };
       const expectedTxn = new algosdk.Transaction(o);
       const suggestedParams = {
@@ -1490,7 +1490,7 @@ describe('Sign', () => {
         note,
         assetSender,
         closeRemainderTo,
-        reKeyTo: rekeyTo,
+        rekeyTo,
       };
       const expectedTxn = new algosdk.Transaction(o);
       const suggestedParams = {
@@ -1540,7 +1540,7 @@ describe('Sign', () => {
         assetFrozen,
         note,
         genesisID,
-        reKeyTo: rekeyTo,
+        rekeyTo,
       };
       const expectedTxn = new algosdk.Transaction(o);
       const suggestedParams = {

--- a/tests/6.Multisig.ts
+++ b/tests/6.Multisig.ts
@@ -52,8 +52,8 @@ describe('Multisig Functionality', () => {
   describe('signMultisigTransaction', () => {
     it('should match golden main repo result', () => {
       const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-        from: sampleMultisigAddr,
-        to: 'PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI',
+        sender: sampleMultisigAddr,
+        receiver: 'PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI',
         amount: 1000,
         note: algosdk.base64ToBytes('RSYiABhShvs='),
         closeRemainderTo:
@@ -86,8 +86,8 @@ describe('Multisig Functionality', () => {
 
     it('should correctly handle a different sender', () => {
       const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-        from: 'EHGMQCXBIFBE364DEKWQVVNCTCTVCGQL3BR2Q5I7CFTRXWIVTF4SYA3GHU',
-        to: 'PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI',
+        sender: 'EHGMQCXBIFBE364DEKWQVVNCTCTVCGQL3BR2Q5I7CFTRXWIVTF4SYA3GHU',
+        receiver: 'PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI',
         amount: 1000,
         note: algosdk.base64ToBytes('RSYiABhShvs='),
         closeRemainderTo:

--- a/tests/6.Multisig.ts
+++ b/tests/6.Multisig.ts
@@ -61,8 +61,8 @@ describe('Multisig Functionality', () => {
         suggestedParams: {
           fee: 1000,
           flatFee: true,
-          firstRound: 62229,
-          lastRound: 63229,
+          firstValid: 62229,
+          lastValid: 63229,
           genesisID: 'devnet-v38.0',
           genesisHash: '/rNsORAUOQDD2lVCyhg2sA/S+BlZElfNI/YEL5jINp0=',
         },
@@ -95,8 +95,8 @@ describe('Multisig Functionality', () => {
         suggestedParams: {
           fee: 1000,
           flatFee: true,
-          firstRound: 62229,
-          lastRound: 63229,
+          firstValid: 62229,
+          lastValid: 63229,
           genesisID: 'devnet-v38.0',
           genesisHash: '/rNsORAUOQDD2lVCyhg2sA/S+BlZElfNI/YEL5jINp0=',
         },

--- a/tests/7.AlgoSDK.js
+++ b/tests/7.AlgoSDK.js
@@ -776,7 +776,7 @@ describe('Algosdk (AKA end to end)', () => {
         type: 'axfer',
         sender: addr,
         receiver: addr,
-        assetRevocationTarget: addr,
+        assetSender: addr,
         amount: 1,
         fee: 10,
         firstValid: 322575,

--- a/tests/7.AlgoSDK.js
+++ b/tests/7.AlgoSDK.js
@@ -705,7 +705,7 @@ describe('Algosdk (AKA end to end)', () => {
         type: 'afrz',
         freezeAccount: addr,
         assetIndex: 1,
-        freezeState: true,
+        assetFrozen: true,
       };
 
       const mnem =

--- a/tests/7.AlgoSDK.js
+++ b/tests/7.AlgoSDK.js
@@ -32,8 +32,8 @@ describe('Algosdk (AKA end to end)', () => {
       const to = 'PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI';
       const fee = 4;
       const amount = 1000;
-      const firstRound = 12466;
-      const lastRound = 13466;
+      const firstValid = 12466;
+      const lastValid = 13466;
       const genesisID = 'devnet-v33.0';
       const genesisHash = 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=';
       const closeRemainderTo =
@@ -43,8 +43,8 @@ describe('Algosdk (AKA end to end)', () => {
       const suggestedParams = {
         genesisHash,
         genesisID,
-        firstRound,
-        lastRound,
+        firstValid,
+        lastValid,
         fee,
       };
       const txnAsObj = algosdk.makePaymentTxnWithSuggestedParams(
@@ -73,8 +73,8 @@ describe('Algosdk (AKA end to end)', () => {
       const to = 'PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI';
       const fee = 4;
       const amount = 1000;
-      const firstRound = 12466;
-      const lastRound = 13466;
+      const firstValid = 12466;
+      const lastValid = 13466;
       const genesisID = 'devnet-v33.0';
       const genesisHash = 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=';
       const closeRemainderTo =
@@ -84,8 +84,8 @@ describe('Algosdk (AKA end to end)', () => {
       const suggestedParams = {
         genesisHash,
         genesisID,
-        firstRound,
-        lastRound,
+        firstValid,
+        lastValid,
         fee,
       };
       const txnAsObj = algosdk.makePaymentTxnWithSuggestedParams(
@@ -126,8 +126,8 @@ describe('Algosdk (AKA end to end)', () => {
         to: 'PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI',
         fee: 4,
         amount: 1000,
-        firstRound: 12466,
-        lastRound: 13466,
+        firstValid: 12466,
+        lastValid: 13466,
         genesisID: 'devnet-v33.0',
         genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
         closeRemainderTo:
@@ -154,8 +154,8 @@ describe('Algosdk (AKA end to end)', () => {
         to: 'PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI',
         fee: 1176,
         amount: 1000,
-        firstRound: 12466,
-        lastRound: 13466,
+        firstValid: 12466,
+        lastValid: 13466,
         genesisID: 'devnet-v33.0',
         genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
         closeRemainderTo:
@@ -185,8 +185,8 @@ describe('Algosdk (AKA end to end)', () => {
         to: 'PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI',
         fee: 4,
         amount: 1000,
-        firstRound: 12466,
-        lastRound: 13466,
+        firstValid: 12466,
+        lastValid: 13466,
         genesisID: 'devnet-v33.0',
         genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
         closeRemainderTo:
@@ -215,8 +215,8 @@ describe('Algosdk (AKA end to end)', () => {
       const to = 'PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI';
       const fee = 4;
       const amount = 1000;
-      const firstRound = 12466;
-      const lastRound = 13466;
+      const firstValid = 12466;
+      const lastValid = 13466;
       const genesisID = 'devnet-v33.0';
       const genesisHash = 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=';
       const closeRemainderTo =
@@ -228,8 +228,8 @@ describe('Algosdk (AKA end to end)', () => {
       const suggestedParams = {
         genesisHash,
         genesisID,
-        firstRound,
-        lastRound,
+        firstValid,
+        lastValid,
         fee,
       };
       const txn = algosdk.makePaymentTxnWithSuggestedParams(
@@ -277,8 +277,8 @@ describe('Algosdk (AKA end to end)', () => {
         to: signer.addr,
         amount: 1000,
         suggestedParams: {
-          firstRound: 12466,
-          lastRound: 13466,
+          firstValid: 12466,
+          lastValid: 13466,
           genesisID: 'devnet-v33.0',
           genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
           fee: 4,
@@ -312,8 +312,8 @@ describe('Algosdk (AKA end to end)', () => {
         to: signer.addr,
         amount: 1000,
         suggestedParams: {
-          firstRound: 12466,
-          lastRound: 13466,
+          firstValid: 12466,
+          lastValid: 13466,
           genesisID: 'devnet-v33.0',
           genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
           fee: 4,
@@ -353,8 +353,8 @@ describe('Algosdk (AKA end to end)', () => {
         to: 'PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI',
         fee: 4,
         amount: 1000,
-        firstRound: 12466,
-        lastRound: 13466,
+        firstValid: 12466,
+        lastValid: 13466,
         genesisID: 'devnet-v33.0',
         genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
         closeRemainderTo:
@@ -395,8 +395,8 @@ describe('Algosdk (AKA end to end)', () => {
         'RWJLJCMQAFZ2ATP2INM2GZTKNL6OULCCUBO5TQPXH3V2KR4AG7U5UA5JNM';
       const fee = 4;
       const amount = 1000;
-      const firstRound = 12466;
-      const lastRound = 13466;
+      const firstValid = 12466;
+      const lastValid = 13466;
       const genesisID = 'devnet-v33.0';
       const genesisHash = 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=';
       const closeRemainder =
@@ -407,8 +407,8 @@ describe('Algosdk (AKA end to end)', () => {
         from: fromAddr,
         fee,
         amount,
-        firstRound,
-        lastRound,
+        firstValid,
+        lastValid,
         genesisID,
         genesisHash,
         closeRemainderTo: closeRemainder,
@@ -417,8 +417,8 @@ describe('Algosdk (AKA end to end)', () => {
       const suggestedParams = {
         genesisHash,
         genesisID,
-        firstRound,
-        lastRound,
+        firstValid,
+        lastValid,
         fee,
       };
       const oObj = algosdk.makePaymentTxnWithSuggestedParams(
@@ -497,22 +497,22 @@ describe('Algosdk (AKA end to end)', () => {
       const amount = 2000;
       const genesisID = 'devnet-v1.0';
       const genesisHash = 'sC3P7e2SdbqKJK0tbiCdK9tdSpbe6XeCGKdoNzmlj0E';
-      const firstRound1 = 710399;
+      const firstValid1 = 710399;
       const note1 = algosdk.base64ToBytes('wRKw5cJ0CMo=');
       const o1 = {
         to: toAddress,
         from: fromAddress,
         fee,
         amount,
-        firstRound: firstRound1,
-        lastRound: firstRound1 + 1000,
+        firstValid: firstValid1,
+        lastValid: firstValid1 + 1000,
         genesisID,
         genesisHash,
         note: note1,
         flatFee: true,
       };
 
-      const firstRound2 = 710515;
+      const firstValid2 = 710515;
       const note2 = algosdk.base64ToBytes('dBlHI6BdrIg=');
 
       const o2 = {
@@ -520,8 +520,8 @@ describe('Algosdk (AKA end to end)', () => {
         from: fromAddress,
         fee,
         amount,
-        firstRound: firstRound2,
-        lastRound: firstRound2 + 1000,
+        firstValid: firstValid2,
+        lastValid: firstValid2 + 1000,
         genesisID,
         genesisHash,
         note: note2,
@@ -598,8 +598,8 @@ describe('Algosdk (AKA end to end)', () => {
       const createTxn = {
         from: address,
         fee: 10,
-        firstRound: 322575,
-        lastRound: 323575,
+        firstValid: 322575,
+        lastValid: 323575,
         genesisHash: 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=',
         assetTotal: 100,
         assetDefaultFrozen: false,
@@ -628,8 +628,8 @@ describe('Algosdk (AKA end to end)', () => {
       const createTxn = {
         from: address,
         fee: 10,
-        firstRound: 322575,
-        lastRound: 323575,
+        firstValid: 322575,
+        lastValid: 323575,
         genesisHash: 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=',
         assetTotal: 100,
         assetDecimals: 1,
@@ -659,8 +659,8 @@ describe('Algosdk (AKA end to end)', () => {
       const o = {
         from: address,
         fee: 10,
-        firstRound: 322575,
-        lastRound: 323575,
+        firstValid: 322575,
+        lastValid: 323575,
         genesisHash: 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=',
         assetIndex: 1234,
         assetManager: address,
@@ -684,8 +684,8 @@ describe('Algosdk (AKA end to end)', () => {
       const o = {
         from: address,
         fee: 10,
-        firstRound: 322575,
-        lastRound: 323575,
+        firstValid: 322575,
+        lastValid: 323575,
         genesisHash: 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=',
         assetIndex: 1,
         type: 'acfg',
@@ -699,8 +699,8 @@ describe('Algosdk (AKA end to end)', () => {
       const o = {
         from: addr,
         fee: 10,
-        firstRound: 322575,
-        lastRound: 323576,
+        firstValid: 322575,
+        lastValid: 323576,
         genesisHash: 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=',
         type: 'afrz',
         freezeAccount: addr,
@@ -726,8 +726,8 @@ describe('Algosdk (AKA end to end)', () => {
         to: addr,
         amount: 1,
         fee: 10,
-        firstRound: 322575,
-        lastRound: 323576,
+        firstValid: 322575,
+        lastValid: 323576,
         genesisHash: 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=',
         assetIndex: 1,
         closeRemainderTo: addr,
@@ -751,8 +751,8 @@ describe('Algosdk (AKA end to end)', () => {
         to: addr,
         amount: 0,
         fee: 10,
-        firstRound: 322575,
-        lastRound: 323575,
+        firstValid: 322575,
+        lastValid: 323575,
         genesisHash: 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=',
         assetIndex: 1,
       };
@@ -776,8 +776,8 @@ describe('Algosdk (AKA end to end)', () => {
         assetRevocationTarget: addr,
         amount: 1,
         fee: 10,
-        firstRound: 322575,
-        lastRound: 323575,
+        firstValid: 322575,
+        lastValid: 323575,
         genesisHash: 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=',
         assetIndex: 1,
       };
@@ -886,7 +886,7 @@ describe('Algosdk (AKA end to end)', () => {
         'advice pudding treat near rule blouse same whisper inner electric quit surface sunny dismiss leader blood seat clown cost exist hospital century reform able sponsor';
       const fee = 1000;
       const amount = 2000;
-      const firstRound = 2063137;
+      const firstValid = 2063137;
       const genesisID = 'devnet-v1.0';
       const genesisHash = 'sC3P7e2SdbqKJK0tbiCdK9tdSpbe6XeCGKdoNzmlj0E=';
       const note = algosdk.base64ToBytes('8xMCTuLQ810=');
@@ -896,8 +896,8 @@ describe('Algosdk (AKA end to end)', () => {
         from: fromAddress,
         fee,
         amount,
-        firstRound,
-        lastRound: firstRound + 1000,
+        firstValid,
+        lastValid: firstValid + 1000,
         genesisID,
         genesisHash,
         note,

--- a/tests/7.AlgoSDK.js
+++ b/tests/7.AlgoSDK.js
@@ -29,7 +29,8 @@ describe('Algosdk (AKA end to end)', () => {
     });
 
     it('should not mutate unsigned transaction when going to or from encoded buffer', () => {
-      const to = 'PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI';
+      const receiver =
+        'PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI';
       const fee = 4;
       const amount = 1000;
       const firstValid = 12466;
@@ -39,7 +40,7 @@ describe('Algosdk (AKA end to end)', () => {
       const closeRemainderTo =
         'IDUTJEUIEVSMXTU4LGTJWZ2UE2E6TIODUKU6UW3FU3UKIQQ77RLUBBBFLA';
       const note = new Uint8Array(algosdk.base64ToBytes('6gAVR0Nsv5Y='));
-      const from = to;
+      const sender = receiver;
       const suggestedParams = {
         genesisHash,
         genesisID,
@@ -48,8 +49,8 @@ describe('Algosdk (AKA end to end)', () => {
         fee,
       };
       const txnAsObj = algosdk.makePaymentTxnWithSuggestedParams(
-        from,
-        to,
+        sender,
+        receiver,
         amount,
         closeRemainderTo,
         note,
@@ -70,7 +71,8 @@ describe('Algosdk (AKA end to end)', () => {
     });
 
     it('should not mutate signed transaction when going to or from encoded buffer', () => {
-      const to = 'PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI';
+      const receiver =
+        'PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI';
       const fee = 4;
       const amount = 1000;
       const firstValid = 12466;
@@ -80,7 +82,7 @@ describe('Algosdk (AKA end to end)', () => {
       const closeRemainderTo =
         'IDUTJEUIEVSMXTU4LGTJWZ2UE2E6TIODUKU6UW3FU3UKIQQ77RLUBBBFLA';
       const note = new Uint8Array(algosdk.base64ToBytes('6gAVR0Nsv5Y='));
-      const from = to;
+      const sender = receiver;
       const suggestedParams = {
         genesisHash,
         genesisID,
@@ -89,8 +91,8 @@ describe('Algosdk (AKA end to end)', () => {
         fee,
       };
       const txnAsObj = algosdk.makePaymentTxnWithSuggestedParams(
-        from,
-        to,
+        sender,
+        receiver,
         amount,
         closeRemainderTo,
         note,
@@ -123,7 +125,7 @@ describe('Algosdk (AKA end to end)', () => {
       const golden =
         'gqNzaWfEQPhUAZ3xkDDcc8FvOVo6UinzmKBCqs0woYSfodlmBMfQvGbeUx3Srxy3dyJDzv7rLm26BRv9FnL2/AuT7NYfiAWjdHhui6NhbXTNA+ilY2xvc2XEIEDpNJKIJWTLzpxZpptnVCaJ6aHDoqnqW2Wm6KRCH/xXo2ZlZc0EmKJmds0wsqNnZW6sZGV2bmV0LXYzMy4womdoxCAmCyAJoJOohot5WHIvpeVG7eftF+TYXEx4r7BFJpDt0qJsds00mqRub3RlxAjqABVHQ2y/lqNyY3bEIHts4k/rW6zAsWTinCIsV/X2PcOH1DkEglhBHF/hD3wCo3NuZMQg5/D4TQaBHfnzHI2HixFV9GcdUaGFwgCQhmf0SVhwaKGkdHlwZaNwYXk=';
       const o = {
-        to: 'PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI',
+        receiver: 'PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI',
         fee: 4,
         amount: 1000,
         firstValid: 12466,
@@ -151,7 +153,7 @@ describe('Algosdk (AKA end to end)', () => {
       const golden =
         'gqNzaWfEQPhUAZ3xkDDcc8FvOVo6UinzmKBCqs0woYSfodlmBMfQvGbeUx3Srxy3dyJDzv7rLm26BRv9FnL2/AuT7NYfiAWjdHhui6NhbXTNA+ilY2xvc2XEIEDpNJKIJWTLzpxZpptnVCaJ6aHDoqnqW2Wm6KRCH/xXo2ZlZc0EmKJmds0wsqNnZW6sZGV2bmV0LXYzMy4womdoxCAmCyAJoJOohot5WHIvpeVG7eftF+TYXEx4r7BFJpDt0qJsds00mqRub3RlxAjqABVHQ2y/lqNyY3bEIHts4k/rW6zAsWTinCIsV/X2PcOH1DkEglhBHF/hD3wCo3NuZMQg5/D4TQaBHfnzHI2HixFV9GcdUaGFwgCQhmf0SVhwaKGkdHlwZaNwYXk=';
       const o = {
-        to: 'PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI',
+        receiver: 'PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI',
         fee: 1176,
         amount: 1000,
         firstValid: 12466,
@@ -182,7 +184,7 @@ describe('Algosdk (AKA end to end)', () => {
       // prettier-ignore
       const lease = new Uint8Array([1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4]);
       const o = {
-        to: 'PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI',
+        receiver: 'PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI',
         fee: 4,
         amount: 1000,
         firstValid: 12466,
@@ -212,7 +214,8 @@ describe('Algosdk (AKA end to end)', () => {
         'gqNzaWfEQOMmFSIKsZvpW0txwzhmbgQjxv6IyN7BbV5sZ2aNgFbVcrWUnqPpQQxfPhV/wdu9jzEPUU1jAujYtcNCxJ7ONgejdHhujKNhbXTNA+ilY2xvc2XEIEDpNJKIJWTLzpxZpptnVCaJ6aHDoqnqW2Wm6KRCH/xXo2ZlZc0FLKJmds0wsqNnZW6sZGV2bmV0LXYzMy4womdoxCAmCyAJoJOohot5WHIvpeVG7eftF+TYXEx4r7BFJpDt0qJsds00mqJseMQgAQIDBAECAwQBAgMEAQIDBAECAwQBAgMEAQIDBAECAwSkbm90ZcQI6gAVR0Nsv5ajcmN2xCB7bOJP61uswLFk4pwiLFf19j3Dh9Q5BIJYQRxf4Q98AqNzbmTEIOfw+E0GgR358xyNh4sRVfRnHVGhhcIAkIZn9ElYcGihpHR5cGWjcGF5';
       // prettier-ignore
       const lease = new Uint8Array([1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4]);
-      const to = 'PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI';
+      const receiver =
+        'PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI';
       const fee = 4;
       const amount = 1000;
       const firstValid = 12466;
@@ -224,7 +227,7 @@ describe('Algosdk (AKA end to end)', () => {
       const note = new Uint8Array(algosdk.base64ToBytes('6gAVR0Nsv5Y='));
       sk = algosdk.mnemonicToSecretKey(sk);
       const key = nacl.keyPairFromSecretKey(sk.sk);
-      const from = algosdk.encodeAddress(key.publicKey);
+      const sender = algosdk.encodeAddress(key.publicKey);
       const suggestedParams = {
         genesisHash,
         genesisID,
@@ -233,8 +236,8 @@ describe('Algosdk (AKA end to end)', () => {
         fee,
       };
       const txn = algosdk.makePaymentTxnWithSuggestedParams(
-        from,
-        to,
+        sender,
+        receiver,
         amount,
         closeRemainderTo,
         note,
@@ -273,8 +276,8 @@ describe('Algosdk (AKA end to end)', () => {
 
       // Create a transaction
       const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-        from: sender.addr,
-        to: signer.addr,
+        sender: sender.addr,
+        receiver: signer.addr,
         amount: 1000,
         suggestedParams: {
           firstValid: 12466,
@@ -308,8 +311,8 @@ describe('Algosdk (AKA end to end)', () => {
 
       // Create a transaction
       const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-        from: sender.addr,
-        to: signer.addr,
+        sender: sender.addr,
+        receiver: signer.addr,
         amount: 1000,
         suggestedParams: {
           firstValid: 12466,
@@ -350,7 +353,7 @@ describe('Algosdk (AKA end to end)', () => {
       const { sk } = algosdk.mnemonicToSecretKey(mnem3);
 
       const o = {
-        to: 'PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI',
+        receiver: 'PNWOET7LLOWMBMLE4KOCELCX6X3D3Q4H2Q4QJASYIEOF7YIPPQBG3YQ5YI',
         fee: 4,
         amount: 1000,
         firstValid: 12466,
@@ -403,8 +406,8 @@ describe('Algosdk (AKA end to end)', () => {
         'IDUTJEUIEVSMXTU4LGTJWZ2UE2E6TIODUKU6UW3FU3UKIQQ77RLUBBBFLA';
       const note = algosdk.base64ToBytes('X4Bl4wQ9rCo=');
       const oDict = {
-        to: toAddr,
-        from: fromAddr,
+        receiver: toAddr,
+        sender: fromAddr,
         fee,
         amount,
         firstValid,
@@ -500,8 +503,8 @@ describe('Algosdk (AKA end to end)', () => {
       const firstValid1 = 710399;
       const note1 = algosdk.base64ToBytes('wRKw5cJ0CMo=');
       const o1 = {
-        to: toAddress,
-        from: fromAddress,
+        receiver: toAddress,
+        sender: fromAddress,
         fee,
         amount,
         firstValid: firstValid1,
@@ -516,8 +519,8 @@ describe('Algosdk (AKA end to end)', () => {
       const note2 = algosdk.base64ToBytes('dBlHI6BdrIg=');
 
       const o2 = {
-        to: toAddress,
-        from: fromAddress,
+        receiver: toAddress,
+        sender: fromAddress,
         fee,
         amount,
         firstValid: firstValid2,
@@ -596,7 +599,7 @@ describe('Algosdk (AKA end to end)', () => {
       let sk =
         'awful drop leaf tennis indoor begin mandate discover uncle seven only coil atom any hospital uncover make any climb actor armed measure need above hundred';
       const createTxn = {
-        from: address,
+        sender: address,
         fee: 10,
         firstValid: 322575,
         lastValid: 323575,
@@ -626,7 +629,7 @@ describe('Algosdk (AKA end to end)', () => {
       let sk =
         'awful drop leaf tennis indoor begin mandate discover uncle seven only coil atom any hospital uncover make any climb actor armed measure need above hundred';
       const createTxn = {
-        from: address,
+        sender: address,
         fee: 10,
         firstValid: 322575,
         lastValid: 323575,
@@ -657,7 +660,7 @@ describe('Algosdk (AKA end to end)', () => {
       let sk =
         'awful drop leaf tennis indoor begin mandate discover uncle seven only coil atom any hospital uncover make any climb actor armed measure need above hundred';
       const o = {
-        from: address,
+        sender: address,
         fee: 10,
         firstValid: 322575,
         lastValid: 323575,
@@ -682,7 +685,7 @@ describe('Algosdk (AKA end to end)', () => {
       let sk =
         'awful drop leaf tennis indoor begin mandate discover uncle seven only coil atom any hospital uncover make any climb actor armed measure need above hundred';
       const o = {
-        from: address,
+        sender: address,
         fee: 10,
         firstValid: 322575,
         lastValid: 323575,
@@ -697,7 +700,7 @@ describe('Algosdk (AKA end to end)', () => {
     it('should return a blob that matches the go code for asset freeze', () => {
       const addr = 'BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4';
       const o = {
-        from: addr,
+        sender: addr,
         fee: 10,
         firstValid: 322575,
         lastValid: 323576,
@@ -722,8 +725,8 @@ describe('Algosdk (AKA end to end)', () => {
 
       const o = {
         type: 'axfer',
-        from: addr,
-        to: addr,
+        sender: addr,
+        receiver: addr,
         amount: 1,
         fee: 10,
         firstValid: 322575,
@@ -747,8 +750,8 @@ describe('Algosdk (AKA end to end)', () => {
 
       const o = {
         type: 'axfer',
-        from: addr,
-        to: addr,
+        sender: addr,
+        receiver: addr,
         amount: 0,
         fee: 10,
         firstValid: 322575,
@@ -771,8 +774,8 @@ describe('Algosdk (AKA end to end)', () => {
 
       const o = {
         type: 'axfer',
-        from: addr,
-        to: addr,
+        sender: addr,
+        receiver: addr,
         assetRevocationTarget: addr,
         amount: 1,
         fee: 10,
@@ -892,8 +895,8 @@ describe('Algosdk (AKA end to end)', () => {
       const note = algosdk.base64ToBytes('8xMCTuLQ810=');
 
       const txn = {
-        to: toAddress,
-        from: fromAddress,
+        receiver: toAddress,
+        sender: fromAddress,
         fee,
         amount,
         firstValid,

--- a/tests/8.LogicSig.ts
+++ b/tests/8.LogicSig.ts
@@ -421,8 +421,8 @@ describe('signLogicSigTransaction', () => {
     expected: { txID: string; blob: Uint8Array }
   ) {
     const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-      from: sender,
-      to: otherAddr,
+      sender,
+      receiver: otherAddr,
       amount: 5000,
       suggestedParams: {
         flatFee: true,
@@ -493,8 +493,8 @@ describe('signLogicSigTransaction', () => {
 
       it('should throw an error when sender is not LogicSig address', () => {
         const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-          from: otherAddr,
-          to: otherAddr,
+          sender: otherAddr,
+          receiver: otherAddr,
           amount: 5000,
           suggestedParams: {
             flatFee: true,
@@ -650,8 +650,9 @@ describe('signLogicSigTransaction', () => {
   it('should sign a raw transaction object', () => {
     const lsig = new algosdk.LogicSig(program);
 
-    const from = lsig.address();
-    const to = 'UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM';
+    const sender = lsig.address();
+    const receiver =
+      'UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM';
     const fee = 10;
     const amount = 847;
     const firstValid = 51;
@@ -663,8 +664,8 @@ describe('signLogicSigTransaction', () => {
       'GAQVB24XEPYOPBQNJQAE4K3OLNYTRYD65ZKR3OEW5TDOOGL7MDKABXHHTM';
     let closeRemainderTo;
     const txn = {
-      from,
-      to,
+      sender,
+      receiver,
       fee,
       amount,
       closeRemainderTo,

--- a/tests/8.LogicSig.ts
+++ b/tests/8.LogicSig.ts
@@ -674,7 +674,7 @@ describe('signLogicSigTransaction', () => {
       note,
       genesisHash,
       genesisID,
-      reKeyTo: rekeyTo,
+      rekeyTo,
     };
 
     const actual = algosdk.signLogicSigTransaction(txn, lsig);

--- a/tests/8.LogicSig.ts
+++ b/tests/8.LogicSig.ts
@@ -427,8 +427,8 @@ describe('signLogicSigTransaction', () => {
       suggestedParams: {
         flatFee: true,
         fee: 217000,
-        firstRound: 972508,
-        lastRound: 973508,
+        firstValid: 972508,
+        lastValid: 973508,
         genesisID: 'testnet-v31.0',
         genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
       },
@@ -499,8 +499,8 @@ describe('signLogicSigTransaction', () => {
           suggestedParams: {
             flatFee: true,
             fee: 217000,
-            firstRound: 972508,
-            lastRound: 973508,
+            firstValid: 972508,
+            lastValid: 973508,
             genesisID: 'testnet-v31.0',
             genesisHash: 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=',
           },
@@ -654,8 +654,8 @@ describe('signLogicSigTransaction', () => {
     const to = 'UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM';
     const fee = 10;
     const amount = 847;
-    const firstRound = 51;
-    const lastRound = 61;
+    const firstValid = 51;
+    const lastValid = 61;
     const note = new Uint8Array([123, 12, 200]);
     const genesisHash = 'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI=';
     const genesisID = '';
@@ -668,8 +668,8 @@ describe('signLogicSigTransaction', () => {
       fee,
       amount,
       closeRemainderTo,
-      firstRound,
-      lastRound,
+      firstValid,
+      lastValid,
       note,
       genesisHash,
       genesisID,

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -1441,7 +1441,7 @@ module.exports = function getSteps(options) {
       this.assetTestFixture.lastTxn = {
         sender: this.assetTestFixture.creator,
         receiver: this.assetTestFixture.creator,
-        assetRevocationTarget: this.accounts[1],
+        assetSender: this.accounts[1],
         amount: parseInt(amount),
         fee: this.fee,
         firstValid: this.fv,

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -2724,7 +2724,7 @@ module.exports = function getSteps(options) {
   /// /////////////////////////////////
 
   When('I add a rekeyTo field with address {string}', function (address) {
-    this.txn.reKeyTo = address;
+    this.txn.rekeyTo = address;
   });
 
   When(
@@ -2732,7 +2732,7 @@ module.exports = function getSteps(options) {
     function () {
       const keypair = keyPairFromSecretKey(this.sk);
       const pubKeyFromSk = keypair.publicKey;
-      this.txn.reKeyTo = algosdk.encodeAddress(pubKeyFromSk);
+      this.txn.rekeyTo = algosdk.encodeAddress(pubKeyFromSk);
     }
   );
 

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -388,14 +388,14 @@ module.exports = function getSteps(options) {
       this.rekey = this.rekey.address;
       // Fund the rekey address with some Algos
       const sp = await this.v2Client.getTransactionParams().do();
-      if (sp.firstRound === 0) sp.firstRound = 1;
+      if (sp.firstValid === 0) sp.firstValid = 1;
       const fundingTxnArgs = {
         from: this.accounts[0],
         to: this.rekey,
         amount: DEV_MODE_INITIAL_MICROALGOS,
         fee: sp.fee,
-        firstRound: sp.firstRound,
-        lastRound: sp.lastRound,
+        firstValid: sp.firstValid,
+        lastValid: sp.lastValid,
         genesisHash: sp.genesisHash,
         genesisID: sp.genesisID,
       };
@@ -482,13 +482,13 @@ module.exports = function getSteps(options) {
     async function (amt, note) {
       this.pk = this.rekey;
       const result = await this.v2Client.getTransactionParams().do();
-      this.lastRound = result.lastRound;
+      this.lastValid = result.lastValid;
       this.txn = {
         from: this.rekey,
         to: this.accounts[1],
         fee: result.fee,
-        firstRound: result.firstRound,
-        lastRound: result.lastRound,
+        firstValid: result.firstValid,
+        lastValid: result.lastValid,
         genesisHash: result.genesisHash,
         genesisID: result.genesisID,
         note: makeUint8Array(algosdk.base64ToBytes(note)),
@@ -513,8 +513,8 @@ module.exports = function getSteps(options) {
         from: algosdk.multisigAddress(this.msig),
         to: this.accounts[1],
         fee: result.fee,
-        firstRound: result.firstRound,
-        lastRound: result.lastRound,
+        firstValid: result.firstValid,
+        lastValid: result.lastValid,
         genesisHash: result.genesisHash,
         genesisID: result.genesisID,
         note: makeUint8Array(algosdk.base64ToBytes(note)),
@@ -664,8 +664,8 @@ module.exports = function getSteps(options) {
     this.txn = {
       to: this.to,
       fee: this.fee,
-      firstRound: this.fv,
-      lastRound: this.lv,
+      firstValid: this.fv,
+      lastValid: this.lv,
       genesisHash: this.gh,
       flatFee: true,
     };
@@ -735,8 +735,8 @@ module.exports = function getSteps(options) {
       from: algosdk.multisigAddress(this.msig),
       to: this.to,
       fee: this.fee,
-      firstRound: this.fv,
-      lastRound: this.lv,
+      firstValid: this.fv,
+      lastValid: this.lv,
       genesisHash: this.gh,
     };
     if (this.gen) {
@@ -760,8 +760,8 @@ module.exports = function getSteps(options) {
       to: this.to,
       fee: this.fee,
       flatFee: true,
-      firstRound: this.fv,
-      lastRound: this.lv,
+      firstValid: this.fv,
+      lastValid: this.lv,
       genesisHash: this.gh,
     };
     if (this.gen) {
@@ -936,12 +936,12 @@ module.exports = function getSteps(options) {
       const result = await this.v2Client.getTransactionParams().do();
       const suggestedParams = {
         fee: result.fee,
-        firstRound: result.firstRound,
-        lastRound: result.lastRound,
+        firstValid: result.firstValid,
+        lastValid: result.lastValid,
         genesisHash: result.genesisHash,
         genesisID: result.genesisID,
       };
-      this.lastRound = result.lastRound;
+      this.lastValid = result.lastValid;
 
       if (type === 'online') {
         this.txn = algosdk.makeKeyRegistrationTxnWithSuggestedParamsFromObject({
@@ -995,8 +995,8 @@ module.exports = function getSteps(options) {
       [this.assetTestFixture.creator] = this.accounts;
       this.params = await this.v2Client.getTransactionParams().do();
       this.fee = this.params.fee;
-      this.fv = this.params.firstRound;
-      this.lv = this.params.lastRound;
+      this.fv = this.params.firstValid;
+      this.lv = this.params.lastValid;
       this.note = undefined;
       this.gh = this.params.genesisHash;
       const parsedIssuance = parseInt(issuance);
@@ -1016,8 +1016,8 @@ module.exports = function getSteps(options) {
       this.assetTestFixture.lastTxn = {
         from: this.assetTestFixture.creator,
         fee: this.fee,
-        firstRound: this.fv,
-        lastRound: this.lv,
+        firstValid: this.fv,
+        lastValid: this.lv,
         note: this.note,
         genesisHash: this.gh,
         assetTotal: parsedIssuance,
@@ -1050,7 +1050,7 @@ module.exports = function getSteps(options) {
         decimals,
       };
       this.txn = this.assetTestFixture.lastTxn;
-      this.lastRound = this.params.lastRound;
+      this.lastValid = this.params.lastValid;
       [this.pk] = this.accounts;
     }
   );
@@ -1061,8 +1061,8 @@ module.exports = function getSteps(options) {
       [this.assetTestFixture.creator] = this.accounts;
       this.params = await this.v2Client.getTransactionParams().do();
       this.fee = this.params.fee;
-      this.fv = this.params.firstRound;
-      this.lv = this.params.lastRound;
+      this.fv = this.params.firstValid;
+      this.lv = this.params.lastValid;
       this.note = undefined;
       this.gh = this.params.genesisHash;
       const parsedIssuance = parseInt(issuance);
@@ -1082,8 +1082,8 @@ module.exports = function getSteps(options) {
       this.assetTestFixture.lastTxn = {
         from: this.assetTestFixture.creator,
         fee: this.fee,
-        firstRound: this.fv,
-        lastRound: this.lv,
+        firstValid: this.fv,
+        lastValid: this.lv,
         note: this.note,
         genesisHash: this.gh,
         assetTotal: parsedIssuance,
@@ -1116,7 +1116,7 @@ module.exports = function getSteps(options) {
         decimals,
       };
       this.txn = this.assetTestFixture.lastTxn;
-      this.lastRound = this.params.lastRound;
+      this.lastValid = this.params.lastValid;
       [this.pk] = this.accounts;
     }
   );
@@ -1170,8 +1170,8 @@ module.exports = function getSteps(options) {
       [this.assetTestFixture.creator] = this.accounts;
       this.params = await this.v2Client.getTransactionParams().do();
       this.fee = this.params.fee;
-      this.fv = this.params.firstRound;
-      this.lv = this.params.lastRound;
+      this.fv = this.params.firstValid;
+      this.lv = this.params.lastValid;
       this.note = undefined;
       this.gh = this.params.genesisHash;
       // if we truly supplied no managers at all, it would be an asset destroy txn
@@ -1186,8 +1186,8 @@ module.exports = function getSteps(options) {
       this.assetTestFixture.lastTxn = {
         from: this.assetTestFixture.creator,
         fee: this.fee,
-        firstRound: this.fv,
-        lastRound: this.lv,
+        firstValid: this.fv,
+        lastValid: this.lv,
         note: this.note,
         genesisHash: this.gh,
         assetManager: manager,
@@ -1203,7 +1203,7 @@ module.exports = function getSteps(options) {
       this.assetTestFixture.expectedParams.freezeaddr = '';
       this.assetTestFixture.expectedParams.clawbackaddr = '';
       this.txn = this.assetTestFixture.lastTxn;
-      this.lastRound = this.params.lastRound;
+      this.lastValid = this.params.lastValid;
       [this.pk] = this.accounts;
     }
   );
@@ -1212,8 +1212,8 @@ module.exports = function getSteps(options) {
     [this.assetTestFixture.creator] = this.accounts;
     this.params = await this.v2Client.getTransactionParams().do();
     this.fee = this.params.fee;
-    this.fv = this.params.firstRound;
-    this.lv = this.params.lastRound;
+    this.fv = this.params.firstValid;
+    this.lv = this.params.lastValid;
     this.note = undefined;
     this.gh = this.params.genesisHash;
     const genesisID = '';
@@ -1222,8 +1222,8 @@ module.exports = function getSteps(options) {
     this.assetTestFixture.lastTxn = {
       from: this.assetTestFixture.creator,
       fee: this.fee,
-      firstRound: this.fv,
-      lastRound: this.lv,
+      firstValid: this.fv,
+      lastValid: this.lv,
       note: this.note,
       genesisHash: this.gh,
       assetIndex: parseInt(this.assetTestFixture.index),
@@ -1232,7 +1232,7 @@ module.exports = function getSteps(options) {
     };
     // update vars used by other helpers
     this.txn = this.assetTestFixture.lastTxn;
-    this.lastRound = this.params.lastRound;
+    this.lastValid = this.params.lastValid;
     [this.pk] = this.accounts;
   });
 
@@ -1252,8 +1252,8 @@ module.exports = function getSteps(options) {
       const accountToUse = this.accounts[1];
       this.params = await this.v2Client.getTransactionParams().do();
       this.fee = this.params.fee;
-      this.fv = this.params.firstRound;
-      this.lv = this.params.lastRound;
+      this.fv = this.params.firstValid;
+      this.lv = this.params.lastValid;
       this.note = undefined;
       this.gh = this.params.genesisHash;
       const genesisID = '';
@@ -1264,8 +1264,8 @@ module.exports = function getSteps(options) {
         to: accountToUse,
         amount: 0,
         fee: this.fee,
-        firstRound: this.fv,
-        lastRound: this.lv,
+        firstValid: this.fv,
+        lastValid: this.lv,
         note: this.note,
         genesisHash: this.gh,
         assetIndex: parseInt(this.assetTestFixture.index),
@@ -1274,7 +1274,7 @@ module.exports = function getSteps(options) {
       };
       // update vars used by other helpers
       this.txn = this.assetTestFixture.lastTxn;
-      this.lastRound = this.params.lastRound;
+      this.lastValid = this.params.lastValid;
       this.pk = accountToUse;
     }
   );
@@ -1284,8 +1284,8 @@ module.exports = function getSteps(options) {
     async function (amount) {
       this.params = await this.v2Client.getTransactionParams().do();
       this.fee = this.params.fee;
-      this.fv = this.params.firstRound;
-      this.lv = this.params.lastRound;
+      this.fv = this.params.firstValid;
+      this.lv = this.params.lastValid;
       this.note = undefined;
       this.gh = this.params.genesisHash;
       const genesisID = '';
@@ -1296,8 +1296,8 @@ module.exports = function getSteps(options) {
         to: this.accounts[1],
         amount: parseInt(amount),
         fee: this.fee,
-        firstRound: this.fv,
-        lastRound: this.lv,
+        firstValid: this.fv,
+        lastValid: this.lv,
         note: this.note,
         genesisHash: this.gh,
         assetIndex: parseInt(this.assetTestFixture.index),
@@ -1306,7 +1306,7 @@ module.exports = function getSteps(options) {
       };
       // update vars used by other helpers
       this.txn = this.assetTestFixture.lastTxn;
-      this.lastRound = this.params.lastRound;
+      this.lastValid = this.params.lastValid;
       this.pk = this.assetTestFixture.creator;
     }
   );
@@ -1316,8 +1316,8 @@ module.exports = function getSteps(options) {
     async function (amount) {
       this.params = await this.v2Client.getTransactionParams().do();
       this.fee = this.params.fee;
-      this.fv = this.params.firstRound;
-      this.lv = this.params.lastRound;
+      this.fv = this.params.firstValid;
+      this.lv = this.params.lastValid;
       this.note = undefined;
       this.gh = this.params.genesisHash;
       const genesisID = '';
@@ -1328,8 +1328,8 @@ module.exports = function getSteps(options) {
         from: this.accounts[1],
         amount: parseInt(amount),
         fee: this.fee,
-        firstRound: this.fv,
-        lastRound: this.lv,
+        firstValid: this.fv,
+        lastValid: this.lv,
         note: this.note,
         genesisHash: this.gh,
         assetIndex: parseInt(this.assetTestFixture.index),
@@ -1338,7 +1338,7 @@ module.exports = function getSteps(options) {
       };
       // update vars used by other helpers
       this.txn = this.assetTestFixture.lastTxn;
-      this.lastRound = this.params.lastRound;
+      this.lastValid = this.params.lastValid;
       [this.pk] = this.accounts;
     }
   );
@@ -1371,8 +1371,8 @@ module.exports = function getSteps(options) {
     async function () {
       this.params = await this.v2Client.getTransactionParams().do();
       this.fee = this.params.fee;
-      this.fv = this.params.firstRound;
-      this.lv = this.params.lastRound;
+      this.fv = this.params.firstValid;
+      this.lv = this.params.lastValid;
       this.note = undefined;
       this.gh = this.params.genesisHash;
       const freezer = this.assetTestFixture.creator;
@@ -1380,8 +1380,8 @@ module.exports = function getSteps(options) {
       this.assetTestFixture.lastTxn = {
         from: freezer,
         fee: this.fee,
-        firstRound: this.fv,
-        lastRound: this.lv,
+        firstValid: this.fv,
+        lastValid: this.lv,
         genesisHash: this.gh,
         type: 'afrz',
         freezeAccount: this.accounts[1],
@@ -1391,7 +1391,7 @@ module.exports = function getSteps(options) {
       };
       // update vars used by other helpers
       this.txn = this.assetTestFixture.lastTxn;
-      this.lastRound = this.params.lastRound;
+      this.lastValid = this.params.lastValid;
       this.pk = this.assetTestFixture.creator;
     }
   );
@@ -1401,8 +1401,8 @@ module.exports = function getSteps(options) {
     async function () {
       this.params = await this.v2Client.getTransactionParams().do();
       this.fee = this.params.fee;
-      this.fv = this.params.firstRound;
-      this.lv = this.params.lastRound;
+      this.fv = this.params.firstValid;
+      this.lv = this.params.lastValid;
       this.note = undefined;
       this.gh = this.params.genesisHash;
       const freezer = this.assetTestFixture.creator;
@@ -1410,8 +1410,8 @@ module.exports = function getSteps(options) {
       this.assetTestFixture.lastTxn = {
         from: freezer,
         fee: this.fee,
-        firstRound: this.fv,
-        lastRound: this.lv,
+        firstValid: this.fv,
+        lastValid: this.lv,
         genesisHash: this.gh,
         type: 'afrz',
         freezeAccount: this.accounts[1],
@@ -1421,7 +1421,7 @@ module.exports = function getSteps(options) {
       };
       // update vars used by other helpers
       this.txn = this.assetTestFixture.lastTxn;
-      this.lastRound = this.params.lastRound;
+      this.lastValid = this.params.lastValid;
       this.pk = this.assetTestFixture.creator;
     }
   );
@@ -1431,8 +1431,8 @@ module.exports = function getSteps(options) {
     async function (amount) {
       this.params = await this.v2Client.getTransactionParams().do();
       this.fee = this.params.fee;
-      this.fv = this.params.firstRound;
-      this.lv = this.params.lastRound;
+      this.fv = this.params.firstValid;
+      this.lv = this.params.lastValid;
       this.note = undefined;
       this.gh = this.params.genesisHash;
       const genesisID = '';
@@ -1444,8 +1444,8 @@ module.exports = function getSteps(options) {
         assetRevocationTarget: this.accounts[1],
         amount: parseInt(amount),
         fee: this.fee,
-        firstRound: this.fv,
-        lastRound: this.lv,
+        firstValid: this.fv,
+        lastValid: this.lv,
         note: this.note,
         genesisHash: this.gh,
         assetIndex: parseInt(this.assetTestFixture.index),
@@ -1454,7 +1454,7 @@ module.exports = function getSteps(options) {
       };
       // update vars used by other helpers
       this.txn = this.assetTestFixture.lastTxn;
-      this.lastRound = this.params.lastRound;
+      this.lastValid = this.params.lastValid;
       this.pk = this.assetTestFixture.creator;
     }
   );
@@ -1968,10 +1968,10 @@ module.exports = function getSteps(options) {
 
   Then(
     'the parsed Suggested Transaction Parameters response should have first round valid of {int}',
-    (firstRound) => {
+    (firstValid) => {
       assert.strictEqual(
-        firstRound,
-        anySuggestedTransactionsResponse.firstRound
+        firstValid,
+        anySuggestedTransactionsResponse.firstValid
       );
     }
   );
@@ -2764,8 +2764,8 @@ module.exports = function getSteps(options) {
       from: 'UAPJE355K7BG7RQVMTZOW7QW4ICZJEIC3RZGYG5LSHZ65K6LCNFPJDSR7M',
       fee: 1000,
       amount: 1000,
-      firstRound: 1,
-      lastRound: 1000,
+      firstValid: 1,
+      lastValid: 1000,
       type: 'pay',
       genesisHash: 'ZIkPs8pTDxbRJsFB1yJ7gvnpDu0Q85FRkl2NCkEAQLU=',
     });
@@ -2954,7 +2954,7 @@ module.exports = function getSteps(options) {
     "I fund the current application's address with {int} microalgos.",
     async function (amount) {
       const sp = await this.v2Client.getTransactionParams().do();
-      if (sp.firstRound === 0) sp.firstRound = 1;
+      if (sp.firstValid === 0) sp.firstValid = 1;
       const fundingTxnArgs = {
         from: this.accounts[0],
         to: algosdk.getApplicationAddress(this.currentApplicationIndex),
@@ -2979,14 +2979,14 @@ module.exports = function getSteps(options) {
 
   Given(
     'suggested transaction parameters fee {int}, flat-fee {string}, first-valid {int}, last-valid {int}, genesis-hash {string}, genesis-id {string}',
-    function (fee, flatFee, firstRound, lastRound, genesisHash, genesisID) {
+    function (fee, flatFee, firstValid, lastValid, genesisHash, genesisID) {
       assert.ok(['true', 'false'].includes(flatFee));
 
       this.suggestedParams = {
         flatFee: flatFee === 'true',
         fee,
-        firstRound,
-        lastRound,
+        firstValid,
+        lastValid,
         genesisID,
         genesisHash,
       };
@@ -3143,8 +3143,8 @@ module.exports = function getSteps(options) {
       // build suggested params object
       const sp = {
         genesisHash: genesisHashBase64,
-        firstRound: firstValid,
-        lastRound: lastValid,
+        firstValid,
+        lastValid,
         fee,
         flatFee: true,
       };
@@ -3333,7 +3333,7 @@ module.exports = function getSteps(options) {
       this.transientAccount = algosdk.generateAccount();
 
       const sp = await this.v2Client.getTransactionParams().do();
-      if (sp.firstRound === 0) sp.firstRound = 1;
+      if (sp.firstValid === 0) sp.firstValid = 1;
       const fundingTxnArgs = {
         from: this.accounts[0],
         to: this.transientAccount.addr,
@@ -3432,7 +3432,7 @@ module.exports = function getSteps(options) {
         boxes = splitAndProcessBoxReferences(boxesCommaSeparatedString);
       }
       const sp = await this.v2Client.getTransactionParams().do();
-      if (sp.firstRound === 0) sp.firstRound = 1;
+      if (sp.firstValid === 0) sp.firstValid = 1;
       const o = {
         type: 'appl',
         from: this.transientAccount.addr,

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -1386,7 +1386,7 @@ module.exports = function getSteps(options) {
         type: 'afrz',
         freezeAccount: this.accounts[1],
         assetIndex: parseInt(this.assetTestFixture.index),
-        freezeState: false,
+        assetFrozen: false,
         note: this.note,
       };
       // update vars used by other helpers
@@ -1416,7 +1416,7 @@ module.exports = function getSteps(options) {
         type: 'afrz',
         freezeAccount: this.accounts[1],
         assetIndex: parseInt(this.assetTestFixture.index),
-        freezeState: true,
+        assetFrozen: true,
         note: this.note,
       };
       // update vars used by other helpers

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -250,12 +250,12 @@ module.exports = function getSteps(options) {
 
   Given(
     'payment transaction parameters {int} {int} {int} {string} {string} {string} {int} {string} {string}',
-    function (fee, fv, lv, gh, to, close, amt, gen, note) {
+    function (fee, fv, lv, gh, receiver, close, amt, gen, note) {
       this.fee = parseInt(fee);
       this.fv = parseInt(fv);
       this.lv = parseInt(lv);
       this.gh = gh;
-      this.to = to;
+      this.receiver = receiver;
       if (close !== 'none') {
         this.close = close;
       }
@@ -390,8 +390,8 @@ module.exports = function getSteps(options) {
       const sp = await this.v2Client.getTransactionParams().do();
       if (sp.firstValid === 0) sp.firstValid = 1;
       const fundingTxnArgs = {
-        from: this.accounts[0],
-        to: this.rekey,
+        sender: this.accounts[0],
+        receiver: this.rekey,
         amount: DEV_MODE_INITIAL_MICROALGOS,
         fee: sp.fee,
         firstValid: sp.firstValid,
@@ -467,8 +467,8 @@ module.exports = function getSteps(options) {
       [this.pk] = this.accounts;
       const result = await this.v2Client.getTransactionParams().do();
       this.txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-        from: this.accounts[0],
-        to: this.accounts[1],
+        sender: this.accounts[0],
+        receiver: this.accounts[1],
         amount: parseInt(amt),
         suggestedParams: result,
         note: makeUint8Array(algosdk.base64ToBytes(note)),
@@ -484,8 +484,8 @@ module.exports = function getSteps(options) {
       const result = await this.v2Client.getTransactionParams().do();
       this.lastValid = result.lastValid;
       this.txn = {
-        from: this.rekey,
-        to: this.accounts[1],
+        sender: this.rekey,
+        receiver: this.accounts[1],
         fee: result.fee,
         firstValid: result.firstValid,
         lastValid: result.lastValid,
@@ -510,8 +510,8 @@ module.exports = function getSteps(options) {
       };
 
       this.txn = {
-        from: algosdk.multisigAddress(this.msig),
-        to: this.accounts[1],
+        sender: algosdk.multisigAddress(this.msig),
+        receiver: this.accounts[1],
         fee: result.fee,
         firstValid: result.firstValid,
         lastValid: result.lastValid,
@@ -662,7 +662,7 @@ module.exports = function getSteps(options) {
 
   When('I create the flat fee payment transaction', function () {
     this.txn = {
-      to: this.to,
+      receiver: this.receiver,
       fee: this.fee,
       firstValid: this.fv,
       lastValid: this.lv,
@@ -732,8 +732,8 @@ module.exports = function getSteps(options) {
 
   When('I create the multisig payment transaction', function () {
     this.txn = {
-      from: algosdk.multisigAddress(this.msig),
-      to: this.to,
+      sender: algosdk.multisigAddress(this.msig),
+      receiver: this.receiver,
       fee: this.fee,
       firstValid: this.fv,
       lastValid: this.lv,
@@ -756,8 +756,8 @@ module.exports = function getSteps(options) {
 
   When('I create the multisig payment transaction with zero fee', function () {
     this.txn = {
-      from: algosdk.multisigAddress(this.msig),
-      to: this.to,
+      sender: algosdk.multisigAddress(this.msig),
+      receiver: this.receiver,
       fee: this.fee,
       flatFee: true,
       firstValid: this.fv,
@@ -945,7 +945,7 @@ module.exports = function getSteps(options) {
 
       if (type === 'online') {
         this.txn = algosdk.makeKeyRegistrationTxnWithSuggestedParamsFromObject({
-          from,
+          sender: from,
           voteKey,
           selectionKey,
           stateProofKey,
@@ -956,12 +956,12 @@ module.exports = function getSteps(options) {
         });
       } else if (type === 'offline') {
         this.txn = algosdk.makeKeyRegistrationTxnWithSuggestedParamsFromObject({
-          from,
+          sender: from,
           suggestedParams,
         });
       } else if (type === 'nonparticipation') {
         this.txn = algosdk.makeKeyRegistrationTxnWithSuggestedParamsFromObject({
-          from,
+          sender: from,
           nonParticipation: true,
           suggestedParams,
         });
@@ -1014,7 +1014,7 @@ module.exports = function getSteps(options) {
       const type = 'acfg';
 
       this.assetTestFixture.lastTxn = {
-        from: this.assetTestFixture.creator,
+        sender: this.assetTestFixture.creator,
         fee: this.fee,
         firstValid: this.fv,
         lastValid: this.lv,
@@ -1080,7 +1080,7 @@ module.exports = function getSteps(options) {
       const type = 'acfg';
 
       this.assetTestFixture.lastTxn = {
-        from: this.assetTestFixture.creator,
+        sender: this.assetTestFixture.creator,
         fee: this.fee,
         firstValid: this.fv,
         lastValid: this.lv,
@@ -1184,7 +1184,7 @@ module.exports = function getSteps(options) {
       const type = 'acfg';
 
       this.assetTestFixture.lastTxn = {
-        from: this.assetTestFixture.creator,
+        sender: this.assetTestFixture.creator,
         fee: this.fee,
         firstValid: this.fv,
         lastValid: this.lv,
@@ -1220,7 +1220,7 @@ module.exports = function getSteps(options) {
     const type = 'acfg';
 
     this.assetTestFixture.lastTxn = {
-      from: this.assetTestFixture.creator,
+      sender: this.assetTestFixture.creator,
       fee: this.fee,
       firstValid: this.fv,
       lastValid: this.lv,
@@ -1260,8 +1260,8 @@ module.exports = function getSteps(options) {
       const type = 'axfer';
 
       this.assetTestFixture.lastTxn = {
-        from: accountToUse,
-        to: accountToUse,
+        sender: accountToUse,
+        receiver: accountToUse,
         amount: 0,
         fee: this.fee,
         firstValid: this.fv,
@@ -1292,8 +1292,8 @@ module.exports = function getSteps(options) {
       const type = 'axfer';
 
       this.assetTestFixture.lastTxn = {
-        from: this.assetTestFixture.creator,
-        to: this.accounts[1],
+        sender: this.assetTestFixture.creator,
+        receiver: this.accounts[1],
         amount: parseInt(amount),
         fee: this.fee,
         firstValid: this.fv,
@@ -1324,8 +1324,8 @@ module.exports = function getSteps(options) {
       const type = 'axfer';
 
       this.assetTestFixture.lastTxn = {
-        to: this.assetTestFixture.creator,
-        from: this.accounts[1],
+        receiver: this.assetTestFixture.creator,
+        sender: this.accounts[1],
         amount: parseInt(amount),
         fee: this.fee,
         firstValid: this.fv,
@@ -1378,7 +1378,7 @@ module.exports = function getSteps(options) {
       const freezer = this.assetTestFixture.creator;
 
       this.assetTestFixture.lastTxn = {
-        from: freezer,
+        sender: freezer,
         fee: this.fee,
         firstValid: this.fv,
         lastValid: this.lv,
@@ -1408,7 +1408,7 @@ module.exports = function getSteps(options) {
       const freezer = this.assetTestFixture.creator;
 
       this.assetTestFixture.lastTxn = {
-        from: freezer,
+        sender: freezer,
         fee: this.fee,
         firstValid: this.fv,
         lastValid: this.lv,
@@ -1439,8 +1439,8 @@ module.exports = function getSteps(options) {
       const type = 'axfer';
 
       this.assetTestFixture.lastTxn = {
-        from: this.assetTestFixture.creator,
-        to: this.assetTestFixture.creator,
+        sender: this.assetTestFixture.creator,
+        receiver: this.assetTestFixture.creator,
         assetRevocationTarget: this.accounts[1],
         amount: parseInt(amount),
         fee: this.fee,
@@ -2736,8 +2736,8 @@ module.exports = function getSteps(options) {
     }
   );
 
-  When('I set the from address to {string}', function (from) {
-    this.txn.from = from;
+  When('I set the from address to {string}', function (sender) {
+    this.txn.sender = sender;
   });
 
   let dryrunResponse;
@@ -2761,7 +2761,7 @@ module.exports = function getSteps(options) {
   When('I dryrun a {string} program {string}', async function (kind, program) {
     const data = await loadResource(program);
     const algoTxn = new algosdk.Transaction({
-      from: 'UAPJE355K7BG7RQVMTZOW7QW4ICZJEIC3RZGYG5LSHZ65K6LCNFPJDSR7M',
+      sender: 'UAPJE355K7BG7RQVMTZOW7QW4ICZJEIC3RZGYG5LSHZ65K6LCNFPJDSR7M',
       fee: 1000,
       amount: 1000,
       firstValid: 1,
@@ -2925,8 +2925,8 @@ module.exports = function getSteps(options) {
         receiver === 'transient' ? this.transientAccount.addr : receiver;
 
       this.txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-        from,
-        to,
+        sender: from,
+        receiver: to,
         amount: parseInt(amount, 10),
         closeRemainderTo: closeTo.length === 0 ? undefined : closeTo,
         suggestedParams: this.suggestedParams,
@@ -2956,8 +2956,8 @@ module.exports = function getSteps(options) {
       const sp = await this.v2Client.getTransactionParams().do();
       if (sp.firstValid === 0) sp.firstValid = 1;
       const fundingTxnArgs = {
-        from: this.accounts[0],
-        to: algosdk.getApplicationAddress(this.currentApplicationIndex),
+        sender: this.accounts[0],
+        receiver: algosdk.getApplicationAddress(this.currentApplicationIndex),
         amount,
         suggestedParams: sp,
       };
@@ -3335,8 +3335,8 @@ module.exports = function getSteps(options) {
       const sp = await this.v2Client.getTransactionParams().do();
       if (sp.firstValid === 0) sp.firstValid = 1;
       const fundingTxnArgs = {
-        from: this.accounts[0],
-        to: this.transientAccount.addr,
+        sender: this.accounts[0],
+        receiver: this.transientAccount.addr,
         amount: fundingAmount,
         suggestedParams: sp,
       };
@@ -3435,7 +3435,7 @@ module.exports = function getSteps(options) {
       if (sp.firstValid === 0) sp.firstValid = 1;
       const o = {
         type: 'appl',
-        from: this.transientAccount.addr,
+        sender: this.transientAccount.addr,
         suggestedParams: sp,
         appIndex: this.currentApplicationIndex,
         appOnComplete: operation,


### PR DESCRIPTION
This PR contains breaking changes in transaction fields that align more closely to the [transaction reference spec](https://developer.algorand.org/docs/get-details/transactions/transactions/).

Changes:
* from -> sender
* to -> receiver
* firstRound -> firstValid
* lastRound -> lastValid
* freezeState -> assetFrozen
* assetRevocationTarget -> assetSender
* reKeyTo -> rekeyTo

https://github.com/algorand/js-algorand-sdk/issues/144