### PR TITLE
node: Update to node 18, drop support for node 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ commands:
             << parameters.sudo >> apt -y update
             << parameters.sudo >> apt -y install curl make git build-essential jq unzip
       - node/install:
-          node-version: '16'
+          node-version: '18'
       - run:
           name: npm ci
           command: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "webpack-cli": "^5.0.1"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,6 @@
   "author": "Algorand, llc",
   "license": "MIT",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   }
 }

--- a/tests/cucumber/docker/Dockerfile
+++ b/tests/cucumber/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
   && apt-get -qqy --no-install-recommends install google-chrome-stable firefox
 
 # install node
-RUN wget -q -O - https://deb.nodesource.com/setup_16.x | bash \
+RUN wget -q -O - https://deb.nodesource.com/setup_18.x | bash \
   && apt-get -qqy --no-install-recommends install nodejs \
   && echo "node version: $(node --version)" \
   && echo "npm version: $(npm --version)"

--- a/tests/cucumber/docker/Dockerfile
+++ b/tests/cucumber/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:focal
 
 # install wget, gnupg2, make
 RUN apt-get update -qqy \


### PR DESCRIPTION
Node v16 went EOL on 2023-09-11, and our dependency chromedriver dropped support for it. So we must update to v18 to continue using it (and it's probably a good idea anyway).