### PR TITLE
Release PR Generation: Use prerelease tag in changelog generation

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -81,6 +81,7 @@ jobs:
         id: build-changelog
         env:
           PREVIOUS_VERSION: ${{ steps.get-release.outputs.latest-tag }}
+          RELEASE_TAG: ${{ steps.set-release.outputs.release-tag }}
         run: |
           CHANGELOG=$(curl -L \
             -X POST \
@@ -88,7 +89,7 @@ jobs:
             -H "Authorization: Bearer ${{ github.token }}"\
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{ github.repository }}/releases/generate-notes \
-            -d '{"tag_name":"${{ env.RELEASE_VERSION }}","target_commitish":"${{ env.RELEASE_BRANCH }}","previous_tag_name":"${{ env.PREVIOUS_VERSION }}","configuration_file_path":".github/release.yml"}' \
+            -d '{"tag_name":"${{ env.RELEASE_TAG }}","target_commitish":"${{ env.RELEASE_BRANCH }}","previous_tag_name":"${{ env.PREVIOUS_VERSION }}","configuration_file_path":".github/release.yml"}' \
             | jq -r '.body')
 
           # The EOF steps are used to save multiline string in github:


### PR DESCRIPTION
Use the prerelease tag when generating the changelog for release PRs.

If a prerelease version is specified, right now that is not used when generating the release PR with the planned version tag.

For example, that causes this statement to be at the end of the changelog:

> **Full Changelog**: https://github.com/algorand/js-algorand-sdk/compare/v2.9.0...v3.0.0

Instead of:

> **Full Changelog**: https://github.com/algorand/js-algorand-sdk/compare/v2.9.0...v3.0.0-beta.1

I manually updated it in #891, but it would be nice to fix this at the source