### PR TITLE
Build: Fix Box API Pagination-dependent integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ commands:
             << parameters.sudo >> apt -y update
             << parameters.sudo >> apt -y install curl make git build-essential jq unzip
       - node/install:
-          node-version: '18'
+          node-version: '22'
       - run:
           name: npm ci
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,10 @@ orbs:
 parameters:
   ubuntu_machine:
     type: string
-    default: 'ubuntu-2004:202111-02'
+    default: 'ubuntu-2404:2024.11.1'
   ubuntu_docker:
     type: string
-    default: 'ubuntu:focal'
+    default: 'ubuntu:noble'
 
 workflows:
   circleci_build_and_test:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2047,9 +2047,9 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "126.0.3",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-126.0.3.tgz",
-      "integrity": "sha512-4o+ZK8926/8lqIlnnvcljCHV88Z8IguEMB5PInOiS9/Lb6cyeZSj2Uvz+ky1Jgyw2Bn7qCLJFfbUslaWnvUUbg==",
+      "version": "126.0.5",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-126.0.5.tgz",
+      "integrity": "sha512-xXVxwxd8CJ6yg2KEvFqLQi7V0RvF78xFnLB+xo9g9MoJNHMQccD7b4OWaxtKDy5RXrMgQ6Jb6vUN3SjTYXHLEQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -937,9 +937,9 @@
       }
     },
     "node_modules/@wdio/logger": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-8.28.0.tgz",
-      "integrity": "sha512-/s6zNCqwy1hoc+K4SJypis0Ud0dlJ+urOelJFO1x0G0rwDRWyFiUP6ijTaCcFxAm29jYEcEPWijl2xkVIHwOyA==",
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.4.4.tgz",
+      "integrity": "sha512-BXx8RXFUW2M4dcO6t5Le95Hi2ZkTQBRsvBQqLekT2rZ6Xmw8ZKZBPf0FptnoftFGg6dYmwnDidYv/0+4PiHjpQ==",
       "dev": true,
       "dependencies": {
         "chalk": "^5.1.2",
@@ -948,13 +948,13 @@
         "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": "^16.13 || >=18"
+        "node": ">=18.20.0"
       }
     },
     "node_modules/@wdio/logger/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -964,9 +964,9 @@
       }
     },
     "node_modules/@wdio/logger/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
       "dev": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -1209,6 +1209,17 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/@zip.js/zip.js": {
+      "version": "2.7.60",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.60.tgz",
+      "integrity": "sha512-vA3rLyqdxBrVo1FWSsbyoecaqWTV+vgPRf0QKeM7kVDG0r+lHUqd7zQDv1TO9k4BcAoNzNDSNrrel24Mk6addA==",
+      "dev": true,
+      "engines": {
+        "bun": ">=0.7.0",
+        "deno": ">=1.0.0",
+        "node": ">=16.5.0"
+      }
+    },
     "node_modules/abab": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
@@ -1251,32 +1262,12 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
       "dev": true,
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/agent-base/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/aggregate-error": {
@@ -1636,9 +1627,9 @@
       }
     },
     "node_modules/b4a": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.4.tgz",
-      "integrity": "sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
+      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
       "dev": true
     },
     "node_modules/balanced-match": {
@@ -1646,6 +1637,78 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/bare-events": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.4.tgz",
+      "integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/bare-fs": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.2.tgz",
+      "integrity": "sha512-8wSeOia5B7LwD4+h465y73KOdj5QHsbbuoUfPBi+pXgFJIPuG7SsiOdJuijWMyfid49eD+WivpfY7KT8gbAzBA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.1.tgz",
+      "integrity": "sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.5.tgz",
+      "integrity": "sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "streamx": "^2.21.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
     },
     "node_modules/basic-ftp": {
       "version": "5.0.5",
@@ -1662,32 +1725,10 @@
       "integrity": "sha1-Qpzuu/pffpNueNc/vcfacWKyDiA=",
       "dev": true
     },
-    "node_modules/big-integer": {
-      "version": "1.6.52",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/bignumber.js": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
       "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/binary": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
-      "dev": true,
-      "dependencies": {
-        "buffers": "~0.1.1",
-        "chainsaw": "~0.1.0"
-      },
       "engines": {
         "node": "*"
       }
@@ -1846,24 +1887,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/buffer-indexof-polyfill": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/buffers": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.2.0"
-      }
-    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -1958,18 +1981,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/chainsaw": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
-      "dev": true,
-      "dependencies": {
-        "traverse": ">=0.3.0 <0.4"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/chalk": {
       "version": "4.1.1",
@@ -2645,15 +2656,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/duplexer2": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": "^2.0.2"
       }
     },
     "node_modules/duration": {
@@ -4400,33 +4402,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/fstream": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
-      },
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/fstream/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -4471,19 +4446,19 @@
       }
     },
     "node_modules/geckodriver": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-4.3.0.tgz",
