### PR TITLE
REST API TEAL bytes fix

### DIFF
--- a/examples/app.ts
+++ b/examples/app.ts
@@ -121,7 +121,7 @@ async function main() {
     sender: caller.addr,
     suggestedParams,
     appIndex: appId,
-    appArgs: [new TextEncoder().encode(now)],
+    appArgs: [algosdk.coerceToBytes(now)],
   });
 
   await algodClient
@@ -140,9 +140,9 @@ async function main() {
     `Raw global state - ${globalState.map((kv) => algosdk.encodeJSON(kv))}`
   );
 
-  const globalKey = algosdk.base64ToBytes(globalState[0].key);
+  const globalKey = globalState[0].key;
   // show global value
-  const globalValue = algosdk.base64ToBytes(globalState[0].value.bytes);
+  const globalValue = globalState[0].value.bytes;
 
   console.log(
     `Decoded global state - ${algosdk.bytesToBase64(globalKey)}: ${algosdk.bytesToBase64(globalValue)}`
@@ -163,7 +163,7 @@ async function main() {
     `Raw local state - ${localState.map((kv) => algosdk.encodeJSON(kv))}`
   );
 
-  const localKey = algosdk.base64ToBytes(localState[0].key);
+  const localKey = localState[0].key;
   // get uint value directly
   const localValue = localState[0].value.uint;
 

--- a/examples/atc.ts
+++ b/examples/atc.ts
@@ -98,7 +98,7 @@ async function main() {
 
   // example: ATC_BOX_REF
   const boxATC = new algosdk.AtomicTransactionComposer();
-  const boxKey = new TextEncoder().encode('key');
+  const boxKey = algosdk.coerceToBytes('key');
   boxATC.addMethodCall({
     appID: appIndex,
     method: boxAccessorMethod,

--- a/examples/indexer.ts
+++ b/examples/indexer.ts
@@ -68,7 +68,7 @@ async function main() {
     sender: sender.addr,
     receiver: sender.addr,
     amount: 1e6,
-    note: new TextEncoder().encode('Hello World!'),
+    note: algosdk.coerceToBytes('Hello World!'),
     suggestedParams,
   });
 
@@ -81,13 +81,12 @@ async function main() {
   // example: INDEXER_PREFIX_SEARCH
   const txnsWithNotePrefix = await indexerClient
     .searchForTransactions()
-    .notePrefix(new TextEncoder().encode('Hello'))
+    .notePrefix(algosdk.coerceToBytes('Hello'))
     .do();
   console.log(
-    `Transactions with note prefix "Hello" ${algosdk.stringifyJSON(
+    `Transactions with note prefix "Hello" ${algosdk.encodeJSON(
       txnsWithNotePrefix,
-      undefined,
-      2
+      { space: 2 }
     )}`
   );
   // example: INDEXER_PREFIX_SEARCH

--- a/examples/lsig.ts
+++ b/examples/lsig.ts
@@ -13,9 +13,7 @@ async function main() {
 
   // example: LSIG_COMPILE
   const smartSigSource = '#pragma version 8\nint 1\nreturn'; // approve everything
-  const result = await client
-    .compile(new TextEncoder().encode(smartSigSource))
-    .do();
+  const result = await client.compile(smartSigSource).do();
 
   // Hash is equivalent to the contract address
   console.log('Hash: ', result.hash);
@@ -28,7 +26,7 @@ async function main() {
   // example: LSIG_INIT
 
   // example: LSIG_PASS_ARGS
-  const args = [new TextEncoder().encode('This is an argument!')];
+  const args = [algosdk.coerceToBytes('This is an argument!')];
   smartSig = new algosdk.LogicSig(algosdk.base64ToBytes(b64program), args);
   // example: LSIG_PASS_ARGS
 

--- a/examples/overview.ts
+++ b/examples/overview.ts
@@ -26,7 +26,7 @@ async function main() {
     suggestedParams,
     receiver: acct2.addr,
     amount: 10000,
-    note: new TextEncoder().encode('hello world'),
+    note: algosdk.coerceToBytes('hello world'),
   });
   // example: TRANSACTION_PAYMENT_CREATE
 

--- a/examples/utils.ts
+++ b/examples/utils.ts
@@ -6,9 +6,7 @@ export async function compileProgram(
   client: algosdk.Algodv2,
   programSource: string
 ) {
-  const compileResponse = await client
-    .compile(new TextEncoder().encode(programSource))
-    .do();
+  const compileResponse = await client.compile(programSource).do();
   const compiledBytes = algosdk.base64ToBytes(compileResponse.result);
   return compiledBytes;
 }

--- a/src/client/v2/algod/models/types.ts
+++ b/src/client/v2/algod/models/types.ts
@@ -558,7 +558,7 @@ export class Account implements Encodable {
 
   static fromEncodingData(data: unknown): Account {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded Account: ${data}`);
     }
     return new Account({
       address: data.get('address'),
@@ -715,7 +715,7 @@ export class AccountApplicationResponse implements Encodable {
 
   static fromEncodingData(data: unknown): AccountApplicationResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded AccountApplicationResponse: ${data}`);
     }
     return new AccountApplicationResponse({
       round: data.get('round'),
@@ -806,7 +806,7 @@ export class AccountAssetHolding implements Encodable {
 
   static fromEncodingData(data: unknown): AccountAssetHolding {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded AccountAssetHolding: ${data}`);
     }
     return new AccountAssetHolding({
       assetHolding: AssetHolding.fromEncodingData(
@@ -912,7 +912,7 @@ export class AccountAssetResponse implements Encodable {
 
   static fromEncodingData(data: unknown): AccountAssetResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded AccountAssetResponse: ${data}`);
     }
     return new AccountAssetResponse({
       round: data.get('round'),
@@ -1010,7 +1010,9 @@ export class AccountAssetsInformationResponse implements Encodable {
 
   static fromEncodingData(data: unknown): AccountAssetsInformationResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(
+        `Invalid decoded AccountAssetsInformationResponse: ${data}`
+      );
     }
     return new AccountAssetsInformationResponse({
       round: data.get('round'),
@@ -1162,7 +1164,7 @@ export class AccountParticipation implements Encodable {
 
   static fromEncodingData(data: unknown): AccountParticipation {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded AccountParticipation: ${data}`);
     }
     return new AccountParticipation({
       selectionParticipationKey: data.get('selection-participation-key'),
@@ -1233,7 +1235,7 @@ export class AccountStateDelta implements Encodable {
 
   static fromEncodingData(data: unknown): AccountStateDelta {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded AccountStateDelta: ${data}`);
     }
     return new AccountStateDelta({
       address: data.get('address'),
@@ -1321,7 +1323,7 @@ export class AppCallLogs implements Encodable {
 
   static fromEncodingData(data: unknown): AppCallLogs {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded AppCallLogs: ${data}`);
     }
     return new AppCallLogs({
       applicationIndex: data.get('application-index'),
@@ -1392,7 +1394,7 @@ export class Application implements Encodable {
 
   static fromEncodingData(data: unknown): Application {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded Application: ${data}`);
     }
     return new Application({
       id: data.get('id'),
@@ -1512,7 +1514,7 @@ export class ApplicationInitialStates implements Encodable {
 
   static fromEncodingData(data: unknown): ApplicationInitialStates {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded ApplicationInitialStates: ${data}`);
     }
     return new ApplicationInitialStates({
       id: data.get('id'),
@@ -1605,7 +1607,7 @@ export class ApplicationKVStorage implements Encodable {
 
   static fromEncodingData(data: unknown): ApplicationKVStorage {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded ApplicationKVStorage: ${data}`);
     }
     return new ApplicationKVStorage({
       kvs: (data.get('kvs') ?? []).map((v: unknown) =>
@@ -1674,7 +1676,7 @@ export class ApplicationLocalReference implements Encodable {
 
   static fromEncodingData(data: unknown): ApplicationLocalReference {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded ApplicationLocalReference: ${data}`);
     }
     return new ApplicationLocalReference({
       account: data.get('account'),
@@ -1766,7 +1768,7 @@ export class ApplicationLocalState implements Encodable {
 
   static fromEncodingData(data: unknown): ApplicationLocalState {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded ApplicationLocalState: ${data}`);
     }
     return new ApplicationLocalState({
       id: data.get('id'),
@@ -1952,7 +1954,7 @@ export class ApplicationParams implements Encodable {
 
   static fromEncodingData(data: unknown): ApplicationParams {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded ApplicationParams: ${data}`);
     }
     return new ApplicationParams({
       approvalProgram: data.get('approval-program'),
@@ -2098,7 +2100,7 @@ export class ApplicationStateOperation implements Encodable {
 
   static fromEncodingData(data: unknown): ApplicationStateOperation {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded ApplicationStateOperation: ${data}`);
     }
     return new ApplicationStateOperation({
       appStateType: data.get('app-state-type'),
@@ -2174,7 +2176,7 @@ export class ApplicationStateSchema implements Encodable {
 
   static fromEncodingData(data: unknown): ApplicationStateSchema {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded ApplicationStateSchema: ${data}`);
     }
     return new ApplicationStateSchema({
       numByteSlice: data.get('num-byte-slice'),
@@ -2250,7 +2252,7 @@ export class Asset implements Encodable {
 
   static fromEncodingData(data: unknown): Asset {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded Asset: ${data}`);
     }
     return new Asset({
       index: data.get('index'),
@@ -2329,7 +2331,7 @@ export class AssetHolding implements Encodable {
 
   static fromEncodingData(data: unknown): AssetHolding {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded AssetHolding: ${data}`);
     }
     return new AssetHolding({
       amount: data.get('amount'),
@@ -2397,7 +2399,7 @@ export class AssetHoldingReference implements Encodable {
 
   static fromEncodingData(data: unknown): AssetHoldingReference {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded AssetHoldingReference: ${data}`);
     }
     return new AssetHoldingReference({
       account: data.get('account'),
@@ -2686,7 +2688,7 @@ export class AssetParams implements Encodable {
 
   static fromEncodingData(data: unknown): AssetParams {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded AssetParams: ${data}`);
     }
     return new AssetParams({
       creator: data.get('creator'),
@@ -2756,7 +2758,7 @@ export class AvmKeyValue implements Encodable {
 
   static fromEncodingData(data: unknown): AvmKeyValue {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded AvmKeyValue: ${data}`);
     }
     return new AvmKeyValue({
       key: data.get('key'),
@@ -2841,7 +2843,7 @@ export class AvmValue implements Encodable {
 
   static fromEncodingData(data: unknown): AvmValue {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded AvmValue: ${data}`);
     }
     return new AvmValue({
       type: data.get('type'),
@@ -2893,7 +2895,7 @@ export class BlockHashResponse implements Encodable {
 
   static fromEncodingData(data: unknown): BlockHashResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded BlockHashResponse: ${data}`);
     }
     return new BlockHashResponse({
       blockhash: data.get('blockHash'),
@@ -2948,7 +2950,7 @@ export class BlockLogsResponse implements Encodable {
 
   static fromEncodingData(data: unknown): BlockLogsResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded BlockLogsResponse: ${data}`);
     }
     return new BlockLogsResponse({
       logs: (data.get('logs') ?? []).map((v: unknown) =>
@@ -3020,7 +3022,7 @@ export class BlockResponse implements Encodable {
 
   static fromEncodingData(data: unknown): BlockResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded BlockResponse: ${data}`);
     }
     return new BlockResponse({
       block: Block.fromEncodingData(data.get('block') ?? new Map()),
@@ -3074,7 +3076,7 @@ export class BlockTxidsResponse implements Encodable {
 
   static fromEncodingData(data: unknown): BlockTxidsResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded BlockTxidsResponse: ${data}`);
     }
     return new BlockTxidsResponse({
       blocktxids: data.get('blockTxids'),
@@ -3150,7 +3152,7 @@ export class Box implements Encodable {
 
   static fromEncodingData(data: unknown): Box {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded Box: ${data}`);
     }
     return new Box({
       name: data.get('name'),
@@ -3202,7 +3204,7 @@ export class BoxDescriptor implements Encodable {
 
   static fromEncodingData(data: unknown): BoxDescriptor {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded BoxDescriptor: ${data}`);
     }
     return new BoxDescriptor({
       name: data.get('name'),
@@ -3267,7 +3269,7 @@ export class BoxReference implements Encodable {
 
   static fromEncodingData(data: unknown): BoxReference {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded BoxReference: ${data}`);
     }
     return new BoxReference({
       app: data.get('app'),
@@ -3317,7 +3319,7 @@ export class BoxesResponse implements Encodable {
 
   static fromEncodingData(data: unknown): BoxesResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded BoxesResponse: ${data}`);
     }
     return new BoxesResponse({
       boxes: (data.get('boxes') ?? []).map((v: unknown) =>
@@ -3415,7 +3417,7 @@ export class BuildVersion implements Encodable {
 
   static fromEncodingData(data: unknown): BuildVersion {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded BuildVersion: ${data}`);
     }
     return new BuildVersion({
       branch: data.get('branch'),
@@ -3505,7 +3507,7 @@ export class CompileResponse implements Encodable {
 
   static fromEncodingData(data: unknown): CompileResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded CompileResponse: ${data}`);
     }
     return new CompileResponse({
       hash: data.get('hash'),
@@ -3560,7 +3562,7 @@ export class DisassembleResponse implements Encodable {
 
   static fromEncodingData(data: unknown): DisassembleResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded DisassembleResponse: ${data}`);
     }
     return new DisassembleResponse({
       result: data.get('result'),
@@ -3699,7 +3701,7 @@ export class DryrunRequest implements Encodable {
 
   static fromEncodingData(data: unknown): DryrunRequest {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded DryrunRequest: ${data}`);
     }
     return new DryrunRequest({
       accounts: (data.get('accounts') ?? []).map((v: unknown) =>
@@ -3791,7 +3793,7 @@ export class DryrunResponse implements Encodable {
 
   static fromEncodingData(data: unknown): DryrunResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded DryrunResponse: ${data}`);
     }
     return new DryrunResponse({
       error: data.get('error'),
@@ -3878,7 +3880,7 @@ export class DryrunSource implements Encodable {
 
   static fromEncodingData(data: unknown): DryrunSource {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded DryrunSource: ${data}`);
     }
     return new DryrunSource({
       appIndex: data.get('app-index'),
@@ -3992,7 +3994,7 @@ export class DryrunState implements Encodable {
 
   static fromEncodingData(data: unknown): DryrunState {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded DryrunState: ${data}`);
     }
     return new DryrunState({
       line: data.get('line'),
@@ -4230,7 +4232,7 @@ export class DryrunTxnResult implements Encodable {
 
   static fromEncodingData(data: unknown): DryrunTxnResult {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded DryrunTxnResult: ${data}`);
     }
     return new DryrunTxnResult({
       disassembly: data.get('disassembly'),
@@ -4322,7 +4324,7 @@ export class ErrorResponse implements Encodable {
 
   static fromEncodingData(data: unknown): ErrorResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded ErrorResponse: ${data}`);
     }
     return new ErrorResponse({
       message: data.get('message'),
@@ -4410,7 +4412,7 @@ export class EvalDelta implements Encodable {
 
   static fromEncodingData(data: unknown): EvalDelta {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded EvalDelta: ${data}`);
     }
     return new EvalDelta({
       action: data.get('action'),
@@ -4468,7 +4470,7 @@ export class EvalDeltaKeyValue implements Encodable {
 
   static fromEncodingData(data: unknown): EvalDeltaKeyValue {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded EvalDeltaKeyValue: ${data}`);
     }
     return new EvalDeltaKeyValue({
       key: data.get('key'),
@@ -4519,7 +4521,9 @@ export class GetBlockTimeStampOffsetResponse implements Encodable {
 
   static fromEncodingData(data: unknown): GetBlockTimeStampOffsetResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(
+        `Invalid decoded GetBlockTimeStampOffsetResponse: ${data}`
+      );
     }
     return new GetBlockTimeStampOffsetResponse({
       offset: data.get('offset'),
@@ -4569,7 +4573,7 @@ export class GetSyncRoundResponse implements Encodable {
 
   static fromEncodingData(data: unknown): GetSyncRoundResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded GetSyncRoundResponse: ${data}`);
     }
     return new GetSyncRoundResponse({
       round: data.get('round'),
@@ -4643,7 +4647,7 @@ export class KvDelta implements Encodable {
 
   static fromEncodingData(data: unknown): KvDelta {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded KvDelta: ${data}`);
     }
     return new KvDelta({
       key: data.get('key'),
@@ -4708,7 +4712,9 @@ export class LedgerStateDeltaForTransactionGroup implements Encodable {
 
   static fromEncodingData(data: unknown): LedgerStateDeltaForTransactionGroup {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(
+        `Invalid decoded LedgerStateDeltaForTransactionGroup: ${data}`
+      );
     }
     return new LedgerStateDeltaForTransactionGroup({
       delta: UntypedValue.fromEncodingData(data.get('Delta') ?? new Map()),
@@ -4787,7 +4793,7 @@ export class LightBlockHeaderProof implements Encodable {
 
   static fromEncodingData(data: unknown): LightBlockHeaderProof {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded LightBlockHeaderProof: ${data}`);
     }
     return new LightBlockHeaderProof({
       index: data.get('index'),
@@ -5279,7 +5285,7 @@ export class NodeStatusResponse implements Encodable {
 
   static fromEncodingData(data: unknown): NodeStatusResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded NodeStatusResponse: ${data}`);
     }
     return new NodeStatusResponse({
       catchupTime: data.get('catchup-time'),
@@ -5611,7 +5617,7 @@ export class PendingTransactionResponse implements Encodable {
 
   static fromEncodingData(data: unknown): PendingTransactionResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded PendingTransactionResponse: ${data}`);
     }
     return new PendingTransactionResponse({
       poolError: data.get('pool-error'),
@@ -5716,7 +5722,7 @@ export class PendingTransactionsResponse implements Encodable {
 
   static fromEncodingData(data: unknown): PendingTransactionsResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded PendingTransactionsResponse: ${data}`);
     }
     return new PendingTransactionsResponse({
       topTransactions: (data.get('top-transactions') ?? []).map((v: unknown) =>
@@ -5769,7 +5775,7 @@ export class PostTransactionsResponse implements Encodable {
 
   static fromEncodingData(data: unknown): PostTransactionsResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded PostTransactionsResponse: ${data}`);
     }
     return new PostTransactionsResponse({
       txid: data.get('txId'),
@@ -5838,7 +5844,7 @@ export class ScratchChange implements Encodable {
 
   static fromEncodingData(data: unknown): ScratchChange {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded ScratchChange: ${data}`);
     }
     return new ScratchChange({
       newValue: AvmValue.fromEncodingData(data.get('new-value') ?? new Map()),
@@ -5904,7 +5910,7 @@ export class SimulateInitialStates implements Encodable {
 
   static fromEncodingData(data: unknown): SimulateInitialStates {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded SimulateInitialStates: ${data}`);
     }
     return new SimulateInitialStates({
       appInitialStates:
@@ -5960,6 +5966,11 @@ export class SimulateRequest implements Encodable {
           omitEmpty: true,
         },
         {
+          key: 'fix-signers',
+          valueSchema: new OptionalSchema(new BooleanSchema()),
+          omitEmpty: true,
+        },
+        {
           key: 'round',
           valueSchema: new OptionalSchema(new Uint64Schema()),
           omitEmpty: true,
@@ -6001,6 +6012,12 @@ export class SimulateRequest implements Encodable {
   public extraOpcodeBudget?: number;
 
   /**
+   * If true, signers for transactions that are missing signatures will be fixed
+   * during evaluation.
+   */
+  public fixSigners?: boolean;
+
+  /**
    * If provided, specifies the round preceding the simulation. State changes through
    * this round will be used to run this simulation. Usually only the 4 most recent
    * rounds will be available (controlled by the node config value MaxAcctLookback).
@@ -6017,6 +6034,8 @@ export class SimulateRequest implements Encodable {
    * @param allowUnnamedResources - Allows access to unnamed resources during simulation.
    * @param execTraceConfig - An object that configures simulation execution trace.
    * @param extraOpcodeBudget - Applies extra opcode budget during simulation for each transaction group.
+   * @param fixSigners - If true, signers for transactions that are missing signatures will be fixed
+   * during evaluation.
    * @param round - If provided, specifies the round preceding the simulation. State changes through
    * this round will be used to run this simulation. Usually only the 4 most recent
    * rounds will be available (controlled by the node config value MaxAcctLookback).
@@ -6029,6 +6048,7 @@ export class SimulateRequest implements Encodable {
     allowUnnamedResources,
     execTraceConfig,
     extraOpcodeBudget,
+    fixSigners,
     round,
   }: {
     txnGroups: SimulateRequestTransactionGroup[];
@@ -6037,6 +6057,7 @@ export class SimulateRequest implements Encodable {
     allowUnnamedResources?: boolean;
     execTraceConfig?: SimulateTraceConfig;
     extraOpcodeBudget?: number | bigint;
+    fixSigners?: boolean;
     round?: number | bigint;
   }) {
     this.txnGroups = txnGroups;
@@ -6048,6 +6069,7 @@ export class SimulateRequest implements Encodable {
       typeof extraOpcodeBudget === 'undefined'
         ? undefined
         : ensureSafeInteger(extraOpcodeBudget);
+    this.fixSigners = fixSigners;
     this.round = typeof round === 'undefined' ? undefined : ensureBigInt(round);
   }
 
@@ -6069,13 +6091,14 @@ export class SimulateRequest implements Encodable {
           : undefined,
       ],
       ['extra-opcode-budget', this.extraOpcodeBudget],
+      ['fix-signers', this.fixSigners],
       ['round', this.round],
     ]);
   }
 
   static fromEncodingData(data: unknown): SimulateRequest {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded SimulateRequest: ${data}`);
     }
     return new SimulateRequest({
       txnGroups: (data.get('txn-groups') ?? []).map((v: unknown) =>
@@ -6089,6 +6112,7 @@ export class SimulateRequest implements Encodable {
           ? SimulateTraceConfig.fromEncodingData(data.get('exec-trace-config'))
           : undefined,
       extraOpcodeBudget: data.get('extra-opcode-budget'),
+      fixSigners: data.get('fix-signers'),
       round: data.get('round'),
     });
   }
@@ -6138,7 +6162,9 @@ export class SimulateRequestTransactionGroup implements Encodable {
 
   static fromEncodingData(data: unknown): SimulateRequestTransactionGroup {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(
+        `Invalid decoded SimulateRequestTransactionGroup: ${data}`
+      );
     }
     return new SimulateRequestTransactionGroup({
       txns: (data.get('txns') ?? []).map((v: unknown) =>
@@ -6290,7 +6316,7 @@ export class SimulateResponse implements Encodable {
 
   static fromEncodingData(data: unknown): SimulateResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded SimulateResponse: ${data}`);
     }
     return new SimulateResponse({
       lastRound: data.get('last-round'),
@@ -6415,7 +6441,7 @@ export class SimulateTraceConfig implements Encodable {
 
   static fromEncodingData(data: unknown): SimulateTraceConfig {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded SimulateTraceConfig: ${data}`);
     }
     return new SimulateTraceConfig({
       enable: data.get('enable'),
@@ -6593,7 +6619,9 @@ export class SimulateTransactionGroupResult implements Encodable {
 
   static fromEncodingData(data: unknown): SimulateTransactionGroupResult {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(
+        `Invalid decoded SimulateTransactionGroupResult: ${data}`
+      );
     }
     return new SimulateTransactionGroupResult({
       txnResults: (data.get('txn-results') ?? []).map((v: unknown) =>
@@ -6641,6 +6669,11 @@ export class SimulateTransactionResult implements Encodable {
           omitEmpty: true,
         },
         {
+          key: 'fixed-signer',
+          valueSchema: new OptionalSchema(new StringSchema()),
+          omitEmpty: true,
+        },
+        {
           key: 'logic-sig-budget-consumed',
           valueSchema: new OptionalSchema(new Uint64Schema()),
           omitEmpty: true,
@@ -6676,6 +6709,12 @@ export class SimulateTransactionResult implements Encodable {
   public execTrace?: SimulationTransactionExecTrace;
 
   /**
+   * The account that needed to sign this transaction when no signature was provided
+   * and the provided signer was incorrect.
+   */
+  public fixedSigner?: Address;
+
+  /**
    * Budget used during execution of a logic sig transaction.
    */
   public logicSigBudgetConsumed?: number;
@@ -6701,6 +6740,8 @@ export class SimulateTransactionResult implements Encodable {
    * budged used by inner app calls spawned by this transaction.
    * @param execTrace - The execution trace of calling an app or a logic sig, containing the inner app
    * call trace in a recursive way.
+   * @param fixedSigner - The account that needed to sign this transaction when no signature was provided
+   * and the provided signer was incorrect.
    * @param logicSigBudgetConsumed - Budget used during execution of a logic sig transaction.
    * @param unnamedResourcesAccessed - These are resources that were accessed by this group that would normally have
    * caused failure, but were allowed in simulation. Depending on where this object
@@ -6716,12 +6757,14 @@ export class SimulateTransactionResult implements Encodable {
     txnResult,
     appBudgetConsumed,
     execTrace,
+    fixedSigner,
     logicSigBudgetConsumed,
     unnamedResourcesAccessed,
   }: {
     txnResult: PendingTransactionResponse;
     appBudgetConsumed?: number | bigint;
     execTrace?: SimulationTransactionExecTrace;
+    fixedSigner?: Address | string;
     logicSigBudgetConsumed?: number | bigint;
     unnamedResourcesAccessed?: SimulateUnnamedResourcesAccessed;
   }) {
@@ -6731,6 +6774,10 @@ export class SimulateTransactionResult implements Encodable {
         ? undefined
         : ensureSafeInteger(appBudgetConsumed);
     this.execTrace = execTrace;
+    this.fixedSigner =
+      typeof fixedSigner === 'string'
+        ? Address.fromString(fixedSigner)
+        : fixedSigner;
     this.logicSigBudgetConsumed =
       typeof logicSigBudgetConsumed === 'undefined'
         ? undefined
@@ -6753,6 +6800,12 @@ export class SimulateTransactionResult implements Encodable {
           ? this.execTrace.toEncodingData()
           : undefined,
       ],
+      [
+        'fixed-signer',
+        typeof this.fixedSigner !== 'undefined'
+          ? this.fixedSigner.toString()
+          : undefined,
+      ],
       ['logic-sig-budget-consumed', this.logicSigBudgetConsumed],
       [
         'unnamed-resources-accessed',
@@ -6765,7 +6818,7 @@ export class SimulateTransactionResult implements Encodable {
 
   static fromEncodingData(data: unknown): SimulateTransactionResult {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded SimulateTransactionResult: ${data}`);
     }
     return new SimulateTransactionResult({
       txnResult: PendingTransactionResponse.fromEncodingData(
@@ -6778,6 +6831,7 @@ export class SimulateTransactionResult implements Encodable {
               data.get('exec-trace')
             )
           : undefined,
+      fixedSigner: data.get('fixed-signer'),
       logicSigBudgetConsumed: data.get('logic-sig-budget-consumed'),
       unnamedResourcesAccessed:
         typeof data.get('unnamed-resources-accessed') !== 'undefined'
@@ -6983,7 +7037,9 @@ export class SimulateUnnamedResourcesAccessed implements Encodable {
 
   static fromEncodingData(data: unknown): SimulateUnnamedResourcesAccessed {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(
+        `Invalid decoded SimulateUnnamedResourcesAccessed: ${data}`
+      );
     }
     return new SimulateUnnamedResourcesAccessed({
       accounts: data.get('accounts'),
@@ -7042,6 +7098,11 @@ export class SimulationEvalOverrides implements Encodable {
           omitEmpty: true,
         },
         {
+          key: 'fix-signers',
+          valueSchema: new OptionalSchema(new BooleanSchema()),
+          omitEmpty: true,
+        },
+        {
           key: 'max-log-calls',
           valueSchema: new OptionalSchema(new Uint64Schema()),
           omitEmpty: true,
@@ -7073,6 +7134,12 @@ export class SimulationEvalOverrides implements Encodable {
   public extraOpcodeBudget?: number;
 
   /**
+   * If true, signers for transactions that are missing signatures will be fixed
+   * during evaluation.
+   */
+  public fixSigners?: boolean;
+
+  /**
    * The maximum log calls one can make during simulation
    */
   public maxLogCalls?: number;
@@ -7088,6 +7155,8 @@ export class SimulationEvalOverrides implements Encodable {
    * were properly signed.
    * @param allowUnnamedResources - If true, allows access to unnamed resources during simulation.
    * @param extraOpcodeBudget - The extra opcode budget added to each transaction group during simulation
+   * @param fixSigners - If true, signers for transactions that are missing signatures will be fixed
+   * during evaluation.
    * @param maxLogCalls - The maximum log calls one can make during simulation
    * @param maxLogSize - The maximum byte number to log during simulation
    */
@@ -7095,12 +7164,14 @@ export class SimulationEvalOverrides implements Encodable {
     allowEmptySignatures,
     allowUnnamedResources,
     extraOpcodeBudget,
+    fixSigners,
     maxLogCalls,
     maxLogSize,
   }: {
     allowEmptySignatures?: boolean;
     allowUnnamedResources?: boolean;
     extraOpcodeBudget?: number | bigint;
+    fixSigners?: boolean;
     maxLogCalls?: number | bigint;
     maxLogSize?: number | bigint;
   }) {
@@ -7110,6 +7181,7 @@ export class SimulationEvalOverrides implements Encodable {
       typeof extraOpcodeBudget === 'undefined'
         ? undefined
         : ensureSafeInteger(extraOpcodeBudget);
+    this.fixSigners = fixSigners;
     this.maxLogCalls =
       typeof maxLogCalls === 'undefined'
         ? undefined
@@ -7130,6 +7202,7 @@ export class SimulationEvalOverrides implements Encodable {
       ['allow-empty-signatures', this.allowEmptySignatures],
       ['allow-unnamed-resources', this.allowUnnamedResources],
       ['extra-opcode-budget', this.extraOpcodeBudget],
+      ['fix-signers', this.fixSigners],
       ['max-log-calls', this.maxLogCalls],
       ['max-log-size', this.maxLogSize],
     ]);
@@ -7137,12 +7210,13 @@ export class SimulationEvalOverrides implements Encodable {
 
   static fromEncodingData(data: unknown): SimulationEvalOverrides {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded SimulationEvalOverrides: ${data}`);
     }
     return new SimulationEvalOverrides({
       allowEmptySignatures: data.get('allow-empty-signatures'),
       allowUnnamedResources: data.get('allow-unnamed-resources'),
       extraOpcodeBudget: data.get('extra-opcode-budget'),
+      fixSigners: data.get('fix-signers'),
       maxLogCalls: data.get('max-log-calls'),
       maxLogSize: data.get('max-log-size'),
     });
@@ -7297,7 +7371,7 @@ export class SimulationOpcodeTraceUnit implements Encodable {
 
   static fromEncodingData(data: unknown): SimulationOpcodeTraceUnit {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded SimulationOpcodeTraceUnit: ${data}`);
     }
     return new SimulationOpcodeTraceUnit({
       pc: data.get('pc'),
@@ -7543,7 +7617,9 @@ export class SimulationTransactionExecTrace implements Encodable {
 
   static fromEncodingData(data: unknown): SimulationTransactionExecTrace {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(
+        `Invalid decoded SimulationTransactionExecTrace: ${data}`
+      );
     }
     return new SimulationTransactionExecTrace({
       approvalProgramHash: data.get('approval-program-hash'),
@@ -7653,7 +7729,7 @@ export class StateProof implements Encodable {
 
   static fromEncodingData(data: unknown): StateProof {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded StateProof: ${data}`);
     }
     return new StateProof({
       message: StateProofMessage.fromEncodingData(
@@ -7784,7 +7860,7 @@ export class StateProofMessage implements Encodable {
 
   static fromEncodingData(data: unknown): StateProofMessage {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded StateProofMessage: ${data}`);
     }
     return new StateProofMessage({
       blockheaderscommitment: data.get('BlockHeadersCommitment'),
@@ -7872,7 +7948,7 @@ export class SupplyResponse implements Encodable {
 
   static fromEncodingData(data: unknown): SupplyResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded SupplyResponse: ${data}`);
     }
     return new SupplyResponse({
       currentRound: data.get('current_round'),
@@ -7892,14 +7968,14 @@ export class TealKeyValue implements Encodable {
     if (!this.encodingSchemaValue) {
       this.encodingSchemaValue = new NamedMapSchema([]);
       (this.encodingSchemaValue as NamedMapSchema).pushEntries(
-        { key: 'key', valueSchema: new StringSchema(), omitEmpty: true },
+        { key: 'key', valueSchema: new ByteArraySchema(), omitEmpty: true },
         { key: 'value', valueSchema: TealValue.encodingSchema, omitEmpty: true }
       );
     }
     return this.encodingSchemaValue;
   }
 
-  public key: string;
+  public key: Uint8Array;
 
   /**
    * Represents a TEAL value.
@@ -7911,8 +7987,8 @@ export class TealKeyValue implements Encodable {
    * @param key -
    * @param value - Represents a TEAL value.
    */
-  constructor({ key, value }: { key: string; value: TealValue }) {
-    this.key = key;
+  constructor({ key, value }: { key: string | Uint8Array; value: TealValue }) {
+    this.key = typeof key === 'string' ? base64ToBytes(key) : key;
     this.value = value;
   }
 
@@ -7930,7 +8006,7 @@ export class TealKeyValue implements Encodable {
 
   static fromEncodingData(data: unknown): TealKeyValue {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded TealKeyValue: ${data}`);
     }
     return new TealKeyValue({
       key: data.get('key'),
@@ -7949,7 +8025,7 @@ export class TealValue implements Encodable {
     if (!this.encodingSchemaValue) {
       this.encodingSchemaValue = new NamedMapSchema([]);
       (this.encodingSchemaValue as NamedMapSchema).pushEntries(
-        { key: 'bytes', valueSchema: new StringSchema(), omitEmpty: true },
+        { key: 'bytes', valueSchema: new ByteArraySchema(), omitEmpty: true },
         { key: 'type', valueSchema: new Uint64Schema(), omitEmpty: true },
         { key: 'uint', valueSchema: new Uint64Schema(), omitEmpty: true }
       );
@@ -7960,7 +8036,7 @@ export class TealValue implements Encodable {
   /**
    * (tb) bytes value.
    */
-  public bytes: string;
+  public bytes: Uint8Array;
 
   /**
    * (tt) value type. Value `1` refers to **bytes**, value `2` refers to **uint**
@@ -7983,11 +8059,11 @@ export class TealValue implements Encodable {
     type,
     uint,
   }: {
-    bytes: string;
+    bytes: string | Uint8Array;
     type: number | bigint;
     uint: number | bigint;
   }) {
-    this.bytes = bytes;
+    this.bytes = typeof bytes === 'string' ? base64ToBytes(bytes) : bytes;
     this.type = ensureSafeInteger(type);
     this.uint = ensureBigInt(uint);
   }
@@ -8007,7 +8083,7 @@ export class TealValue implements Encodable {
 
   static fromEncodingData(data: unknown): TealValue {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded TealValue: ${data}`);
     }
     return new TealValue({
       bytes: data.get('bytes'),
@@ -8065,7 +8141,9 @@ export class TransactionGroupLedgerStateDeltasForRoundResponse
     data: unknown
   ): TransactionGroupLedgerStateDeltasForRoundResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(
+        `Invalid decoded TransactionGroupLedgerStateDeltasForRoundResponse: ${data}`
+      );
     }
     return new TransactionGroupLedgerStateDeltasForRoundResponse({
       deltas: (data.get('Deltas') ?? []).map((v: unknown) =>
@@ -8198,7 +8276,7 @@ export class TransactionParametersResponse implements Encodable {
 
   static fromEncodingData(data: unknown): TransactionParametersResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded TransactionParametersResponse: ${data}`);
     }
     return new TransactionParametersResponse({
       consensusVersion: data.get('consensus-version'),
@@ -8316,7 +8394,7 @@ export class TransactionProofResponse implements Encodable {
 
   static fromEncodingData(data: unknown): TransactionProofResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded TransactionProofResponse: ${data}`);
     }
     return new TransactionProofResponse({
       idx: data.get('idx'),
@@ -8410,7 +8488,7 @@ export class Version implements Encodable {
 
   static fromEncodingData(data: unknown): Version {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded Version: ${data}`);
     }
     return new Version({
       build: BuildVersion.fromEncodingData(data.get('build') ?? new Map()),

--- a/src/client/v2/indexer/models/types.ts
+++ b/src/client/v2/indexer/models/types.ts
@@ -599,7 +599,7 @@ export class Account implements Encodable {
 
   static fromEncodingData(data: unknown): Account {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded Account: ${data}`);
     }
     return new Account({
       address: data.get('address'),
@@ -799,7 +799,7 @@ export class AccountParticipation implements Encodable {
 
   static fromEncodingData(data: unknown): AccountParticipation {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded AccountParticipation: ${data}`);
     }
     return new AccountParticipation({
       selectionParticipationKey: data.get('selection-participation-key'),
@@ -881,7 +881,7 @@ export class AccountResponse implements Encodable {
 
   static fromEncodingData(data: unknown): AccountResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded AccountResponse: ${data}`);
     }
     return new AccountResponse({
       account: Account.fromEncodingData(data.get('account') ?? new Map()),
@@ -948,7 +948,7 @@ export class AccountStateDelta implements Encodable {
 
   static fromEncodingData(data: unknown): AccountStateDelta {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded AccountStateDelta: ${data}`);
     }
     return new AccountStateDelta({
       address: data.get('address'),
@@ -1038,7 +1038,7 @@ export class AccountsResponse implements Encodable {
 
   static fromEncodingData(data: unknown): AccountsResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded AccountsResponse: ${data}`);
     }
     return new AccountsResponse({
       accounts: (data.get('accounts') ?? []).map((v: unknown) =>
@@ -1162,7 +1162,7 @@ export class Application implements Encodable {
 
   static fromEncodingData(data: unknown): Application {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded Application: ${data}`);
     }
     return new Application({
       id: data.get('id'),
@@ -1312,7 +1312,7 @@ export class ApplicationLocalState implements Encodable {
 
   static fromEncodingData(data: unknown): ApplicationLocalState {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded ApplicationLocalState: ${data}`);
     }
     return new ApplicationLocalState({
       id: data.get('id'),
@@ -1414,7 +1414,9 @@ export class ApplicationLocalStatesResponse implements Encodable {
 
   static fromEncodingData(data: unknown): ApplicationLocalStatesResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(
+        `Invalid decoded ApplicationLocalStatesResponse: ${data}`
+      );
     }
     return new ApplicationLocalStatesResponse({
       appsLocalStates: (data.get('apps-local-states') ?? []).map((v: unknown) =>
@@ -1481,7 +1483,7 @@ export class ApplicationLogData implements Encodable {
 
   static fromEncodingData(data: unknown): ApplicationLogData {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded ApplicationLogData: ${data}`);
     }
     return new ApplicationLogData({
       logs: data.get('logs'),
@@ -1591,7 +1593,7 @@ export class ApplicationLogsResponse implements Encodable {
 
   static fromEncodingData(data: unknown): ApplicationLogsResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded ApplicationLogsResponse: ${data}`);
     }
     return new ApplicationLogsResponse({
       applicationId: data.get('application-id'),
@@ -1785,7 +1787,7 @@ export class ApplicationParams implements Encodable {
 
   static fromEncodingData(data: unknown): ApplicationParams {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded ApplicationParams: ${data}`);
     }
     return new ApplicationParams({
       approvalProgram: data.get('approval-program'),
@@ -1884,7 +1886,7 @@ export class ApplicationResponse implements Encodable {
 
   static fromEncodingData(data: unknown): ApplicationResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded ApplicationResponse: ${data}`);
     }
     return new ApplicationResponse({
       currentRound: data.get('current-round'),
@@ -1957,7 +1959,7 @@ export class ApplicationStateSchema implements Encodable {
 
   static fromEncodingData(data: unknown): ApplicationStateSchema {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded ApplicationStateSchema: ${data}`);
     }
     return new ApplicationStateSchema({
       numByteSlice: data.get('num-byte-slice'),
@@ -2045,7 +2047,7 @@ export class ApplicationsResponse implements Encodable {
 
   static fromEncodingData(data: unknown): ApplicationsResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded ApplicationsResponse: ${data}`);
     }
     return new ApplicationsResponse({
       applications: (data.get('applications') ?? []).map((v: unknown) =>
@@ -2175,7 +2177,7 @@ export class Asset implements Encodable {
 
   static fromEncodingData(data: unknown): Asset {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded Asset: ${data}`);
     }
     return new Asset({
       index: data.get('index'),
@@ -2266,7 +2268,7 @@ export class AssetBalancesResponse implements Encodable {
 
   static fromEncodingData(data: unknown): AssetBalancesResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded AssetBalancesResponse: ${data}`);
     }
     return new AssetBalancesResponse({
       balances: (data.get('balances') ?? []).map((v: unknown) =>
@@ -2399,7 +2401,7 @@ export class AssetHolding implements Encodable {
 
   static fromEncodingData(data: unknown): AssetHolding {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded AssetHolding: ${data}`);
     }
     return new AssetHolding({
       amount: data.get('amount'),
@@ -2491,7 +2493,7 @@ export class AssetHoldingsResponse implements Encodable {
 
   static fromEncodingData(data: unknown): AssetHoldingsResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded AssetHoldingsResponse: ${data}`);
     }
     return new AssetHoldingsResponse({
       assets: (data.get('assets') ?? []).map((v: unknown) =>
@@ -2783,7 +2785,7 @@ export class AssetParams implements Encodable {
 
   static fromEncodingData(data: unknown): AssetParams {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded AssetParams: ${data}`);
     }
     return new AssetParams({
       creator: data.get('creator'),
@@ -2866,7 +2868,7 @@ export class AssetResponse implements Encodable {
 
   static fromEncodingData(data: unknown): AssetResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded AssetResponse: ${data}`);
     }
     return new AssetResponse({
       asset: Asset.fromEncodingData(data.get('asset') ?? new Map()),
@@ -2954,7 +2956,7 @@ export class AssetsResponse implements Encodable {
 
   static fromEncodingData(data: unknown): AssetsResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded AssetsResponse: ${data}`);
     }
     return new AssetsResponse({
       assets: (data.get('assets') ?? []).map((v: unknown) =>
@@ -3358,7 +3360,7 @@ export class Block implements Encodable {
 
   static fromEncodingData(data: unknown): Block {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded Block: ${data}`);
     }
     return new Block({
       genesisHash: data.get('genesis-hash'),
@@ -3539,7 +3541,7 @@ export class BlockRewards implements Encodable {
 
   static fromEncodingData(data: unknown): BlockRewards {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded BlockRewards: ${data}`);
     }
     return new BlockRewards({
       feeSink: data.get('fee-sink'),
@@ -3673,7 +3675,7 @@ export class BlockUpgradeState implements Encodable {
 
   static fromEncodingData(data: unknown): BlockUpgradeState {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded BlockUpgradeState: ${data}`);
     }
     return new BlockUpgradeState({
       currentProtocol: data.get('current-protocol'),
@@ -3768,7 +3770,7 @@ export class BlockUpgradeVote implements Encodable {
 
   static fromEncodingData(data: unknown): BlockUpgradeVote {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded BlockUpgradeVote: ${data}`);
     }
     return new BlockUpgradeVote({
       upgradeApprove: data.get('upgrade-approve'),
@@ -3846,7 +3848,7 @@ export class Box implements Encodable {
 
   static fromEncodingData(data: unknown): Box {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded Box: ${data}`);
     }
     return new Box({
       name: data.get('name'),
@@ -3898,7 +3900,7 @@ export class BoxDescriptor implements Encodable {
 
   static fromEncodingData(data: unknown): BoxDescriptor {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded BoxDescriptor: ${data}`);
     }
     return new BoxDescriptor({
       name: data.get('name'),
@@ -3985,7 +3987,7 @@ export class BoxesResponse implements Encodable {
 
   static fromEncodingData(data: unknown): BoxesResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded BoxesResponse: ${data}`);
     }
     return new BoxesResponse({
       applicationId: data.get('application-id'),
@@ -4051,7 +4053,7 @@ export class ErrorResponse implements Encodable {
 
   static fromEncodingData(data: unknown): ErrorResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded ErrorResponse: ${data}`);
     }
     return new ErrorResponse({
       message: data.get('message'),
@@ -4139,7 +4141,7 @@ export class EvalDelta implements Encodable {
 
   static fromEncodingData(data: unknown): EvalDelta {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded EvalDelta: ${data}`);
     }
     return new EvalDelta({
       action: data.get('action'),
@@ -4197,7 +4199,7 @@ export class EvalDeltaKeyValue implements Encodable {
 
   static fromEncodingData(data: unknown): EvalDeltaKeyValue {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded EvalDeltaKeyValue: ${data}`);
     }
     return new EvalDeltaKeyValue({
       key: data.get('key'),
@@ -4246,7 +4248,7 @@ export class HashFactory implements Encodable {
 
   static fromEncodingData(data: unknown): HashFactory {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded HashFactory: ${data}`);
     }
     return new HashFactory({
       hashType: data.get('hash-type'),
@@ -4369,7 +4371,7 @@ export class HealthCheck implements Encodable {
 
   static fromEncodingData(data: unknown): HealthCheck {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded HealthCheck: ${data}`);
     }
     return new HealthCheck({
       dbAvailable: data.get('db-available'),
@@ -4508,7 +4510,7 @@ export class IndexerStateProofMessage implements Encodable {
 
   static fromEncodingData(data: unknown): IndexerStateProofMessage {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded IndexerStateProofMessage: ${data}`);
     }
     return new IndexerStateProofMessage({
       blockHeadersCommitment: data.get('block-headers-commitment'),
@@ -4604,7 +4606,7 @@ export class MerkleArrayProof implements Encodable {
 
   static fromEncodingData(data: unknown): MerkleArrayProof {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded MerkleArrayProof: ${data}`);
     }
     return new MerkleArrayProof({
       hashFactory:
@@ -4727,7 +4729,7 @@ export class MiniAssetHolding implements Encodable {
 
   static fromEncodingData(data: unknown): MiniAssetHolding {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded MiniAssetHolding: ${data}`);
     }
     return new MiniAssetHolding({
       address: data.get('address'),
@@ -4807,7 +4809,7 @@ export class ParticipationUpdates implements Encodable {
 
   static fromEncodingData(data: unknown): ParticipationUpdates {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded ParticipationUpdates: ${data}`);
     }
     return new ParticipationUpdates({
       absentParticipationAccounts: data.get('absent-participation-accounts'),
@@ -4987,7 +4989,7 @@ export class StateProofFields implements Encodable {
 
   static fromEncodingData(data: unknown): StateProofFields {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded StateProofFields: ${data}`);
     }
     return new StateProofFields({
       partProofs:
@@ -5080,7 +5082,7 @@ export class StateProofParticipant implements Encodable {
 
   static fromEncodingData(data: unknown): StateProofParticipant {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded StateProofParticipant: ${data}`);
     }
     return new StateProofParticipant({
       verifier:
@@ -5182,7 +5184,7 @@ export class StateProofReveal implements Encodable {
 
   static fromEncodingData(data: unknown): StateProofReveal {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded StateProofReveal: ${data}`);
     }
     return new StateProofReveal({
       participant:
@@ -5265,7 +5267,7 @@ export class StateProofSigSlot implements Encodable {
 
   static fromEncodingData(data: unknown): StateProofSigSlot {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded StateProofSigSlot: ${data}`);
     }
     return new StateProofSigSlot({
       lowerSigWeight: data.get('lower-sig-weight'),
@@ -5374,7 +5376,7 @@ export class StateProofSignature implements Encodable {
 
   static fromEncodingData(data: unknown): StateProofSignature {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded StateProofSignature: ${data}`);
     }
     return new StateProofSignature({
       falconSignature: data.get('falcon-signature'),
@@ -5492,7 +5494,7 @@ export class StateProofTracking implements Encodable {
 
   static fromEncodingData(data: unknown): StateProofTracking {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded StateProofTracking: ${data}`);
     }
     return new StateProofTracking({
       nextRound: data.get('next-round'),
@@ -5569,7 +5571,7 @@ export class StateProofVerifier implements Encodable {
 
   static fromEncodingData(data: unknown): StateProofVerifier {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded StateProofVerifier: ${data}`);
     }
     return new StateProofVerifier({
       commitment: data.get('commitment'),
@@ -5642,7 +5644,7 @@ export class StateSchema implements Encodable {
 
   static fromEncodingData(data: unknown): StateSchema {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded StateSchema: ${data}`);
     }
     return new StateSchema({
       numByteSlice: data.get('num-byte-slice'),
@@ -5661,14 +5663,14 @@ export class TealKeyValue implements Encodable {
     if (!this.encodingSchemaValue) {
       this.encodingSchemaValue = new NamedMapSchema([]);
       (this.encodingSchemaValue as NamedMapSchema).pushEntries(
-        { key: 'key', valueSchema: new StringSchema(), omitEmpty: true },
+        { key: 'key', valueSchema: new ByteArraySchema(), omitEmpty: true },
         { key: 'value', valueSchema: TealValue.encodingSchema, omitEmpty: true }
       );
     }
     return this.encodingSchemaValue;
   }
 
-  public key: string;
+  public key: Uint8Array;
 
   /**
    * Represents a TEAL value.
@@ -5680,8 +5682,8 @@ export class TealKeyValue implements Encodable {
    * @param key -
    * @param value - Represents a TEAL value.
    */
-  constructor({ key, value }: { key: string; value: TealValue }) {
-    this.key = key;
+  constructor({ key, value }: { key: string | Uint8Array; value: TealValue }) {
+    this.key = typeof key === 'string' ? base64ToBytes(key) : key;
     this.value = value;
   }
 
@@ -5699,7 +5701,7 @@ export class TealKeyValue implements Encodable {
 
   static fromEncodingData(data: unknown): TealKeyValue {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded TealKeyValue: ${data}`);
     }
     return new TealKeyValue({
       key: data.get('key'),
@@ -5718,7 +5720,7 @@ export class TealValue implements Encodable {
     if (!this.encodingSchemaValue) {
       this.encodingSchemaValue = new NamedMapSchema([]);
       (this.encodingSchemaValue as NamedMapSchema).pushEntries(
-        { key: 'bytes', valueSchema: new StringSchema(), omitEmpty: true },
+        { key: 'bytes', valueSchema: new ByteArraySchema(), omitEmpty: true },
         { key: 'type', valueSchema: new Uint64Schema(), omitEmpty: true },
         { key: 'uint', valueSchema: new Uint64Schema(), omitEmpty: true }
       );
@@ -5729,7 +5731,7 @@ export class TealValue implements Encodable {
   /**
    * bytes value.
    */
-  public bytes: string;
+  public bytes: Uint8Array;
 
   /**
    * type of the value. Value `1` refers to **bytes**, value `2` refers to **uint**
@@ -5752,11 +5754,11 @@ export class TealValue implements Encodable {
     type,
     uint,
   }: {
-    bytes: string;
+    bytes: string | Uint8Array;
     type: number | bigint;
     uint: number | bigint;
   }) {
-    this.bytes = bytes;
+    this.bytes = typeof bytes === 'string' ? base64ToBytes(bytes) : bytes;
     this.type = ensureSafeInteger(type);
     this.uint = ensureBigInt(uint);
   }
@@ -5776,7 +5778,7 @@ export class TealValue implements Encodable {
 
   static fromEncodingData(data: unknown): TealValue {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded TealValue: ${data}`);
     }
     return new TealValue({
       bytes: data.get('bytes'),
@@ -6514,7 +6516,7 @@ export class Transaction implements Encodable {
 
   static fromEncodingData(data: unknown): Transaction {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded Transaction: ${data}`);
     }
     return new Transaction({
       fee: data.get('fee'),
@@ -6893,7 +6895,7 @@ export class TransactionApplication implements Encodable {
 
   static fromEncodingData(data: unknown): TransactionApplication {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded TransactionApplication: ${data}`);
     }
     return new TransactionApplication({
       applicationId: data.get('application-id'),
@@ -6998,7 +7000,7 @@ export class TransactionAssetConfig implements Encodable {
 
   static fromEncodingData(data: unknown): TransactionAssetConfig {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded TransactionAssetConfig: ${data}`);
     }
     return new TransactionAssetConfig({
       assetId: data.get('asset-id'),
@@ -7084,7 +7086,7 @@ export class TransactionAssetFreeze implements Encodable {
 
   static fromEncodingData(data: unknown): TransactionAssetFreeze {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded TransactionAssetFreeze: ${data}`);
     }
     return new TransactionAssetFreeze({
       address: data.get('address'),
@@ -7222,7 +7224,7 @@ export class TransactionAssetTransfer implements Encodable {
 
   static fromEncodingData(data: unknown): TransactionAssetTransfer {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded TransactionAssetTransfer: ${data}`);
     }
     return new TransactionAssetTransfer({
       amount: data.get('amount'),
@@ -7397,7 +7399,7 @@ export class TransactionKeyreg implements Encodable {
 
   static fromEncodingData(data: unknown): TransactionKeyreg {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded TransactionKeyreg: ${data}`);
     }
     return new TransactionKeyreg({
       nonParticipation: data.get('non-participation'),
@@ -7507,7 +7509,7 @@ export class TransactionPayment implements Encodable {
 
   static fromEncodingData(data: unknown): TransactionPayment {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded TransactionPayment: ${data}`);
     }
     return new TransactionPayment({
       amount: data.get('amount'),
@@ -7591,7 +7593,7 @@ export class TransactionResponse implements Encodable {
 
   static fromEncodingData(data: unknown): TransactionResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded TransactionResponse: ${data}`);
     }
     return new TransactionResponse({
       currentRound: data.get('current-round'),
@@ -7705,7 +7707,7 @@ export class TransactionSignature implements Encodable {
 
   static fromEncodingData(data: unknown): TransactionSignature {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded TransactionSignature: ${data}`);
     }
     return new TransactionSignature({
       logicsig:
@@ -7830,7 +7832,7 @@ export class TransactionSignatureLogicsig implements Encodable {
 
   static fromEncodingData(data: unknown): TransactionSignatureLogicsig {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded TransactionSignatureLogicsig: ${data}`);
     }
     return new TransactionSignatureLogicsig({
       logic: data.get('logic'),
@@ -7941,7 +7943,7 @@ export class TransactionSignatureMultisig implements Encodable {
 
   static fromEncodingData(data: unknown): TransactionSignatureMultisig {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded TransactionSignatureMultisig: ${data}`);
     }
     return new TransactionSignatureMultisig({
       subsignature:
@@ -8024,7 +8026,9 @@ export class TransactionSignatureMultisigSubsignature implements Encodable {
     data: unknown
   ): TransactionSignatureMultisigSubsignature {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(
+        `Invalid decoded TransactionSignatureMultisigSubsignature: ${data}`
+      );
     }
     return new TransactionSignatureMultisigSubsignature({
       publicKey: data.get('public-key'),
@@ -8136,7 +8140,7 @@ export class TransactionStateProof implements Encodable {
 
   static fromEncodingData(data: unknown): TransactionStateProof {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded TransactionStateProof: ${data}`);
     }
     return new TransactionStateProof({
       message:
@@ -8231,7 +8235,7 @@ export class TransactionsResponse implements Encodable {
 
   static fromEncodingData(data: unknown): TransactionsResponse {
     if (!(data instanceof Map)) {
-      throw new Error(`Invalid decoded logic sig account: ${data}`);
+      throw new Error(`Invalid decoded TransactionsResponse: ${data}`);
     }
     return new TransactionsResponse({
       currentRound: data.get('current-round'),

--- a/src/dryrun.ts
+++ b/src/dryrun.ts
@@ -11,7 +11,7 @@ import {
   TealValue,
 } from './client/v2/algod/models/types.js';
 import { getApplicationAddress } from './encoding/address.js';
-import { base64ToBytes, bytesToHex } from './encoding/binarydata.js';
+import { bytesToHex } from './encoding/binarydata.js';
 import { SignedTransaction } from './signedTransaction.js';
 import { TransactionType } from './types/transactions/index.js';
 import { stringifyJSON } from './utils/utils.js';
@@ -183,9 +183,7 @@ function scratchToString(
 
   const newScratch = currScratch[newScratchIdx];
   if (newScratch.bytes.length > 0) {
-    return `${newScratchIdx} = 0x${bytesToHex(
-      base64ToBytes(newScratch.bytes)
-    )}`;
+    return `${newScratchIdx} = 0x${bytesToHex(newScratch.bytes)}`;
   }
   return `${newScratchIdx} = ${newScratch.uint.toString()}`;
 }
@@ -199,7 +197,7 @@ function stackToString(
     .map((sv) => {
       switch (sv.type) {
         case 1:
-          return `0x${bytesToHex(base64ToBytes(sv.bytes))}`;
+          return `0x${bytesToHex(sv.bytes)}`;
         case 2:
           return sv.uint.toString();
         default:

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -3824,7 +3824,7 @@ module.exports = function getSteps(options) {
       numByteSlices,
       numUints,
       applicationState,
-      stateKey,
+      stateKeyB64,
       stateValue
     ) {
       const accountInfo = await this.v2Client
@@ -3863,7 +3863,7 @@ module.exports = function getSteps(options) {
       assert.ok(foundApp);
 
       // If there is no key to check, we're done.
-      if (stateKey === '') {
+      if (stateKeyB64 === '') {
         return;
       }
 
@@ -3904,11 +3904,14 @@ module.exports = function getSteps(options) {
       for (let i = 0; i < keyValues.length; i++) {
         const keyValue = keyValues[i];
         const foundKey = keyValue.key;
-        if (foundKey === stateKey) {
+        if (algosdk.bytesToBase64(foundKey) === stateKeyB64) {
           foundValueForKey = true;
           const foundValue = keyValue.value;
           if (foundValue.type === 1) {
-            assert.strictEqual(foundValue.bytes, stateValue);
+            assert.deepStrictEqual(
+              foundValue.bytes,
+              algosdk.base64ToBytes(stateValue)
+            );
           } else if (foundValue.type === 0) {
             assert.strictEqual(foundValue.uint, stateValue);
           }


### PR DESCRIPTION
Algod types TEAL byte keys and byte values as strings and base64 encodes them in responses. There was some discussion in https://github.com/algorand/go-algorand/pull/5492 about changing the types on algod, but we decided against it.

This PR updates the types client side so that users don't need to manually decode base64 strings.

A few byte conversion operations were cleaned up as well in the example files.

Relies on https://github.com/algorand/generator/pull/79 to update the generated REST models.