### PR TITLE
CICD: implement tests in GitHub Actions

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'      
+          cache: 'npm'
       - name: Install npm dependencies
         run: npm ci
       - name: Check Prettier formatting
@@ -52,7 +52,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'      
+          cache: 'npm'
       - name: Install npm dependencies
         run: npm ci
       - name: Compile test
@@ -70,7 +70,7 @@ jobs:
       CI: true
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4      
+        uses: actions/checkout@v4
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -100,9 +100,9 @@ jobs:
           firefox-version: latest
       - name: Run tests (${{ matrix.browser }})
         run: |
-          if [ "${{ matrix.browser }}" == "node" ]; then 
+          if [ "${{ matrix.browser }}" == "node" ]; then
             unset TEST_BROWSER
-          else 
+          else
             export TEST_BROWSER=${{ matrix.browser }}
           fi
           npm test
@@ -116,6 +116,8 @@ jobs:
       pages: write
       id-token: write
     if: github.ref == 'refs/heads/main'
+    environment:
+      name: github-pages
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -123,7 +125,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'      
+          cache: 'npm'
       - name: Install npm dependencies
         run: npm ci
       - name: Generate documentation

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -76,20 +76,22 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
-      - name: Setup Chrome browser
+      - name: Install npm dependencies
+        run: |
+          npm ci
+          - name: Setup Chrome browser
+          if: matrix.browser == 'chrome'
+          uses: browser-actions/setup-chrome@v1
+          with:
+            chrome-version: latest
+      - name: Install chromedriver if applicable
         if: matrix.browser == 'chrome'
-        uses: browser-actions/setup-chrome@v1
-        with:
-          chrome-version: stable
-          install-chromedriver: true
+        run: npm install chromedriver@latest
       - name: Setup Firefox browser
         if: matrix.browser == 'firefox'
         uses: browser-actions/setup-firefox@v1
         with:
           firefox-version: latest
-      - name: Install npm dependencies
-        run: |
-          npm ci
       - name: Run tests (${{ matrix.browser }})
         run: |
           if [ "${{ matrix.browser }}" == "node" ]; then 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -91,9 +91,17 @@ jobs:
       - name: Install matching chromedriver
         if: matrix.browser == 'chrome'
         run: |
+          # Get the installed Chrome version
+          CHROME_VERSION=$(google-chrome --version | grep -oE '[0-9]+' | head -1)
+          echo "Detected Chrome version: $CHROME_VERSION"
+          
           # Remove the fixed version chromedriver and install one that matches Chrome
           npm uninstall chromedriver
-          npm install chromedriver@latest
+          npm install chromedriver@$CHROME_VERSION || npm install chromedriver@latest
+          
+          # Verify the installation
+          echo "Installed ChromeDriver version:"
+          npx chromedriver --version
       - name: Setup Firefox browser
         if: matrix.browser == 'firefox'
         uses: browser-actions/setup-firefox@v1

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,0 +1,164 @@
+name: CI - Test Suite
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+env:
+  NODE_VERSION: '22'
+
+jobs:
+  eslint:
+    name: ESLint
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+      
+      - name: Install npm dependencies
+        run: npm ci
+      
+      - name: Run ESLint
+        run: npm run lint
+
+  prettier:
+    name: Prettier
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+      
+      - name: Install npm dependencies
+        run: npm ci
+      
+      - name: Check Prettier formatting
+        run: npx prettier --check .
+
+  compile-test:
+    name: Compile Test
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+      
+      - name: Install npm dependencies
+        run: npm ci
+      
+      - name: Compile test
+        run: |
+          npm run build
+          npx tsc -p tests/compile
+
+  build-and-test:
+    name: Build and Test (${{ matrix.browser }})
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        browser: [node, chrome, firefox]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Install system dependencies
+        run: |
+          sudo apt update
+          sudo apt -y install curl make git build-essential jq unzip ca-certificates gnupg lsb-release
+      
+      - name: Install Chrome
+        if: matrix.browser == 'chrome'
+        run: |
+          sudo apt -y install google-chrome-stable
+      
+      - name: Install Docker
+        run: |
+          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+            $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt update
+          sudo apt -y install docker-ce docker-ce-cli containerd.io
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+      
+      - name: Install npm dependencies
+        run: |
+          npm ci
+          if [ "${{ matrix.browser }}" == "chrome" ]; then npm install chromedriver@latest; fi
+      
+      - name: Setup Chrome browser
+        if: matrix.browser == 'chrome'
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: stable
+      
+      - name: Setup Firefox browser
+        if: matrix.browser == 'firefox'
+        uses: browser-actions/setup-firefox@v1
+        with:
+          firefox-version: latest
+      
+      - name: Run tests (${{ matrix.browser }})
+        run: |
+          if [ "${{ matrix.browser }}" == "node" ]; then 
+            unset TEST_BROWSER
+          else 
+            export TEST_BROWSER=${{ matrix.browser }}
+          fi
+          npm test
+          make docker-test
+
+  generate-docs:
+    name: Generate Documentation
+    runs-on: ubuntu-24.04
+    needs: [eslint, prettier, compile-test, build-and-test]
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+      
+      - name: Install npm dependencies
+        run: npm ci
+      
+      - name: Generate documentation
+        run: |
+          rm -rf docs
+          npm run docs
+          touch docs/.nojekyll
+      
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs
+          commit_message: 'Automated docs update'

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -76,22 +76,20 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
-      - name: Install npm dependencies
-        run: |
-          npm ci
       - name: Setup Chrome browser
         if: matrix.browser == 'chrome'
         uses: browser-actions/setup-chrome@v1
         with:
           chrome-version: stable
