### PR TITLE
CICD: Update chromedriver in package.json to 116+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,3 +133,4 @@ commands:
           command: |
             set -e
             npm ci
+            npm install chromedriver@latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@typescript-eslint/eslint-plugin": "^4.26.1",
         "@typescript-eslint/parser": "^4.26.1",
         "assert": "^2.0.0",
-        "chromedriver": "^115.0.1",
+        "chromedriver": "^116.0.0",
         "concurrently": "^6.2.0",
         "cucumber": "^5.1.0",
         "es-abstract": "^1.18.3",
@@ -1592,9 +1592,9 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "115.0.1",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-115.0.1.tgz",
-      "integrity": "sha512-faE6WvIhXfhnoZ3nAxUXYzeDCKy612oPwpkUp0mVkA7fZPg2JHSUiYOQhUYgzHQgGvDWD5Fy2+M2xV55GKHBVQ==",
+      "version": "116.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-116.0.0.tgz",
+      "integrity": "sha512-/TQaRn+RUAYnVqy5Vx8VtU8DvtWosU8QLM2u7BoNM5h55PRQPXF/onHAehEi8Sj/CehdKqH50NFdiumQAUr0DQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -9296,9 +9296,9 @@
       "dev": true
     },
     "chromedriver": {
-      "version": "115.0.1",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-115.0.1.tgz",
-      "integrity": "sha512-faE6WvIhXfhnoZ3nAxUXYzeDCKy612oPwpkUp0mVkA7fZPg2JHSUiYOQhUYgzHQgGvDWD5Fy2+M2xV55GKHBVQ==",
+      "version": "116.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-116.0.0.tgz",
+      "integrity": "sha512-/TQaRn+RUAYnVqy5Vx8VtU8DvtWosU8QLM2u7BoNM5h55PRQPXF/onHAehEi8Sj/CehdKqH50NFdiumQAUr0DQ==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@typescript-eslint/eslint-plugin": "^4.26.1",
         "@typescript-eslint/parser": "^4.26.1",
         "assert": "^2.0.0",
-        "chromedriver": "^114.0.0",
+        "chromedriver": "^115.0.0",
         "concurrently": "^6.2.0",
         "cucumber": "^5.1.0",
         "es-abstract": "^1.18.3",
@@ -1592,9 +1592,9 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "114.0.3",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-114.0.3.tgz",
-      "integrity": "sha512-Qy5kqsAUrCDwpovM5pIWFkb3X3IgJLoorigwFEDgC1boL094svny3N7yw06marJHAuyX4CE/hhd25RarIcKvKg==",
+      "version": "115.0.1",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-115.0.1.tgz",
+      "integrity": "sha512-faE6WvIhXfhnoZ3nAxUXYzeDCKy612oPwpkUp0mVkA7fZPg2JHSUiYOQhUYgzHQgGvDWD5Fy2+M2xV55GKHBVQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -9296,9 +9296,9 @@
       "dev": true
     },
     "chromedriver": {
-      "version": "114.0.3",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-114.0.3.tgz",
-      "integrity": "sha512-Qy5kqsAUrCDwpovM5pIWFkb3X3IgJLoorigwFEDgC1boL094svny3N7yw06marJHAuyX4CE/hhd25RarIcKvKg==",
+      "version": "115.0.1",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-115.0.1.tgz",
+      "integrity": "sha512-faE6WvIhXfhnoZ3nAxUXYzeDCKy612oPwpkUp0mVkA7fZPg2JHSUiYOQhUYgzHQgGvDWD5Fy2+M2xV55GKHBVQ==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@typescript-eslint/eslint-plugin": "^4.26.1",
         "@typescript-eslint/parser": "^4.26.1",
         "assert": "^2.0.0",
-        "chromedriver": "^115.0.0",
+        "chromedriver": "^115.0.1",
         "concurrently": "^6.2.0",
         "cucumber": "^5.1.0",
         "es-abstract": "^1.18.3",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@typescript-eslint/eslint-plugin": "^4.26.1",
     "@typescript-eslint/parser": "^4.26.1",
     "assert": "^2.0.0",
-    "chromedriver": "^114.0.0",
+    "chromedriver": "^115.0.0",
     "concurrently": "^6.2.0",
     "cucumber": "^5.1.0",
     "es-abstract": "^1.18.3",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@typescript-eslint/eslint-plugin": "^4.26.1",
     "@typescript-eslint/parser": "^4.26.1",
     "assert": "^2.0.0",
-    "chromedriver": "^115.0.0",
+    "chromedriver": "^115.0.1",
     "concurrently": "^6.2.0",
     "cucumber": "^5.1.0",
     "es-abstract": "^1.18.3",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@typescript-eslint/eslint-plugin": "^4.26.1",
     "@typescript-eslint/parser": "^4.26.1",
     "assert": "^2.0.0",
-    "chromedriver": "^115.0.1",
+    "chromedriver": "^116.0.0",
     "concurrently": "^6.2.0",
     "cucumber": "^5.1.0",
     "es-abstract": "^1.18.3",


### PR DESCRIPTION
Updates chromedriver package -- Fixes failing Chrome CI setup.

Extra thoughts:
* I don't think `npm install chromedriver@latest` is necessary, because Chrome 115+ pulls up its own version of chromedriver and use that instead: https://chromedriver.chromium.org/downloads/version-selection ~~Here is an instance where an invalid chromedriver version is supplied (v116 is supplied, but the latest version is [115](https://www.npmjs.com/package/chromedriver)), but the CI process still runs up properly: https://github.com/algorand/js-algorand-sdk/pull/776/commits/7569f079b0ca5ef8021a0c69b2ac31005c391372~~
* I wonder if there's a way to remove this dependency altogether, especially since v115+ installs chromedriver alongside chrome, but this might require custom scripts anyway