### PR TITLE
Docs: fix link in README so it works in typedoc 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AlgoSDK is the official JavaScript library for communicating with the Algorand n
 
 ## New Major Version 3
 
-Existing codebases using v2 of this library will be incompatible with v3. The v3 release introduces breaking changes to the API, and a migration guide is available [here](https://github.com/algorand/js-algorand-sdk/blob/develop/v2_TO_v3_MIGRATION_GUIDE.md).
+Existing codebases using v2 of this library will be incompatible with v3. The v3 release introduces breaking changes to the API, and a migration guide is available [here](https://github.com/algorand/js-algorand-sdk/blob/main/v2_TO_v3_MIGRATION_GUIDE.md).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AlgoSDK is the official JavaScript library for communicating with the Algorand n
 
 ## New Major Version 3
 
-Existing codebases using v2 of this library will be incompatible with v3. The v3 release introduces breaking changes to the API, and a migration guide is available [here](v2_TO_v3_MIGRATION_GUIDE.md).
+Existing codebases using v2 of this library will be incompatible with v3. The v3 release introduces breaking changes to the API, and a migration guide is available [here](https://github.com/algorand/js-algorand-sdk/blob/develop/v2_TO_v3_MIGRATION_GUIDE.md).
 
 ## Installation
 


### PR DESCRIPTION
Port of (#947) onto the main branch after git flow retirement.