### PR TITLE
Fix: Don't delete `dist` folder when creating release PR

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -115,7 +115,7 @@ jobs:
         env:
           RELEASE_TAG: ${{ steps.set-release.outputs.release-tag }}
         run: |
-          rm -rf dist node_modules
+          rm -rf node_modules
           npm ci
           npm run build
           NEW_HASH=$(cat dist/browser/algosdk.min.js | openssl dgst -sha384 -binary | openssl base64 -A)


### PR DESCRIPTION
#889 was created using the create release PR github action, but it deletes the entire `dist` folder when it shouldn't. With v3, a file permanently exists in the `dist` folder and we don't want to remove it.