### PR TITLE
3.0.0: Add ability to pass through fetch options

### DIFF
--- a/src/client/baseHTTPClient.ts
+++ b/src/client/baseHTTPClient.ts
@@ -26,8 +26,11 @@ export interface BaseHTTPClientError {
  * wallets to provide access to paid API services without leaking
  * the secret tokens/URLs.
  *
- * Note that post and delete also have an optional query parameter
- * This is to allow future extension where post and delete may have queries
+ * The parameter `customOptions` is an object that can be used to configure
+ * individual requests with specific specific to the BaseHTTPClient implementation.
+ *
+ * Note that DELETE requests have an optional query parameter.
+ * This is to allow future extension where DELETE may have queries
  * Currently however HTTPClient does not make use of it
  *
  * Compared to HTTPClient, BaseHTTPClient does not deal with serialization/deserialization
@@ -41,18 +44,21 @@ export interface BaseHTTPClient {
   get(
     relativePath: string,
     query?: Query<string>,
-    requestHeaders?: Record<string, string>
+    requestHeaders?: Record<string, string>,
+    customOptions?: Record<string, unknown>
   ): Promise<BaseHTTPClientResponse>;
   post(
     relativePath: string,
     data: Uint8Array,
     query?: Query<string>,
-    requestHeaders?: Record<string, string>
+    requestHeaders?: Record<string, string>,
+    customOptions?: Record<string, unknown>
   ): Promise<BaseHTTPClientResponse>;
   delete(
     relativePath: string,
     data?: Uint8Array,
     query?: Query<string>,
-    requestHeaders?: Record<string, string>
+    requestHeaders?: Record<string, string>,
+    customOptions?: Record<string, unknown>
   ): Promise<BaseHTTPClientResponse>;
 }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -264,22 +264,23 @@ export class HTTPClient {
    *
    * @param options - The options to use for the request.
    * @param options.relativePath - The path of the request.
-   * @param options.jsonOptions - Options object to use to decode JSON responses. See
-   *   utils.parseJSON for the options available.
    * @param options.query - An object containing the query parameters of the request.
    * @param options.requestHeaders - An object containing additional request headers to use.
-   * @param options.parseBody - An optional boolean indicating whether the response body should be parsed
    *   or not.
+   * @param options.customOptions - An object containing additional options to pass to the
+   *   underlying BaseHTTPClient instance.
    * @returns Response object.
    */
   async get({
     relativePath,
     query,
     requestHeaders,
+    customOptions,
   }: {
     relativePath: string;
     query?: Query<any>;
     requestHeaders?: Record<string, string>;
+    customOptions?: Record<string, unknown>;
   }): Promise<HTTPClientResponse> {
     const format = getAcceptFormat(query);
     const fullHeaders = { ...(requestHeaders ?? {}), accept: format };
@@ -288,7 +289,8 @@ export class HTTPClient {
       const res = await this.bc.get(
         relativePath,
         query ? removeFalsyOrEmpty(query) : undefined,
-        fullHeaders
+        fullHeaders,
+        customOptions
       );
 
       return HTTPClient.prepareResponse(res, format);
@@ -308,11 +310,13 @@ export class HTTPClient {
     data,
     query,
     requestHeaders,
+    customOptions,
   }: {
     relativePath: string;
     data: any;
     query?: Query<any>;
     requestHeaders?: Record<string, string>;
+    customOptions?: Record<string, unknown>;
   }): Promise<HTTPClientResponse> {
     const fullHeaders = {
       'content-type': 'application/json',
@@ -324,7 +328,8 @@ export class HTTPClient {
         relativePath,
         HTTPClient.serializeData(data, fullHeaders),
         query,
-        fullHeaders
+        fullHeaders,
+        customOptions
       );
 
       return HTTPClient.prepareResponse(res, 'application/json');
@@ -343,10 +348,12 @@ export class HTTPClient {
     relativePath,
     data,
     requestHeaders,
+    customOptions,
   }: {
     relativePath: string;
     data: any;
     requestHeaders?: Record<string, string>;
+    customOptions?: Record<string, unknown>;
   }) {
     const fullHeaders = {
       'content-type': 'application/json',
@@ -360,7 +367,8 @@ export class HTTPClient {
           ? HTTPClient.serializeData(data, fullHeaders)
           : undefined,
         undefined,
-        fullHeaders
+        fullHeaders,
+        customOptions
       );
 
       return HTTPClient.prepareResponse(res, 'application/json');

--- a/src/client/urlTokenBaseHTTPClient.ts
+++ b/src/client/urlTokenBaseHTTPClient.ts
@@ -42,6 +42,9 @@ export type TokenHeader =
  * Implementation of BaseHTTPClient that uses a URL and a token
  * and make the REST queries using fetch.
  * This is the default implementation of BaseHTTPClient.
+ *
+ * Additional fetch options can be configured by using the `customOptions` parameter on
+ * get/post/delete requests.
  */
 export class URLTokenBaseHTTPClient implements BaseHTTPClient {
   private readonly baseURL: URL;
@@ -154,17 +157,19 @@ export class URLTokenBaseHTTPClient implements BaseHTTPClient {
   async get(
     relativePath: string,
     query?: Query<string>,
-    requestHeaders: Record<string, string> = {}
+    requestHeaders?: Record<string, string>,
+    customOptions?: Record<string, unknown>
   ): Promise<BaseHTTPClientResponse> {
     // Expand headers for use in fetch
     const headers = {
       ...this.tokenHeader,
       ...this.defaultHeaders,
-      ...requestHeaders,
+      ...(requestHeaders ?? {}),
     };
 
     const res = await fetch(this.getURL(relativePath, query), {
       headers,
+      ...(customOptions ?? {}),
     });
 
     return URLTokenBaseHTTPClient.formatFetchResponse(res);
@@ -174,19 +179,21 @@ export class URLTokenBaseHTTPClient implements BaseHTTPClient {
     relativePath: string,
     data: Uint8Array,
     query?: Query<string>,
-    requestHeaders: Record<string, string> = {}
+    requestHeaders?: Record<string, string>,
+    customOptions?: Record<string, unknown>
   ): Promise<BaseHTTPClientResponse> {
     // Expand headers for use in fetch
     const headers = {
       ...this.tokenHeader,
       ...this.defaultHeaders,
-      ...requestHeaders,
+      ...(requestHeaders ?? {}),
     };
 
     const res = await fetch(this.getURL(relativePath, query), {
       method: 'POST',
       body: data,
       headers,
+      ...(customOptions ?? {}),
     });
 
     return URLTokenBaseHTTPClient.formatFetchResponse(res);
@@ -196,19 +203,21 @@ export class URLTokenBaseHTTPClient implements BaseHTTPClient {
     relativePath: string,
     data?: Uint8Array,
     query?: Query<string>,
-    requestHeaders: Record<string, string> = {}
+    requestHeaders?: Record<string, string>,
+    customOptions?: Record<string, unknown>
   ): Promise<BaseHTTPClientResponse> {
     // Expand headers for use in fetch
     const headers = {
       ...this.tokenHeader,
       ...this.defaultHeaders,
-      ...requestHeaders,
+      ...(requestHeaders ?? {}),
     };
 
     const res = await fetch(this.getURL(relativePath, query), {
       method: 'DELETE',
       body: data,
       headers,
+      ...(customOptions ?? {}),
     });
 
     return URLTokenBaseHTTPClient.formatFetchResponse(res);

--- a/src/client/v2/algod/compile.ts
+++ b/src/client/v2/algod/compile.ts
@@ -39,7 +39,8 @@ export default class Compile extends JSONRequest<CompileResponse> {
   }
 
   protected executeRequest(
-    headers: Record<string, string>
+    headers?: Record<string, string>,
+    customOptions?: Record<string, unknown>
   ): Promise<HTTPClientResponse> {
     const txHeaders = setHeaders(headers);
     return this.c.post({
@@ -47,6 +48,7 @@ export default class Compile extends JSONRequest<CompileResponse> {
       data: coerceToBytes(this.source),
       query: this.query,
       requestHeaders: txHeaders,
+      customOptions,
     });
   }
 

--- a/src/client/v2/algod/disassemble.ts
+++ b/src/client/v2/algod/disassemble.ts
@@ -34,7 +34,8 @@ export default class Disassemble extends JSONRequest<DisassembleResponse> {
   }
 
   protected executeRequest(
-    headers: Record<string, string>
+    headers?: Record<string, string>,
+    customOptions?: Record<string, unknown>
   ): Promise<HTTPClientResponse> {
     const txHeaders = setHeaders(headers);
     return this.c.post({
@@ -42,6 +43,7 @@ export default class Disassemble extends JSONRequest<DisassembleResponse> {
       data: coerceToBytes(this.source),
       query: this.query,
       requestHeaders: txHeaders,
+      customOptions,
     });
   }
 

--- a/src/client/v2/algod/dryrun.ts
+++ b/src/client/v2/algod/dryrun.ts
@@ -19,13 +19,15 @@ export default class Dryrun extends JSONRequest<DryrunResponse> {
   }
 
   protected executeRequest(
-    headers: Record<string, string>
+    headers?: Record<string, string>,
+    customOptions?: Record<string, unknown>
   ): Promise<HTTPClientResponse> {
     const txHeaders = setHeaders(headers);
     return this.c.post({
       relativePath: this.path(),
       data: this.blob,
       requestHeaders: txHeaders,
+      customOptions,
     });
   }
 

--- a/src/client/v2/algod/sendRawTransaction.ts
+++ b/src/client/v2/algod/sendRawTransaction.ts
@@ -52,13 +52,15 @@ export default class SendRawTransaction extends JSONRequest<PostTransactionsResp
   }
 
   protected executeRequest(
-    headers: Record<string, string>
+    headers?: Record<string, string>,
+    customOptions?: Record<string, unknown>
   ): Promise<HTTPClientResponse> {
     const txHeaders = setSendTransactionHeaders(headers);
     return this.c.post({
       relativePath: this.path(),
       data: this.txnBytesToPost,
       requestHeaders: txHeaders,
+      customOptions,
     });
   }
 

--- a/src/client/v2/algod/setBlockOffsetTimestamp.ts
+++ b/src/client/v2/algod/setBlockOffsetTimestamp.ts
@@ -14,12 +14,14 @@ export default class SetBlockOffsetTimestamp extends JSONRequest<void> {
   }
 
   protected executeRequest(
-    headers: Record<string, string>
+    headers?: Record<string, string>,
+    customOptions?: Record<string, unknown>
   ): Promise<HTTPClientResponse> {
     return this.c.post({
       relativePath: this.path(),
       data: null,
       requestHeaders: headers,
+      customOptions,
     });
   }
 

--- a/src/client/v2/algod/setSyncRound.ts
+++ b/src/client/v2/algod/setSyncRound.ts
@@ -14,12 +14,14 @@ export default class SetSyncRound extends JSONRequest<void> {
   }
 
   protected executeRequest(
-    headers: Record<string, string>
+    headers?: Record<string, string>,
+    customOptions?: Record<string, unknown>
   ): Promise<HTTPClientResponse> {
     return this.c.post({
       relativePath: this.path(),
       data: null,
       requestHeaders: headers,
+      customOptions,
     });
   }
 

--- a/src/client/v2/algod/simulateTransaction.ts
+++ b/src/client/v2/algod/simulateTransaction.ts
@@ -37,7 +37,8 @@ export default class SimulateRawTransactions extends JSONRequest<SimulateRespons
   }
 
   protected executeRequest(
-    headers: Record<string, string>
+    headers?: Record<string, string>,
+    customOptions?: Record<string, unknown>
   ): Promise<HTTPClientResponse> {
     const txHeaders = setSimulateTransactionsHeaders(headers);
     return this.c.post({
@@ -45,6 +46,7 @@ export default class SimulateRawTransactions extends JSONRequest<SimulateRespons
       data: this.requestBytes,
       query: this.query,
       requestHeaders: txHeaders,
+      customOptions,
     });
   }
 

--- a/src/client/v2/algod/unsetSyncRound.ts
+++ b/src/client/v2/algod/unsetSyncRound.ts
@@ -8,12 +8,14 @@ export default class UnsetSyncRound extends JSONRequest<void> {
   }
 
   protected executeRequest(
-    headers: Record<string, string>
+    headers?: Record<string, string>,
+    customOptions?: Record<string, unknown>
   ): Promise<HTTPClientResponse> {
     return this.c.delete({
       relativePath: this.path(),
       data: undefined,
       requestHeaders: headers,
+      customOptions,
     });
   }
 

--- a/src/client/v2/jsonrequest.ts
+++ b/src/client/v2/jsonrequest.ts
@@ -52,7 +52,7 @@ export default abstract class JSONRequest<Data> {
   /**
    * Execute the request and decode the response.
    * @param headers - Additional headers to send in the request. Optional.
-   * @param customOptions - Additional options to pass to the underlying HTTPBaseClient. For
+   * @param customOptions - Additional options to pass to the underlying BaseHTTPClient. For
    *   {@link URLTokenBaseHTTPClient}, which is the default client, this will be treated as
    *   additional options to pass to the network `fetch` method.
    * @returns A promise which resolves to the parsed response object.
@@ -69,7 +69,7 @@ export default abstract class JSONRequest<Data> {
   /**
    * Execute the request, but do not process the response data in any way.
    * @param headers - Additional headers to send in the request. Optional.
-   * @param customOptions - Additional options to pass to the underlying HTTPBaseClient. For
+   * @param customOptions - Additional options to pass to the underlying BaseHTTPClient. For
    *   {@link URLTokenBaseHTTPClient}, which is the default client, this will be treated as
    *   additional options to pass to the network `fetch` method.
    * @returns A promise which resolves to the raw response data, exactly as returned by the server.

--- a/src/client/v2/jsonrequest.ts
+++ b/src/client/v2/jsonrequest.ts
@@ -38,34 +38,48 @@ export default abstract class JSONRequest<Data> {
    * Execute the request
    */
   protected executeRequest(
-    headers: Record<string, string>
+    headers?: Record<string, string>,
+    customOptions?: Record<string, unknown>
   ): Promise<HTTPClientResponse> {
     return this.c.get({
       relativePath: this.path(),
       query: this.query,
       requestHeaders: headers,
+      customOptions,
     });
   }
 
   /**
    * Execute the request and decode the response.
    * @param headers - Additional headers to send in the request. Optional.
-   * @returns A promise which resolves to the parsed response data.
+   * @param customOptions - Additional options to pass to the underlying HTTPBaseClient. For
+   *   {@link URLTokenBaseHTTPClient}, which is the default client, this will be treated as
+   *   additional options to pass to the network `fetch` method.
+   * @returns A promise which resolves to the parsed response object.
    * @category JSONRequest
    */
-  async do(headers: Record<string, string> = {}): Promise<Data> {
-    const res = await this.executeRequest(headers);
+  async do(
+    headers?: Record<string, string>,
+    customOptions?: Record<string, unknown>
+  ): Promise<Data> {
+    const res = await this.executeRequest(headers, customOptions);
     return this.prepare(res);
   }
 
   /**
    * Execute the request, but do not process the response data in any way.
    * @param headers - Additional headers to send in the request. Optional.
+   * @param customOptions - Additional options to pass to the underlying HTTPBaseClient. For
+   *   {@link URLTokenBaseHTTPClient}, which is the default client, this will be treated as
+   *   additional options to pass to the network `fetch` method.
    * @returns A promise which resolves to the raw response data, exactly as returned by the server.
    * @category JSONRequest
    */
-  async doRaw(headers: Record<string, string> = {}): Promise<Uint8Array> {
-    const res = await this.executeRequest(headers);
+  async doRaw(
+    headers?: Record<string, string>,
+    customOptions?: Record<string, unknown>
+  ): Promise<Uint8Array> {
+    const res = await this.executeRequest(headers, customOptions);
     return res.body;
   }
 }

--- a/tests/9.Client.ts
+++ b/tests/9.Client.ts
@@ -187,4 +187,27 @@ describe('client', () => {
 
     /* eslint-disable dot-notation */
   });
+  describe('Additional fetch options', () => {
+    // eslint-disable-next-line func-names
+    it('should pass additional options to the fetch method', async function () {
+      this.timeout(3_000);
+
+      const client = new AlgodClient('', 'http://localhost:8080/neverreturn/');
+
+      const abortController = new AbortController();
+
+      setTimeout(() => {
+        abortController.abort();
+      }, 2_000);
+
+      try {
+        await client
+          .healthCheck()
+          .do(undefined, { signal: abortController.signal });
+        throw new Error('Request should have failed but did not');
+      } catch (err) {
+        assert.ok(err.toString().includes('This operation was aborted'), err);
+      }
+    });
+  });
 });

--- a/tests/9.Client.ts
+++ b/tests/9.Client.ts
@@ -206,7 +206,8 @@ describe('client', () => {
           .do(undefined, { signal: abortController.signal });
         throw new Error('Request should have failed but did not');
       } catch (err) {
-        assert.ok(err.toString().includes('This operation was aborted'), err);
+        const errorString = (err as Error).toString();
+        assert.ok(errorString.includes('aborted'), errorString);
       }
     });
   });

--- a/tests/mocha.js
+++ b/tests/mocha.js
@@ -17,6 +17,12 @@ const resourcePath = path.dirname(__dirname);
 
 async function startResourceServer() {
   const app = express();
+
+  app.use('/neverreturn/*', (req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.write('This request will never return');
+  });
+
   app.use(express.static(resourcePath));
   await new Promise((resolve) => {
     resourceServer = app.listen(resourceServerPort, undefined, resolve);


### PR DESCRIPTION
When making requests, exposes an additional options object that can be passed through to the underlying `BaseHTTPClient`. For the default `URLTokenBaseHTTPClient`, this is treated as additional options to pass to the `fetch` network call.

Fixes #858