### PR TITLE
TEAL Source Map: Improve SourceMap and support columns

### DIFF
--- a/.test-env
+++ b/.test-env
@@ -1,6 +1,6 @@
 # Configs for testing repo download:
 SDK_TESTING_URL="https://github.com/algorand/algorand-sdk-testing"
-SDK_TESTING_BRANCH="sourcemap-v2-testcases"
+SDK_TESTING_BRANCH="V2"
 SDK_TESTING_HARNESS="test-harness"
 
 INSTALL_ONLY=0

--- a/.test-env
+++ b/.test-env
@@ -1,6 +1,6 @@
 # Configs for testing repo download:
 SDK_TESTING_URL="https://github.com/algorand/algorand-sdk-testing"
-SDK_TESTING_BRANCH="V2"
+SDK_TESTING_BRANCH="sourcemap-v2-testcases"
 SDK_TESTING_HARNESS="test-harness"
 
 INSTALL_ONLY=0

--- a/src/logic/sourcemap.ts
+++ b/src/logic/sourcemap.ts
@@ -22,7 +22,7 @@ export interface PcLineLocation {
 /**
  * Contains a mapping from TEAL program PC to source file location.
  */
-export class SourceMap {
+export class ProgramSourceMap {
   public readonly version: number;
   /**
    * A list of original sources used by the "mappings" entry.

--- a/src/main.ts
+++ b/src/main.ts
@@ -183,7 +183,11 @@ export {
   verifyMultisig,
   multisigAddress,
 } from './multisig';
-export { SourceMap, SourceLocation, PcLineLocation } from './logic/sourcemap';
+export {
+  ProgramSourceMap,
+  SourceLocation,
+  PcLineLocation,
+} from './logic/sourcemap';
 
 export * from './dryrun';
 export * from './makeTxn';

--- a/src/main.ts
+++ b/src/main.ts
@@ -183,7 +183,7 @@ export {
   verifyMultisig,
   multisigAddress,
 } from './multisig';
-export { SourceMap } from './logic/sourcemap';
+export { SourceMap, SourceLocation, PcLineLocation } from './logic/sourcemap';
 
 export * from './dryrun';
 export * from './makeTxn';

--- a/tests/8.LogicSig.ts
+++ b/tests/8.LogicSig.ts
@@ -701,20 +701,20 @@ describe('SourceMap', () => {
   };
 
   const expectedLocations = new Map<number, algosdk.SourceLocation>([
-    [4, { line: 3, column: 0 }],
-    [6, { line: 3, column: 19 }],
-    [8, { line: 3, column: 26 }],
-    [9, { line: 3, column: 30 }],
-    [12, { line: 5, column: 0 }],
-    [14, { line: 5, column: 7 }],
-    [16, { line: 5, column: 14 }],
-    [17, { line: 6, column: 0 }],
-    [19, { line: 6, column: 7 }],
-    [20, { line: 6, column: 14 }],
-    [21, { line: 1, column: 21 }],
-    [22, { line: 1, column: 25 }],
-    [23, { line: 10, column: 4 }],
-    [24, { line: 11, column: 4 }],
+    [4, { sourceIndex: 0, line: 3, column: 0 }],
+    [6, { sourceIndex: 0, line: 3, column: 19 }],
+    [8, { sourceIndex: 0, line: 3, column: 26 }],
+    [9, { sourceIndex: 0, line: 3, column: 30 }],
+    [12, { sourceIndex: 0, line: 5, column: 0 }],
+    [14, { sourceIndex: 0, line: 5, column: 7 }],
+    [16, { sourceIndex: 0, line: 5, column: 14 }],
+    [17, { sourceIndex: 0, line: 6, column: 0 }],
+    [19, { sourceIndex: 0, line: 6, column: 7 }],
+    [20, { sourceIndex: 0, line: 6, column: 14 }],
+    [21, { sourceIndex: 0, line: 1, column: 21 }],
+    [22, { sourceIndex: 0, line: 1, column: 25 }],
+    [23, { sourceIndex: 0, line: 10, column: 4 }],
+    [24, { sourceIndex: 0, line: 11, column: 4 }],
   ]);
 
   const expectedPcsForLine = new Map<number, algosdk.PcLineLocation[]>([
@@ -795,7 +795,7 @@ describe('SourceMap', () => {
       for (let line = 1; line <= maxLineToCheck; line++) {
         const expected = expectedPcsForLine.get(line) || [];
         assert.deepStrictEqual(
-          sourceMap.getPcsForLine(line),
+          sourceMap.getPcsOnSourceLine(0, line),
           expected,
           `line=${line}`
         );

--- a/tests/8.LogicSig.ts
+++ b/tests/8.LogicSig.ts
@@ -691,7 +691,7 @@ describe('signLogicSigTransaction', () => {
   });
 });
 
-describe('SourceMap', () => {
+describe('ProgramSourceMap', () => {
   const input = {
     version: 3,
     sources: ['test/scripts/e2e_subs/tealprogs/sourcemap-test.teal'],
@@ -754,8 +754,8 @@ describe('SourceMap', () => {
     [11, [{ pc: 24, column: 4 }]],
   ]);
 
-  it('should be able to read a SourceMap', () => {
-    const sourceMap = new algosdk.SourceMap(input);
+  it('should be able to read a ProgramSourceMap', () => {
+    const sourceMap = new algosdk.ProgramSourceMap(input);
 
     assert.strictEqual(sourceMap.version, input.version);
     assert.deepStrictEqual(sourceMap.sources, input.sources);
@@ -765,7 +765,7 @@ describe('SourceMap', () => {
 
   describe('getLocationForPc', () => {
     it('should return the correct location for all pcs', () => {
-      const sourceMap = new algosdk.SourceMap(input);
+      const sourceMap = new algosdk.ProgramSourceMap(input);
       const maxPcToCheck = 30;
 
       for (let pc = 0; pc < maxPcToCheck; pc++) {
@@ -781,7 +781,7 @@ describe('SourceMap', () => {
 
   describe('getPcs', () => {
     it('should return the correct pcs', () => {
-      const sourceMap = new algosdk.SourceMap(input);
+      const sourceMap = new algosdk.ProgramSourceMap(input);
       const expectedPcs = Array.from(expectedLocations.keys());
       assert.deepStrictEqual(sourceMap.getPcs(), expectedPcs);
     });
@@ -789,7 +789,7 @@ describe('SourceMap', () => {
 
   describe('getPcsForLine', () => {
     it('should return the correct pcs for all lines', () => {
-      const sourceMap = new algosdk.SourceMap(input);
+      const sourceMap = new algosdk.ProgramSourceMap(input);
       const maxLineToCheck = 15;
 
       for (let line = 1; line <= maxLineToCheck; line++) {

--- a/tests/8.LogicSig.ts
+++ b/tests/8.LogicSig.ts
@@ -690,3 +690,116 @@ describe('signLogicSigTransaction', () => {
     assert.deepStrictEqual(actual, expected);
   });
 });
+
+describe('SourceMap', () => {
+  const input = {
+    version: 3,
+    sources: ['test/scripts/e2e_subs/tealprogs/sourcemap-test.teal'],
+    names: [],
+    mappings:
+      ';;;;AAGA;;AAAmB;;AAAO;AAAI;;;AAE9B;;AAAO;;AAAO;AACd;;AAAO;AAAO;AALO;AAAI;AASrB;AACA',
+  };
+
+  const expectedLocations = new Map<number, algosdk.SourceLocation>([
+    [4, { line: 3, column: 0 }],
+    [6, { line: 3, column: 19 }],
+    [8, { line: 3, column: 26 }],
+    [9, { line: 3, column: 30 }],
+    [12, { line: 5, column: 0 }],
+    [14, { line: 5, column: 7 }],
+    [16, { line: 5, column: 14 }],
+    [17, { line: 6, column: 0 }],
+    [19, { line: 6, column: 7 }],
+    [20, { line: 6, column: 14 }],
+    [21, { line: 1, column: 21 }],
+    [22, { line: 1, column: 25 }],
+    [23, { line: 10, column: 4 }],
+    [24, { line: 11, column: 4 }],
+  ]);
+
+  const expectedPcsForLine = new Map<number, algosdk.PcLineLocation[]>([
+    [
+      3,
+      [
+        { pc: 4, column: 0 },
+        { pc: 6, column: 19 },
+        { pc: 8, column: 26 },
+        { pc: 9, column: 30 },
+      ],
+    ],
+    [
+      5,
+      [
+        { pc: 12, column: 0 },
+        { pc: 14, column: 7 },
+        { pc: 16, column: 14 },
+      ],
+    ],
+    [
+      6,
+      [
+        { pc: 17, column: 0 },
+        { pc: 19, column: 7 },
+        { pc: 20, column: 14 },
+      ],
+    ],
+    [
+      1,
+      [
+        { pc: 21, column: 21 },
+        { pc: 22, column: 25 },
+      ],
+    ],
+    [10, [{ pc: 23, column: 4 }]],
+    [11, [{ pc: 24, column: 4 }]],
+  ]);
+
+  it('should be able to read a SourceMap', () => {
+    const sourceMap = new algosdk.SourceMap(input);
+
+    assert.strictEqual(sourceMap.version, input.version);
+    assert.deepStrictEqual(sourceMap.sources, input.sources);
+    assert.deepStrictEqual(sourceMap.names, input.names);
+    assert.strictEqual(sourceMap.mappings, input.mappings);
+  });
+
+  describe('getLocationForPc', () => {
+    it('should return the correct location for all pcs', () => {
+      const sourceMap = new algosdk.SourceMap(input);
+      const maxPcToCheck = 30;
+
+      for (let pc = 0; pc < maxPcToCheck; pc++) {
+        const expected = expectedLocations.get(pc);
+        assert.deepStrictEqual(
+          sourceMap.getLocationForPc(pc),
+          expected,
+          `pc=${pc}`
+        );
+      }
+    });
+  });
+
+  describe('getPcs', () => {
+    it('should return the correct pcs', () => {
+      const sourceMap = new algosdk.SourceMap(input);
+      const expectedPcs = Array.from(expectedLocations.keys());
+      assert.deepStrictEqual(sourceMap.getPcs(), expectedPcs);
+    });
+  });
+
+  describe('getPcsForLine', () => {
+    it('should return the correct pcs for all lines', () => {
+      const sourceMap = new algosdk.SourceMap(input);
+      const maxLineToCheck = 15;
+
+      for (let line = 1; line <= maxLineToCheck; line++) {
+        const expected = expectedPcsForLine.get(line) || [];
+        assert.deepStrictEqual(
+          sourceMap.getPcsForLine(line),
+          expected,
+          `line=${line}`
+        );
+      }
+    });
+  });
+});

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -4698,8 +4698,11 @@ module.exports = function getSteps(options) {
   });
 
   Then('the source map contains pcs {string}', function (pcsString) {
-    const pcs = pcsString.split(',').map((pc) => parseInt(pc, 10));
-    assert.deepStrictEqual(this.sourcemap.getPcs(), pcs);
+    const expectedPcs = makeArray(
+      ...pcsString.split(',').map((pc) => parseInt(pc, 10))
+    );
+    const actualPcs = makeArray(...this.sourcemap.getPcs());
+    assert.deepStrictEqual(actualPcs, expectedPcs);
   });
 
   Then(

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -4694,7 +4694,7 @@ module.exports = function getSteps(options) {
 
   Given('a source map json file {string}', async function (srcmap) {
     const js = await loadResourceAsJson(srcmap);
-    this.sourcemap = new algosdk.SourceMap(js);
+    this.sourcemap = new algosdk.ProgramSourceMap(js);
   });
 
   Then('the source map contains pcs {string}', function (pcsString) {

--- a/tests/cucumber/unit.tags
+++ b/tests/cucumber/unit.tags
@@ -27,7 +27,7 @@
 @unit.responses.timestamp
 @unit.responses.txid.json
 @unit.responses.txngroupdeltas.json
-@unit.sourcemap
+@unit.sourcemapv2
 @unit.stateproof.paths
 @unit.stateproof.responses
 @unit.stateproof.responses.msgp


### PR DESCRIPTION
Improve the source map class and take advantage of column reporting from https://github.com/algorand/go-algorand/pull/5776 to provide more accurate mappings.

Also, rename from `SourceMap` to `ProgramSourceMap` to be more specific. Our source maps are not exactly the same as general source maps, since they map indexes from a binary file (the compiled bytecode) to source locations.