-      - name: Install chromedriver if applicable
-        if: matrix.browser == 'chrome'
-        run: npm install chromedriver --detect_chromedriver_version
+          install-chromedriver: true
       - name: Setup Firefox browser
         if: matrix.browser == 'firefox'
         uses: browser-actions/setup-firefox@v1
         with:
           firefox-version: latest
+      - name: Install npm dependencies
+        run: |
+          npm ci
       - name: Run tests (${{ matrix.browser }})
         run: |
           if [ "${{ matrix.browser }}" == "node" ]; then 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   NODE_VERSION: '22'
-  CHROME_VERSION: 'stable'
 
 jobs:
   eslint:
@@ -89,11 +88,6 @@ jobs:
       - name: Install npm dependencies
         run: |
           npm ci
-      - name: Setup Chrome browser
-        if: matrix.browser == 'chrome'
-        uses: browser-actions/setup-chrome@v1
-        with:
-          chrome-version: ${{ env.CHROME_VERSION }}
       - name: Install matching chromedriver
         if: matrix.browser == 'chrome'
         run: |

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -85,7 +85,12 @@ jobs:
         uses: browser-actions/setup-chrome@v1
         with:
           chrome-version: ${{ env.CHROME_VERSION }}
-          install-chromedriver: true
+      - name: Install matching chromedriver
+        if: matrix.browser == 'chrome'
+        run: |
+          # Remove the fixed version chromedriver and install one that matches Chrome
+          npm uninstall chromedriver
+          npm install chromedriver@latest
       - name: Setup Firefox browser
         if: matrix.browser == 'firefox'
         uses: browser-actions/setup-firefox@v1

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -9,6 +9,10 @@ on:
 env:
   NODE_VERSION: '22'
 
+concurrency:
+  group: pr-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   eslint:
     name: ESLint

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -8,6 +8,8 @@ on:
 
 env:
   NODE_VERSION: '22'
+  CHROME_VERSION: 'stable'
+  CHROMEDRIVER_VERSION: '136'
 
 jobs:
   eslint:
@@ -83,10 +85,10 @@ jobs:
         if: matrix.browser == 'chrome'
         uses: browser-actions/setup-chrome@v1
         with:
-          chrome-version: latest
+          chrome-version: ${{ env.CHROME_VERSION }}
       - name: Install chromedriver if applicable
         if: matrix.browser == 'chrome'
-        run: npm install chromedriver@latest
+        run: npm install chromedriver@${{ env.CHROMEDRIVER_VERSION }} --no-save
       - name: Setup Firefox browser
         if: matrix.browser == 'firefox'
         uses: browser-actions/setup-firefox@v1

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -83,6 +83,7 @@ jobs:
         if: matrix.browser == 'chrome'
         uses: browser-actions/setup-chrome@v1
         with:
+          chrome-version: stable
           install-chromedriver: true
       - name: Setup Firefox browser
         if: matrix.browser == 'firefox'

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -97,11 +97,6 @@ jobs:
           # Verify the installation
           echo "Installed ChromeDriver version:"
           npx chromedriver --version
-      - name: Setup Firefox browser
-        if: matrix.browser == 'firefox'
-        uses: browser-actions/setup-firefox@v1
-        with:
-          firefox-version: latest
       - name: Run tests (${{ matrix.browser }})
         run: |
           if [ "${{ matrix.browser }}" == "node" ]; then

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -70,6 +70,15 @@ jobs:
     env:
       CI: true
     steps:
+      - name: Check for pre-installed chrome
+        run: |
+          if command -v google-chrome > /dev/null; then
+            echo "Google Chrome is already installed."
+            which google-chrome
+            google-chrome --version
+          else
+            echo "Google Chrome is not installed."
+          fi
       - name: Checkout code
         uses: actions/checkout@v4      
       - name: Setup Node.js

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -69,15 +69,6 @@ jobs:
     env:
       CI: true
     steps:
