### PR TITLE
DevOps: Fix docker-test by locking to amd64 and updating dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,13 @@ harness:
 harness-down:
 	./test-harness.sh down
 
+# Force to platform=linux/amd64 because chrome isn't available on arm64
 docker-build:
-	docker build -t js-sdk-testing -f tests/cucumber/docker/Dockerfile $(CURDIR) --build-arg TEST_BROWSER --build-arg CI=true
+	docker build --platform=linux/amd64 -t js-sdk-testing -f tests/cucumber/docker/Dockerfile $(CURDIR) --build-arg TEST_BROWSER --build-arg CI=true
 
 docker-run:
 	docker ps -a
-	docker run -it --network host js-sdk-testing:latest
+	docker run --platform=linux/amd64 -it --network host js-sdk-testing:latest
 
 smoke-test-examples:
 	cd examples && bash smoke_test.sh && cd -

--- a/tests/cucumber/docker/Dockerfile
+++ b/tests/cucumber/docker/Dockerfile
@@ -1,19 +1,21 @@
-FROM ubuntu:focal
+FROM ubuntu:noble
 
 # install wget, gnupg2, make
-RUN apt-get update -qqy \
-  && apt-get -qqy install wget gnupg2 make
+RUN apt-get -qqy update \
+  && DEBIAN_FRONTEND=noninteractive apt-get -qqy install wget gnupg2 make
 
 # install chrome, firefox
 # based on https://github.com/SeleniumHQ/docker-selenium/blob/trunk/NodeChrome/Dockerfile
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-  && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list \
-  && apt-get update -qqy \
-  && apt-get -qqy --no-install-recommends install google-chrome-stable firefox
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor | tee /etc/apt/trusted.gpg.d/google.gpg >/dev/null && \
+    echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list && \
+    wget -q https://packages.mozilla.org/apt/repo-signing-key.gpg -O- | tee /etc/apt/keyrings/packages.mozilla.org.asc > /dev/null && \
+    echo "deb [signed-by=/etc/apt/keyrings/packages.mozilla.org.asc] https://packages.mozilla.org/apt mozilla main" | tee -a /etc/apt/sources.list.d/mozilla.list > /dev/null && \
+    DEBIAN_FRONTEND=noninteractive apt-get -qqy update && \
+    DEBIAN_FRONTEND=noninteractive apt-get -qqy install firefox google-chrome-stable
 
 # install node
-RUN wget -q -O - https://deb.nodesource.com/setup_18.x | bash \
-  && apt-get -qqy --no-install-recommends install nodejs \
+RUN wget -q -O - https://deb.nodesource.com/setup_22.x | bash \
+  && DEBIAN_FRONTEND=noninteractive apt-get -qqy --no-install-recommends install nodejs \
   && echo "node version: $(node --version)" \
   && echo "npm version: $(npm --version)"
 

--- a/tests/cucumber/docker/Dockerfile
+++ b/tests/cucumber/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:noble
+FROM ubuntu:jammy
 
 # install wget, gnupg2, make
 RUN apt-get -qqy update \
@@ -20,9 +20,9 @@ RUN wget -q -O - https://deb.nodesource.com/setup_22.x | bash \
   && echo "npm version: $(npm --version)"
 
 # Copy SDK code into the container
-RUN mkdir -p $HOME/js-algorand-sdk
-COPY . $HOME/js-algorand-sdk
-WORKDIR $HOME/js-algorand-sdk
+RUN mkdir -p /app/js-algorand-sdk
+COPY . /app/js-algorand-sdk
+WORKDIR /app/js-algorand-sdk
 
 ARG TEST_BROWSER
 ENV TEST_BROWSER=$TEST_BROWSER


### PR DESCRIPTION
## Summary

This PR makes the following fixes to the cucumber docker container:

- updates ubuntu to newer LTS
- forces docker-build to amd64, to allow for google-chrome-stable install
- cleans up install for firefox and chrome
- update node install to v22
- removes broken $HOME variable

## Testing

Known test failures show up (but tests run) for `make docker-test`
