### PR TITLE
fix: add instanceof fallback for cases of duplicated module resolution

### DIFF
--- a/src/abi/abi_type.ts
+++ b/src/abi/abi_type.ts
@@ -261,7 +261,7 @@ export class ABIAddressType extends ABIType {
       return decodedAddress.publicKey;
     }
 
-    if (value instanceof Address) {
+    if (typeof value === 'object' && 'publicKey' in value) {
       return value.publicKey;
     }
 

--- a/src/encoding/address.ts
+++ b/src/encoding/address.ts
@@ -57,10 +57,7 @@ export class Address {
    * Check if the address is equal to another address.
    */
   equals(other: Address): boolean {
-    return (
-      other instanceof Address &&
-      utils.arrayEqual(this.publicKey, other.publicKey)
-    );
+    return utils.arrayEqual(this.publicKey, other.publicKey);
   }
 
   /**

--- a/src/encoding/schema/address.ts
+++ b/src/encoding/schema/address.ts
@@ -20,8 +20,14 @@ export class AddressSchema extends Schema {
   }
 
   public prepareMsgpack(data: unknown): MsgpackEncodingData {
-    if (data instanceof Address) {
-      return data.publicKey;
+    if (
+      data instanceof Address ||
+      (data &&
+        typeof data === 'object' &&
+        'publicKey' in data &&
+        data.publicKey instanceof Uint8Array)
+    ) {
+      return data.publicKey as Uint8Array;
     }
     throw new Error(`Invalid address: (${typeof data}) ${data}`);
   }
@@ -40,8 +46,13 @@ export class AddressSchema extends Schema {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _options: PrepareJSONOptions
   ): JSONEncodingData {
-    if (data instanceof Address) {
-      return data.toString();
+    if (
+      data instanceof Address ||
+      (data && typeof data === 'object' && 'toString' in data)
+    ) {
+      // Since are checking for the toString method, we might have something that isn't an Address
+      // Using Address.fromString allows us to throw an error if the input is not a valid address
+      return Address.fromString(data.toString()).toString();
     }
     throw new Error(`Invalid address: (${typeof data}) ${data}`);
   }

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -81,6 +81,11 @@ function ensureAddress(input: unknown): Address {
   if (input instanceof Address) {
     return input;
   }
+
+  if (typeof input === 'object' && 'toString' in input) {
+    return Address.fromString(input.toString());
+  }
+
   throw new Error(`Not an address: ${input}`);
 }
 
@@ -93,6 +98,8 @@ function optionalAddress(input: unknown): Address | undefined {
     addr = input;
   } else if (typeof input === 'string') {
     addr = Address.fromString(input);
+  } else if (typeof input === 'object' && 'toString' in input) {
+    addr = Address.fromString(input.toString());
   } else {
     throw new Error(`Not an address: ${input}`);
   }


### PR DESCRIPTION
We've recently had reports of `not an Address` error from people building on Algorand: https://github.com/algorandfoundation/algokit-utils-ts/issues/399

The cause seems to be two different `Address` classes being imported from the SDK. From the user's perspective, they are using the right `algosdk.Address` class, but depending on how dependencies import this class it might not properly evaluate in `instanceof` checks. 

I've personally encountered this when using the tinyman sdk. The fix would seemingly be to have every library that uses algosdk to list it as a `peerDependency` but even with [this change](https://github.com/tinymanorg/tinyman-js-sdk/compare/main...joe-p:tinyman-js-sdk:fix/algosdk_peer_dep?expand=1) the same error was still happening. This is despite `npm ls algosdk` showing every module being dedpued. Perhaps it has to do with _how_ it's imported. 

Keeping this PR as draft while we discuss the best way to properly fix this. 

To reproduce, clone this repo: https://github.com/joe-p/arc84_poc and run the following commands (`main` has the fix, which is an override using this PR)
  
  ```bash
git checkout 53d63e9c0a62b16abfc3f3803649894502ea7ec5
rm -rf node_modules && npm i
bun scripts/headless_demo.ts
  ```
  
  **Error:**
  ```bash
  error: Not an address: LAIXFJCAPMTKK5ZYQVWJE7F5P73PJ24QMJE774DHTVGRVH4JAS4RHD6VGQ
      at ensureAddress (/Users/joe/git/joe-p/arc11550_poc/projects/demo/node_modules/algosdk/dist/esm/transaction.js:45:11)
      at new Transaction (/Users/joe/git/joe-p/arc11550_poc/projects/demo/node_modules/algosdk/dist/esm/transaction.js:135:23)
      at makeApplicationCallTxnFromObject (/Users/joe/git/joe-p/arc11550_poc/projects/demo/node_modules/algosdk/dist/esm/makeTxn.js:209:12)
      at addMethodCall (/Users/joe/git/joe-p/arc11550_poc/projects/demo/node_modules/algosdk/dist/esm/composer.js:260:18)
      at <anonymous> (/Users/joe/git/joe-p/arc11550_poc/projects/demo/node_modules/@algorandfoundation/algokit-utils/types/composer.mjs:1045:23)
      at commonTxnBuildStep (/Users/joe/git/joe-p/arc11550_poc/projects/demo/node_modules/@algorandfoundation/algokit-utils/types/composer.mjs:893:21)
      at <anonymous> (/Users/joe/git/joe-p/arc11550_poc/projects/demo/node_modules/@algorandfoundation/algokit-utils/types/composer.mjs:1044:29)
```

**npm ls output:** 

```bash
demo@0.1.0 /Users/joe/git/joe-p/arc11550_poc/projects/demo
├─┬ @algorandfoundation/algokit-client-generator@5.0.0
│ └── algosdk@3.3.0 deduped
├─┬ @algorandfoundation/algokit-utils@9.1.0
│ └── algosdk@3.3.0 deduped
├─┬ @blockshake/defly-connect@1.2.1
│ └── algosdk@3.3.0 deduped
├─┬ @perawallet/connect@1.4.2
│ └── algosdk@3.3.0 deduped
├─┬ @tinymanorg/tinyman-js-sdk@5.0.2
│ └── algosdk@3.3.0 deduped
├─┬ @txnlab/use-wallet-react@4.1.0
│ └── algosdk@3.3.0 deduped
├─┬ @txnlab/use-wallet@4.1.0
│ └── algosdk@3.3.0 deduped
└── algosdk@3.3.0
```