-      - name: Check for pre-installed chrome
-        run: |
-          if command -v google-chrome > /dev/null; then
-            echo "Google Chrome is already installed."
-            which google-chrome
-            google-chrome --version
-          else
-            echo "Google Chrome is not installed."
-          fi
       - name: Checkout code
         uses: actions/checkout@v4      
       - name: Setup Node.js
@@ -121,6 +112,9 @@ jobs:
     name: Generate Documentation
     runs-on: ubuntu-24.04
     needs: [eslint, prettier, compile-test, build-and-test]
+    permissions:
+      pages: write
+      id-token: write
     if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout code
@@ -137,9 +131,12 @@ jobs:
           rm -rf docs
           npm run docs
           touch docs/.nojekyll
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
-          commit_message: 'Automated docs update'
+          path: ./docs
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -16,16 +16,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
-      
       - name: Install npm dependencies
         run: npm ci
-      
       - name: Run ESLint
         run: npm run lint
 
@@ -35,16 +32,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-      
+          cache: 'npm'      
       - name: Install npm dependencies
         run: npm ci
-      
       - name: Check Prettier formatting
         run: npx prettier --check .
 
@@ -54,16 +48,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-      
+          cache: 'npm'      
       - name: Install npm dependencies
         run: npm ci
-      
       - name: Compile test
         run: |
           npm run build
@@ -75,51 +66,30 @@ jobs:
     strategy:
       matrix:
         browser: [node, chrome, firefox]
+    env:
+      CI: true
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
-      
-      - name: Install system dependencies
-        run: |
-          sudo apt update
-          sudo apt -y install curl make git build-essential jq unzip ca-certificates gnupg lsb-release
-      
-      - name: Install Chrome
-        if: matrix.browser == 'chrome'
-        run: |
-          sudo apt -y install google-chrome-stable
-      
-      - name: Install Docker
-        run: |
-          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
-            $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt update
-          sudo apt -y install docker-ce docker-ce-cli containerd.io
-      
+        uses: actions/checkout@v4      
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
-      
       - name: Install npm dependencies
         run: |
           npm ci
           if [ "${{ matrix.browser }}" == "chrome" ]; then npm install chromedriver@latest; fi
-      
       - name: Setup Chrome browser
         if: matrix.browser == 'chrome'
         uses: browser-actions/setup-chrome@v1
         with:
-          chrome-version: stable
-      
+          chrome-version: stable      
       - name: Setup Firefox browser
         if: matrix.browser == 'firefox'
         uses: browser-actions/setup-firefox@v1
         with:
           firefox-version: latest
-      
       - name: Run tests (${{ matrix.browser }})
         run: |
           if [ "${{ matrix.browser }}" == "node" ]; then 
@@ -128,7 +98,7 @@ jobs:
             export TEST_BROWSER=${{ matrix.browser }}
           fi
           npm test
-          make docker-test
+          npm ci-test
 
   generate-docs:
     name: Generate Documentation
@@ -138,24 +108,18 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-      
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-      
+          cache: 'npm'      
       - name: Install npm dependencies
         run: npm ci
-      
       - name: Generate documentation
         run: |
           rm -rf docs
           npm run docs
           touch docs/.nojekyll
-      
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -98,7 +98,7 @@ jobs:
             export TEST_BROWSER=${{ matrix.browser }}
           fi
           npm test
-          npm ci-test
+          make ci-test
 
   generate-docs:
     name: Generate Documentation

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -79,12 +79,11 @@ jobs:
       - name: Install npm dependencies
         run: |
           npm ci
-          if [ "${{ matrix.browser }}" == "chrome" ]; then npm install chromedriver@latest; fi
       - name: Setup Chrome browser
         if: matrix.browser == 'chrome'
         uses: browser-actions/setup-chrome@v1
         with:
-          chrome-version: stable      
+          install-chromedriver: true
       - name: Setup Firefox browser
         if: matrix.browser == 'firefox'
         uses: browser-actions/setup-firefox@v1

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -9,7 +9,6 @@ on:
 env:
   NODE_VERSION: '22'
   CHROME_VERSION: 'stable'
-  CHROMEDRIVER_VERSION: '136.0.3'
 
 jobs:
   eslint:
@@ -86,9 +85,7 @@ jobs:
         uses: browser-actions/setup-chrome@v1
         with:
           chrome-version: ${{ env.CHROME_VERSION }}
-      - name: Install chromedriver if applicable
-        if: matrix.browser == 'chrome'
-        run: npm install chromedriver@${{ env.CHROMEDRIVER_VERSION }} --no-save
+          install-chromedriver: true
       - name: Setup Firefox browser
         if: matrix.browser == 'firefox'
         uses: browser-actions/setup-firefox@v1

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -9,7 +9,7 @@ on:
 env:
   NODE_VERSION: '22'
   CHROME_VERSION: 'stable'
