### PR TITLE
fix: handle null values when deserializing byte arrays

### DIFF
--- a/src/encoding/schema/bytearray.ts
+++ b/src/encoding/schema/bytearray.ts
@@ -48,6 +48,9 @@ export class ByteArraySchema extends Schema {
   }
 
   public fromPreparedJSON(encoded: JSONEncodingData): Uint8Array {
+    if (encoded === null || encoded === undefined) {
+      return this.defaultValue();
+    }
     if (typeof encoded === 'string') {
       return base64ToBytes(encoded);
     }


### PR DESCRIPTION
The indexer API supports retrieving deleted applications by suppling the `include-all=true` param when calling `/v2/applications/{applicationId}`, however when fetching a deleted application via the algosdk using `indexer.lookupApplications(applicationId).includeAll(true).do()` it throws an error "Invalid byte array: (object) null".

This error is due to the indexer API returning a `null` value for the `approval-program` and `clear-state-program`, however those values are deserialized using the `ByteArraySchema` which expects a base64 encoded bytes value. This can be observed in this application https://mainnet-idx.algonode.cloud/v2/applications/2365972864?include-all=true

This PR updates the ByteArraySchema JSON deserializer to handle `null` or `undefined` values and maps them to the default value (empty byte array).