-      "integrity": "sha512-QfpvxFsMORwKpvnLslkHCr3NTCczHAvkte6+pQGsiUZXKBe6mO4TTb727b+9KMVSK6XZqhR6ZwImKdP+F5vS6A==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-4.5.1.tgz",
+      "integrity": "sha512-lGCRqPMuzbRNDWJOQcUqhNqPvNsIFu6yzXF8J/6K3WCYFd2r5ckbeF7h1cxsnjA7YLSEiWzERCt6/gjZ3tW0ug==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@wdio/logger": "^8.24.12",
+        "@wdio/logger": "^9.0.0",
+        "@zip.js/zip.js": "^2.7.48",
         "decamelize": "^6.0.0",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.2",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
         "node-fetch": "^3.3.2",
-        "tar-fs": "^3.0.4",
-        "unzipper": "^0.10.14",
+        "tar-fs": "^3.0.6",
         "which": "^4.0.0"
       },
       "bin": {
@@ -4981,12 +4956,12 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
-      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
       "dependencies": {
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
@@ -5973,12 +5948,6 @@
         "node": ">=0.6.19"
       }
     },
-    "node_modules/listenercount": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-      "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
-      "dev": true
-    },
     "node_modules/listr2": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.10.0.tgz",
@@ -6101,9 +6070,9 @@
       }
     },
     "node_modules/loglevel": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.1.tgz",
-      "integrity": "sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
       "dev": true,
       "engines": {
         "node": ">= 0.6.0"
@@ -6294,24 +6263,6 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "dev": true
     },
     "node_modules/mocha": {
       "version": "11.1.0",
@@ -7348,12 +7299,6 @@
         }
       ]
     },
-    "node_modules/queue-tick": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
-      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
-      "dev": true
-    },
     "node_modules/random-bytes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
@@ -8217,13 +8162,16 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.15.6",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.6.tgz",
-      "integrity": "sha512-q+vQL4AAz+FdfT137VF69Cc/APqUbxy+MDOImRrMvchJpigHj9GksgDU2LYbO9rx7RX6osWgxJB2WxhYv4SZAw==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.0.tgz",
+      "integrity": "sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==",
       "dev": true,
       "dependencies": {
-        "fast-fifo": "^1.1.0",
-        "queue-tick": "^1.0.1"
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.2.0"
       }
     },
     "node_modules/string_decoder": {
@@ -8455,20 +8403,23 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.4.tgz",
-      "integrity": "sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
+      "integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
       "dev": true,
       "dependencies": {
-        "mkdirp-classic": "^0.5.2",
         "pump": "^3.0.0",
         "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
       }
     },
     "node_modules/tar-stream": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.6.tgz",
-      "integrity": "sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
       "dev": true,
       "dependencies": {
         "b4a": "^1.6.4",
@@ -8597,6 +8548,15 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/text-decoder": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "dev": true,
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -8669,15 +8629,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.6"
-      }
-    },
-    "node_modules/traverse": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/tree-kill": {
@@ -8976,30 +8927,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/unzipper": {
-      "version": "0.10.14",
-      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
-      "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
-      "dev": true,
-      "dependencies": {
-        "big-integer": "^1.6.17",
-        "binary": "~0.3.0",
-        "bluebird": "~3.4.1",
-        "buffer-indexof-polyfill": "~1.0.0",
-        "duplexer2": "~0.1.4",
-        "fstream": "^1.0.12",
-        "graceful-fs": "^4.2.2",
-        "listenercount": "~1.0.1",
-        "readable-stream": "~2.3.6",
-        "setimmediate": "~1.0.4"
-      }
-    },
-    "node_modules/unzipper/node_modules/bluebird": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
-      "dev": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -171,6 +171,12 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
+    "node_modules/@bazel/runfiles": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@bazel/runfiles/-/runfiles-6.3.1.tgz",
+      "integrity": "sha512-1uLNT5NZsUVIGS4syuHwTzZ8HycMPyr6POA3FCE4GbMtc4rhoJk8aZKtNIRthJYfL+iioppi+rTfH3olMPr9nA==",
+      "dev": true
+    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -7674,17 +7680,28 @@
       "dev": true
     },
     "node_modules/selenium-webdriver": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.10.0.tgz",
