### PR TITLE
feat: add Address as an ABIValue and handle encoding an Address

### DIFF
--- a/tests/10.ABI.ts
+++ b/tests/10.ABI.ts
@@ -231,6 +231,22 @@ describe('ABI type checking', () => {
 });
 
 describe('ABI encoding', () => {
+  // Note we are not using the newTestCase array below because we are not testing round-trip
+  // encoding. We added support for encoding Address as `address`, but decode should still return
+  // a string for backwards compatibility
+  it('ABIAddressType should encode Address properly', () => {
+    const abiType = new ABIAddressType();
+    const addr = decodeAddress(
+      'MO2H6ZU47Q36GJ6GVHUKGEBEQINN7ZWVACMWZQGIYUOE3RBSRVYHV4ACJI'
+    );
+
+    assert.deepStrictEqual(abiType.encode(addr), addr.publicKey);
+    assert.deepStrictEqual(
+      abiType.decode(abiType.encode(addr)),
+      addr.toString()
+    );
+  });
+
   type TestCase<T> = {
     abiType: ABIType;
     input: T;


### PR DESCRIPTION
Allows `Address` to be an acceptable ABIValue and properly handles `Address` in `ABIAddressType.encode`