### PR TITLE
API: Support for header-only flag on /v2/block algod endpoint (v2.x backport)

### DIFF
--- a/src/client/v2/algod/block.ts
+++ b/src/client/v2/algod/block.ts
@@ -20,6 +20,28 @@ export default class Block extends JSONRequest {
     return `/v2/blocks/${this.round}`;
   }
 
+  /**
+   * If true, only the block header (exclusive of payset or certificate) may be included in response.
+   *
+   * #### Example
+   * ```typescript
+   *
+   * const roundNumber = 41000000;
+   *
+   * const blockResponse = await algodClient
+   *        .block(roundNumber)
+   *        .headerOnly(true)
+   *        .do();
+   * ```
+   *
+   * @param headerOnly - the flag indicating whether exclusively return header in response
+   * @category query
+   */
+  headerOnly(headerOnly: boolean) {
+    this.query['header-only'] = headerOnly;
+    return this;
+  }
+
   // eslint-disable-next-line class-methods-use-this
   prepare(body: Uint8Array) {
     if (body && body.byteLength > 0) {

--- a/src/client/v2/algod/models/types.ts
+++ b/src/client/v2/algod/models/types.ts
@@ -2099,38 +2099,6 @@ export class BlockHashResponse extends BaseModel {
 }
 
 /**
- * Block header.
- */
-export class BlockHeaderResponse extends BaseModel {
-  /**
-   * Block header data.
-   */
-  public blockheader?: BlockHeader;
-
-  /**
-   * Creates a new `BlockHeaderResponse` object.
-   * @param blockheader - Block header data.
-   */
-  constructor({ blockheader }: { blockheader?: BlockHeader }) {
-    super();
-    this.blockheader = blockheader;
-
-    this.attribute_map = {
-      blockheader: 'blockHeader',
-    };
-  }
-
-  // eslint-disable-next-line camelcase
-  static from_obj_for_encoding(data: Record<string, any>): BlockHeaderResponse {
-    /* eslint-disable dot-notation */
-    return new BlockHeaderResponse({
-      blockheader: data['blockHeader'],
-    });
-    /* eslint-enable dot-notation */
-  }
-}
-
-/**
  * All logs emitted in the given round. Each app call, whether top-level or inner,
  * that contains logs results in a separate AppCallLogs object. Therefore there may
  * be multiple AppCallLogs with the same application ID and outer transaction ID in

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -1771,6 +1771,23 @@ module.exports = function getSteps(options) {
     }
   );
 
+  When(
+    'we make a Get Block call for round {int} with format {string} and header-only {string}',
+    async function (round, format, headerOnly) {
+      if (format !== 'msgpack') {
+        assert.fail('this SDK only supports format msgpack for this function');
+      }
+
+      const builder = this.v2Client.block(round);
+      const hob = headerOnly.toLowerCase() === 'true';
+
+      if (hob) {
+        builder.headerOnly(hob);
+      }
+      await builder.do();
+    }
+  );
+
   When('we make a GetAssetByID call for assetID {int}', async function (index) {
     await this.v2Client.getAssetByID(index).do();
   });
@@ -1952,6 +1969,16 @@ module.exports = function getSteps(options) {
 
   Then(
     'the parsed Get Block response should have rewards pool {string}',
+    (rewardsPoolAddress) => {
+      const rewardsPoolB64String = Buffer.from(
+        anyBlockResponse.block.rwd
+      ).toString('base64');
+      assert.strictEqual(rewardsPoolAddress, rewardsPoolB64String);
+    }
+  );
+
+  Then(
+    'the parsed Get Block response should have rewards pool {string} and no certificate or payset',
     (rewardsPoolAddress) => {
       const rewardsPoolB64String = Buffer.from(
         anyBlockResponse.block.rwd


### PR DESCRIPTION
This PR adds support for a new header-only=true parameter to the '/v2/block/{round}' endpoint. Includes support for cross-SDK test cases.