-      "integrity": "sha512-hSQPw6jgc+ej/UEcdQPG/iBwwMeCEgZr9HByY/J8ToyXztEqXzU9aLsIyrlj1BywBcStO4JQK/zMUWWrV8+riA==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.31.0.tgz",
+      "integrity": "sha512-0MWEwypM0+c1NnZ87UEMxZdwphKoaK2UJ2qXzKWrJiM0gazFjgNVimxlHTOO90G2cOhphZqwpqSCJy62NTEzyA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/SeleniumHQ"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/selenium"
+        }
+      ],
       "dependencies": {
+        "@bazel/runfiles": "^6.3.1",
         "jszip": "^3.10.1",
-        "tmp": "^0.2.1",
-        "ws": ">=8.13.0"
+        "tmp": "^0.2.3",
+        "ws": "^8.18.0"
       },
       "engines": {
-        "node": ">= 14.20.0"
+        "node": ">= 18.20.5"
       }
     },
     "node_modules/semver": {
@@ -8624,15 +8641,12 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
       "dev": true,
-      "dependencies": {
-        "rimraf": "^3.0.0"
-      },
       "engines": {
-        "node": ">=8.17.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/to-regex-range": {

--- a/tests/cucumber/docker/Dockerfile
+++ b/tests/cucumber/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy
+FROM ubuntu:noble
 
 # install wget, gnupg2, make
 RUN apt-get -qqy update \

--- a/tests/cucumber/steps/index.js
+++ b/tests/cucumber/steps/index.js
@@ -33,14 +33,14 @@ if (browser) {
 
   if (process.env.CI) {
     chromeOptions = chromeOptions.addArguments(
-      'no-sandbox',
-      'disable-gpu',
-      'headless'
+      '--no-sandbox',
+      '--disable-gpu',
+      '--headless=new'
     );
     firefoxOptions = firefoxOptions
       .setPreference('remote.active-protocols', 1) // Sets protocol to only WebDriver BiDi
       .setPreference('network.http.network-changed.timeout', 30) // In Docker tests this apparently matters
-      .headless();
+      .addArguments('-headless');
   }
 
   driverBuilder = new webdriver.Builder()

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -5128,6 +5128,43 @@ module.exports = function getSteps(options) {
     }
   );
 
+  async function sendZeroPaysToAdvanceChain(
+    algodClient,
+    account,
+    appIndex,
+    boxLength
+  ) {
+    // balancesFlushInterval in algod is 5 seconds, so we need at least that amount of time to pass to trigger the flush we need
+    // eslint-disable-next-line no-promise-executor-return
+    const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+    /* eslint-disable no-await-in-loop */
+    for (let i = 0; i < 50; i++) {
+      const sp = await algodClient.getTransactionParams().do();
+      const algoTxn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
+        sender: account.addr,
+        receiver: account.addr,
+        amount: 0,
+        suggestedParams: sp,
+      });
+
+      const algoStxn = algoTxn.signTxn(account.sk);
+      await algodClient.sendRawTransaction(algoStxn).do();
+
+      // MaxAccountLookback is 4, we start checking for our boxes after the 5th round from create transaction
+      if (i > 5) {
+        const resp = await algodClient.getApplicationBoxes(appIndex).do();
+
+        // If the boxes have shown up, break out of loop
+        if (resp.boxes.length === boxLength) {
+          break;
+        } else {
+          await sleep(1000); // Sleep then continue
+        }
+      }
+    }
+    /* eslint-enable no-await-in-loop */
+  }
+
   Then(
     'according to {string}, the current application should have the following boxes {string}.',
     async function (fromClient, boxNames) {
@@ -5137,7 +5174,12 @@ module.exports = function getSteps(options) {
       if (fromClient === 'algod') {
         // We need to advance a few rounds so that app boxes endpoint returns expected boxes (
         // it only pulls persisted data, so need to get past MaxAccountLookback and flush after)
-        await sendZeroPaysToAdvanceChain(this.v2Client, this.transientAccount, this.currentApplicationIndex, boxes.length);
+        await sendZeroPaysToAdvanceChain(
+          this.v2Client,
+          this.transientAccount,
+          this.currentApplicationIndex,
+          boxes.length
+        );
         resp = await this.v2Client
           .getApplicationBoxes(this.currentApplicationIndex)
           .do();
@@ -5155,42 +5197,6 @@ module.exports = function getSteps(options) {
       assert.deepStrictEqual(expectedBoxes, actualBoxes);
     }
   );
-
-  async function sendZeroPaysToAdvanceChain(algodClient, account, appIndex, boxLength) {
-    // balancesFlushInterval in algod is 5 seconds, so we need at least that amount of time to pass to trigger the flush 
-    // we need
-    const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
-
-    for (let i = 0; i < 50; i++) {
-
-      const sp = await algodClient.getTransactionParams().do();
-      const algoTxn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-        sender: account.addr,
-        receiver: account.addr,
-        amount: 0,
-        suggestedParams: sp,
-      });
-
-      const algoStxn = algoTxn.signTxn(account.sk);
-      await algodClient.sendRawTransaction(algoStxn).do();
-
-      // MaxAccountLookback is 4, we start checking for our boxes after the 5th round from create transaction
-      if (i > 5) {
-        resp = await algodClient
-            .getApplicationBoxes(appIndex)
-            .do();
-
-        // If the boxes have shown up, break out of loop
-        if (resp.boxes.length == boxLength) {
-          break;
-        } else {
-          await sleep(1000); // Sleep then continue
-        }
-      }
-    }
-  }
-
-
 
   Then(
     'I wait for indexer to catch up to the round where my most recent transaction was confirmed.',

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -5128,7 +5128,7 @@ module.exports = function getSteps(options) {
     }
   );
 
-  async function sendZeroPaysToAdvanceChain(
+  async function advanceChainWaitForBox(
     algodClient,
     account,
     appIndex,
@@ -5174,7 +5174,7 @@ module.exports = function getSteps(options) {
       if (fromClient === 'algod') {
         // We need to advance a few rounds so that app boxes endpoint returns expected boxes (
         // it only pulls persisted data, so need to get past MaxAccountLookback and flush after)
-        await sendZeroPaysToAdvanceChain(
+        await advanceChainWaitForBox(
           this.v2Client,
           this.transientAccount,
           this.currentApplicationIndex,

--- a/tests/cucumber/steps/steps.js
+++ b/tests/cucumber/steps/steps.js
@@ -5135,6 +5135,9 @@ module.exports = function getSteps(options) {
 
       let resp = null;
       if (fromClient === 'algod') {
+        // We need to advance a few rounds so that app boxes endpoint returns expected boxes (
+        // it only pulls persisted data, so need to get past MaxAccountLookback and flush after)
+        await sendZeroPaysToAdvanceChain(this.v2Client, this.transientAccount, this.currentApplicationIndex, boxes.length);
         resp = await this.v2Client
           .getApplicationBoxes(this.currentApplicationIndex)
           .do();
@@ -5152,6 +5155,42 @@ module.exports = function getSteps(options) {
       assert.deepStrictEqual(expectedBoxes, actualBoxes);
     }
   );
+
+  async function sendZeroPaysToAdvanceChain(algodClient, account, appIndex, boxLength) {
+    // balancesFlushInterval in algod is 5 seconds, so we need at least that amount of time to pass to trigger the flush 
+    // we need
+    const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+    for (let i = 0; i < 50; i++) {
+
+      const sp = await algodClient.getTransactionParams().do();
+      const algoTxn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
+        sender: account.addr,
+        receiver: account.addr,
+        amount: 0,
+        suggestedParams: sp,
+      });
+
+      const algoStxn = algoTxn.signTxn(account.sk);
+      await algodClient.sendRawTransaction(algoStxn).do();
+
+      // MaxAccountLookback is 4, we start checking for our boxes after the 5th round from create transaction
+      if (i > 5) {
+        resp = await algodClient
+            .getApplicationBoxes(appIndex)
+            .do();
+
+        // If the boxes have shown up, break out of loop
+        if (resp.boxes.length == boxLength) {
+          break;
+        } else {
+          await sleep(1000); // Sleep then continue
+        }
+      }
+    }
+  }
+
+
 
   Then(
     'I wait for indexer to catch up to the round where my most recent transaction was confirmed.',

--- a/tests/mocha.js
+++ b/tests/mocha.js
@@ -95,11 +95,11 @@ async function testRunner() {
 
     if (process.env.CI) {
       chromeOptions = chromeOptions.addArguments(
-        'no-sandbox',
-        'headless',
-        'disable-gpu'
+        '--no-sandbox',
+        '--headless=new',
+        '--disable-gpu'
       );
-      firefoxOptions = firefoxOptions.headless();
+      firefoxOptions = firefoxOptions.addArguments('-headless');
     }
 
     const driver = await new webdriver.Builder()


### PR DESCRIPTION
Add appropriate waits/sleeps to allow for box pagination API calls to return all expected/persisted results in application cucumber tests.

Set Node version in Circle build to v22, update Ubuntu image for builds to noble/24.04, and update selenium/geckodriver for compatibility with Ubuntu 24.