### PR TITLE
Add address bytes length check in encodeAddress

### DIFF
--- a/examples/app.ts
+++ b/examples/app.ts
@@ -153,10 +153,8 @@ async function main() {
 
   // decode b64 string key with Buffer
   const globalKey = algosdk.base64ToString(globalState.key);
-  // decode b64 address value with encodeAddress and Buffer
-  const globalValue = algosdk.encodeAddress(
-    algosdk.base64ToBytes(globalState.value.bytes)
-  );
+  // show global value
+  const globalValue = globalState.value.bytes;
 
   console.log(`Decoded global state - ${globalKey}: ${globalValue}`);
 

--- a/src/encoding/address.ts
+++ b/src/encoding/address.ts
@@ -100,6 +100,12 @@ export function isValidAddress(address: string) {
  * @returns the address and checksum encoded as a string.
  */
 export function encodeAddress(address: Uint8Array) {
+  // Check address length
+  if (
+    address.length !==
+    ALGORAND_ADDRESS_BYTE_LENGTH - ALGORAND_CHECKSUM_BYTE_LENGTH
+  )
+    throw new Error(MALFORMED_ADDRESS_ERROR_MSG);
   // compute checksum
   const checksum = nacl
     .genericHash(address)

--- a/src/encoding/address.ts
+++ b/src/encoding/address.ts
@@ -105,7 +105,9 @@ export function encodeAddress(address: Uint8Array) {
     address.length !==
     ALGORAND_ADDRESS_BYTE_LENGTH - ALGORAND_CHECKSUM_BYTE_LENGTH
   )
-    throw new Error(MALFORMED_ADDRESS_ERROR_MSG);
+    throw new Error(
+      `${MALFORMED_ADDRESS_ERROR_MSG}: ${address}, length ${address.length}`
+    );
   // compute checksum
   const checksum = nacl
     .genericHash(address)

--- a/tests/3.Address.js
+++ b/tests/3.Address.js
@@ -74,6 +74,16 @@ describe('address', () => {
       assert.ok(algosdk.isValidAddress(addr));
     });
 
+    it('should throw an error for addresses with incorrect length', () => {
+      const pk = nacl.randomBytes(15);
+      assert.throws(
+        () => {
+          algosdk.encodeAddress(pk);
+        },
+        (err) => err.message.includes(address.MALFORMED_ADDRESS_ERROR_MSG)
+      );
+    });
+
     it('should be able to encode and decode an address', () => {
       const pk = nacl.randomBytes(32);
       const addr = algosdk.encodeAddress(pk);


### PR DESCRIPTION
Adds check when encoding address to string that address is 32 bytes. Also fixes an example that would fail this check because it passes an empty bytearray to encode. Targets the v3 branch.

https://github.com/algorand/js-algorand-sdk/issues/805