### PR TITLE
README: update CI badge

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,0 @@
-.github/ @algorand/devops
-.circleci/ @algorand/devops

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # js-algorand-sdk
 
-[![CircleCI](https://dl.circleci.com/status-badge/img/gh/algorand/js-algorand-sdk/tree/develop.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/algorand/js-algorand-sdk/tree/develop) [![npm version](https://badge.fury.io/js/algosdk.svg)](https://www.npmjs.com/package/algosdk)
+[![CI - Test Suite](https://github.com/algorand/js-algorand-sdk/actions/workflows/ci-pr.yml/badge.svg)](https://github.com/algorand/js-algorand-sdk/actions/workflows/ci-pr.yml) [![npm version](https://badge.fury.io/js/algosdk.svg)](https://www.npmjs.com/package/algosdk)
 
 AlgoSDK is the official JavaScript library for communicating with the Algorand network. It's designed for modern browsers and Node.js.
 


### PR DESCRIPTION
## Summary

Since tests were shifted to GitHub Actions, this PR swaps the status badge to reflect this.

Additionally, the CODEOWNERS file was removed.

## Test Plan

See if badge displays, and verify tests (but no code changes so should pass).