-  CHROMEDRIVER_VERSION: '136'
+  CHROMEDRIVER_VERSION: '136.0.3'
 
 jobs:
   eslint:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -79,11 +79,11 @@ jobs:
       - name: Install npm dependencies
         run: |
           npm ci
-          - name: Setup Chrome browser
-          if: matrix.browser == 'chrome'
-          uses: browser-actions/setup-chrome@v1
-          with:
-            chrome-version: latest
+      - name: Setup Chrome browser
+        if: matrix.browser == 'chrome'
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: latest
       - name: Install chromedriver if applicable
         if: matrix.browser == 'chrome'
         run: npm install chromedriver@latest

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -84,7 +84,9 @@ jobs:
         uses: browser-actions/setup-chrome@v1
         with:
           chrome-version: stable
-          install-chromedriver: true
+      - name: Install chromedriver if applicable
+        if: matrix.browser == 'chrome'
+        run: npm install chromedriver --detect_chromedriver_version
       - name: Setup Firefox browser
         if: matrix.browser == 'firefox'
         uses: browser-actions/setup-firefox@v1

--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,5 @@ ci-test: harness prepare-browser-tests unit integration smoke-test-examples
 
 format:
 	npm run format
+
+.PHONY: ci-test

--- a/Makefile
+++ b/Makefile
@@ -24,12 +24,18 @@ docker-build:
 
 docker-run:
 	docker ps -a
-	docker run --platform=linux/amd64 -it --network host js-sdk-testing:latest
+	docker run --platform=linux/amd64 -t --network host js-sdk-testing:latest
 
 smoke-test-examples:
 	cd examples && bash smoke_test.sh && cd -
 
 docker-test: harness docker-build docker-run
+
+prepare-browser-tests:
+	npm ci
+	npm run prepare-browser-tests
+
+ci-test: harness prepare-browser-tests unit integration smoke-test-examples
 
 format:
 	npm run format

--- a/package-lock.json
+++ b/package-lock.json
@@ -8817,10 +8817,11 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
-      "integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.9.tgz",
+      "integrity": "sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0",
         "tar-stream": "^3.1.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@typescript-eslint/eslint-plugin": "^6.18.1",
         "@typescript-eslint/parser": "^6.18.1",
         "assert": "^2.0.0",
-        "chromedriver": "^126.0.3",
+        "chromedriver": "^136.0.3",
         "concurrently": "^6.2.0",
         "cucumber": "^5.1.0",
         "es-abstract": "^1.18.3",
@@ -2456,14 +2456,15 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "126.0.5",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-126.0.5.tgz",
-      "integrity": "sha512-xXVxwxd8CJ6yg2KEvFqLQi7V0RvF78xFnLB+xo9g9MoJNHMQccD7b4OWaxtKDy5RXrMgQ6Jb6vUN3SjTYXHLEQ==",
+      "version": "136.0.3",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-136.0.3.tgz",
+      "integrity": "sha512-bE27WxCr8Fd12ZFvRWbkWgTvm9MF+le59U6MlxejO9bC9bPHp+IQfttsDMXThb05/M+/FOx8x2/0mQ50zG0kDg==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@testim/chrome-version": "^1.1.4",
-        "axios": "^1.6.7",
+        "axios": "^1.7.4",
         "compare-versions": "^6.1.0",
         "extract-zip": "^2.0.1",
         "proxy-agent": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@typescript-eslint/eslint-plugin": "^6.18.1",
     "@typescript-eslint/parser": "^6.18.1",
     "assert": "^2.0.0",
-    "chromedriver": "^126.0.3",
+    "chromedriver": "^136.0.3",
     "concurrently": "^6.2.0",
     "cucumber": "^5.1.0",
     "es-abstract": "^1.18.3",


### PR DESCRIPTION
## Summary

This is an implementation of unit and integration tests in GitHub Actions. Google Chrome and Firefox appear to already be installed in the ubuntu-24.04 image, so no need to install them here.

Chromedriver requires an explanation. Because we have it as a devDependency, the value for it can be overridden by what is in package.json. Because this is just for testing, We install a version of chromedriver that matches the installed google-chrome.

Oddly geckodriver doesn't appear to show any compatibility issues, but if it does later, we may have to revisit. (The driver version does not match the browser version, so we may have to figure out the right versioning.)

Some other changes:
- Removed interactive mode from dockerfile, as it was unnecessary
- Created a ci-test target that does not build a docker container, as it was redundant
- Upgraded chromedriver in package.json, because it was getting 404 errors in builds
- Updated tar-fs from 3.0.8 -> 3.0.9

## Testing

Ensure tests pass on this PR (including CircleCI).

The generate-docs job was tested on a fork.
