### PR TITLE
DevOps: Update release PR generator to nodejs 18

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Update Version References in Source
         env:


### PR DESCRIPTION
# Summary

NodeJS v16 is no longer supported, so bump the release PR generator appropriately.

# Testing

Ran `npm install` and `npm test` using v18.
