### PR TITLE
fix: allow either boolean value for nonParticipation offline keyregs

### DIFF
--- a/examples/participation.ts
+++ b/examples/participation.ts
@@ -49,7 +49,6 @@ async function main() {
     {
       from: addr,
       suggestedParams,
-      nonParticipation: true,
     }
   );
   console.log(offlineKeyReg.get_obj_for_encoding());

--- a/src/makeTxn.ts
+++ b/src/makeTxn.ts
@@ -135,7 +135,7 @@ export function makeKeyRegistrationTxnWithSuggestedParams(
   voteKeyDilution: undefined,
   suggestedParams: MustHaveSuggestedParams<KeyRegistrationTxn>['suggestedParams'],
   rekeyTo?: KeyRegistrationTxn['reKeyTo'],
-  nonParticipation?: true,
+  nonParticipation?: boolean,
   stateProofKey?: undefined
 ): txnBuilder.Transaction;
 export function makeKeyRegistrationTxnWithSuggestedParams(


### PR DESCRIPTION
Fixes a bug in the typing that would make the user think they need to set nonParticipation to `true`. 

Also removed `nonParticipation: true` from the example file.

# Current behavior

```ts
  algosdk.makeKeyRegistrationTxnWithSuggestedParams(
    addr,
    undefined,
    undefined,
    undefined,
    undefined,
    undefined,
    undefined,
    suggestedParams,
    undefined,
    false,
    undefined
  )
```

```
No overload matches this call.
  Overload 1 of 2, '(from: string, note: Uint8Array | undefined, voteKey: string | Uint8Array, selectionKey: string | Uint8Array, voteFirst: number, voteLast: number, voteKeyDilution: number, suggestedParams: SuggestedParams, rekeyTo?: string | undefined, nonParticipation?: false | undefined, stateProofKey?: string | ... 1 more ... | undefined): Transaction', gave the following error.
    Argument of type 'undefined' is not assignable to parameter of type 'string | Uint8Array'.
  Overload 2 of 2, '(from: string, note: Uint8Array | undefined, voteKey: undefined, selectionKey: undefined, voteFirst: undefined, voteLast: undefined, voteKeyDilution: undefined, suggestedParams: SuggestedParams, rekeyTo?: string | undefined, nonParticipation?: true | undefined, stateProofKey?: undefined): Transaction', gave the following error.
    Argument of type 'false' is not assignable to parameter of type 'true'.ts(2769)
makeTxn.ts(141, 17): The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
```

# New Behavior 

```ts
  algosdk.makeKeyRegistrationTxnWithSuggestedParams(
    addr,
    undefined,
    undefined,
    undefined,
    undefined,
    undefined,
    undefined,
    suggestedParams,
    undefined,
    false,
    undefined
  )
```

No error displayed