### PR TITLE
readonly field on ABIMethodParams

### DIFF
--- a/src/abi/method.ts
+++ b/src/abi/method.ts
@@ -59,6 +59,7 @@ export interface ABIMethodReturnParams {
 export interface ABIMethodParams {
   name: string;
   desc?: string;
+  readonly?: boolean;
   args: ABIMethodArgParams[];
   returns: ABIMethodReturnParams;
 }


### PR DESCRIPTION
generated client throws error on every readonly method with missing readonly field on ABIMethodParams