### PR TITLE
types: add txn access

### DIFF
--- a/src/appAccess.ts
+++ b/src/appAccess.ts
@@ -254,7 +254,7 @@ export function foreignArraysToResourceReferences({
   function ensureApp(app: number | bigint) {
     let appFound = false;
     for (const rr of accessList) {
-      if (rr.appIndex && rr.appIndex === app) {
+      if (rr.appIndex === app) {
         appFound = true;
         break;
       }

--- a/src/appAccess.ts
+++ b/src/appAccess.ts
@@ -5,6 +5,7 @@ import {
   LocalsReference,
   ResourceReference,
 } from './types/transactions/base.js';
+import { ensureSafeUnsignedInteger } from './utils/utils.js';
 
 /**
  * resourceReferencesToEncodingData translates an array of ResourceReferences into an array of encoding data
@@ -40,7 +41,6 @@ export function resourceReferencesToEncodingData(
   }
 
   const zeroAddr = Address.zeroAddress();
-
   for (const rr of references) {
     if (rr.address || rr.assetIndex || rr.appIndex) {
       ensure(rr);
@@ -87,8 +87,8 @@ export function resourceReferencesToEncodingData(
         ])
       );
     }
-    if (rr.boxes) {
-      const b = rr.boxes;
+    if (rr.box) {
+      const b = rr.box;
       let appIdx = 0;
       if (b.appIndex && BigInt(b.appIndex) !== appIndex) {
         appIdx = ensure({ appIndex: b.appIndex });
@@ -109,6 +109,66 @@ export function resourceReferencesToEncodingData(
   return accessList;
 }
 
+export function convertIndicesToResourceReferences(
+  accessList: Array<Map<string, unknown>>
+): Array<ResourceReference> {
+  const references: Array<ResourceReference> = [];
+  for (const item of accessList) {
+    const address = item.get('d') as Address | undefined;
+    const assetIndex = item.get('s') as bigint | undefined;
+    const appIndex = item.get('p') as bigint | undefined;
+    if (address) {
+      references.push({ address });
+    } else if (assetIndex) {
+      references.push({ assetIndex });
+    } else if (appIndex) {
+      references.push({ appIndex });
+    }
+    const holding = item.get('h') as Map<string, unknown> | undefined;
+    if (holding) {
+      const hAddressIndex = ensureSafeUnsignedInteger(holding.get('d') ?? 0);
+      const hAssetIndex = ensureSafeUnsignedInteger(holding.get('s'));
+      if (!hAssetIndex) {
+        throw new Error(`Holding missing asset index: ${holding}`);
+      }
+      const hAddress =
+        hAddressIndex === 0
+          ? Address.zeroAddress()
+          : (references[hAddressIndex - 1].address as Address);
+      const asset = references[hAssetIndex - 1].assetIndex as bigint;
+      references.push({ holding: { address: hAddress, assetIndex: asset } });
+    }
+    const locals = item.get('l') as Map<string, unknown> | undefined;
+    if (locals) {
+      const lAddressIndex = ensureSafeUnsignedInteger(locals.get('d') ?? 0);
+      const lAppIndex = ensureSafeUnsignedInteger(locals.get('p') ?? 0);
+      const lAddress =
+        lAddressIndex === 0
+          ? Address.zeroAddress()
+          : (references[lAddressIndex - 1].address as Address);
+      const app =
+        lAppIndex === 0
+          ? BigInt(0)
+          : (references[lAppIndex - 1].appIndex as bigint);
+      references.push({ locals: { address: lAddress, appIndex: app } });
+    }
+    const box = item.get('b') as Map<string, unknown> | undefined;
+    if (box) {
+      const bAppIndex = ensureSafeUnsignedInteger(box.get('i') ?? 0);
+      const name = box.get('n') as Uint8Array;
+      if (!name) {
+        throw new Error(`Box missing name: ${box}`);
+      }
+      const app =
+        bAppIndex === 0
+          ? BigInt(0)
+          : (references[bAppIndex - 1].appIndex as number | bigint);
+      references.push({ box: { appIndex: app, name } });
+    }
+  }
+  return references;
+}
+
 /**
  * foreignArraysToResourceReferences makes a single array of ResourceReferences from various foreign resource arrays.
  * Note, runtime representation of ResourceReference uses addresses, app and asset identifiers, not indexes.
@@ -121,6 +181,7 @@ export function resourceReferencesToEncodingData(
  * @param boxes - optional array of boxes
  */
 export function foreignArraysToResourceReferences({
+  appIndex,
   accounts,
   foreignAssets,
   foreignApps,
@@ -128,6 +189,7 @@ export function foreignArraysToResourceReferences({
   locals,
   boxes,
 }: {
+  appIndex: bigint | number;
   accounts?: ReadonlyArray<string | Address>;
   foreignAssets?: ReadonlyArray<number | bigint>;
   foreignApps?: ReadonlyArray<number | bigint>;
@@ -136,23 +198,91 @@ export function foreignArraysToResourceReferences({
   boxes?: ReadonlyArray<BoxReference>;
 }): Array<ResourceReference> {
   const accessList: Array<ResourceReference> = [];
+  function ensureAddress(addr: string | Address) {
+    let addr2: Address;
+    if (typeof addr === 'string') {
+      if (addr === '') {
+        return;
+      }
+      addr2 = Address.fromString(addr);
+    } else {
+      addr2 = addr;
+    }
+    if (addr2.equals(Address.zeroAddress())) {
+      return;
+    }
+    let addrFound = false;
+    for (const rr of accessList) {
+      if (!rr.address) {
+        continue;
+      }
+      let rrAddress = rr.address;
+      if (typeof rr.address === 'string') {
+        rrAddress = Address.fromString(rr.address);
+      }
+      if ((rrAddress as Address).equals(addr2)) {
+        addrFound = true;
+        break;
+      }
+    }
+    if (!addrFound) {
+      accessList.push({ address: addr });
+    }
+  }
+  function ensureAsset(asset: number | bigint) {
+    let assetFound = false;
+    for (const rr of accessList) {
+      if (rr.assetIndex && rr.assetIndex === asset) {
+        assetFound = true;
+        break;
+      }
+    }
+    if (!assetFound) {
+      accessList.push({ assetIndex: asset });
+    }
+  }
+  function ensureApp(app: number | bigint) {
+    let appFound = false;
+    for (const rr of accessList) {
+      if (rr.appIndex && rr.appIndex === app) {
+        appFound = true;
+        break;
+      }
+    }
+    if (!appFound) {
+      accessList.push({ appIndex: app });
+    }
+  }
   for (const acct of accounts ?? []) {
-    accessList.push({ address: acct });
+    ensureAddress(acct);
   }
   for (const asset of foreignAssets ?? []) {
-    accessList.push({ assetIndex: asset });
+    ensureAsset(asset);
   }
   for (const app of foreignApps ?? []) {
-    accessList.push({ appIndex: app });
+    ensureApp(app);
   }
   for (const holding of holdings ?? []) {
+    if (holding.address) {
+      ensureAddress(holding.address);
+    }
+    ensureAsset(holding.assetIndex);
     accessList.push({ holding });
   }
   for (const local of locals ?? []) {
+    if (local.address) {
+      ensureAddress(local.address);
+    }
+    if (local.appIndex && BigInt(local.appIndex) !== appIndex) {
+      ensureApp(local.appIndex);
+    }
     accessList.push({ locals: local });
   }
   for (const box of boxes ?? []) {
-    accessList.push({ boxes: box });
+    if (box.appIndex && BigInt(box.appIndex) !== appIndex) {
+      ensureApp(box.appIndex);
+    }
+    accessList.push({ box });
   }
   return accessList;
 }

--- a/src/appAccess.ts
+++ b/src/appAccess.ts
@@ -44,6 +44,7 @@ export function resourceReferencesToEncodingData(
   for (const rr of references) {
     if (rr.address || rr.assetIndex || rr.appIndex) {
       ensure(rr);
+      continue;
     }
 
     if (rr.holding) {
@@ -64,6 +65,7 @@ export function resourceReferencesToEncodingData(
           ],
         ])
       );
+      continue;
     }
     if (rr.locals) {
       const l = rr.locals;
@@ -86,6 +88,7 @@ export function resourceReferencesToEncodingData(
           ],
         ])
       );
+      continue;
     }
     if (rr.box) {
       const b = rr.box;
@@ -119,10 +122,15 @@ export function convertIndicesToResourceReferences(
     const appIndex = item.get('p') as bigint | undefined;
     if (address) {
       references.push({ address });
-    } else if (assetIndex) {
+      continue;
+    }
+    if (assetIndex) {
       references.push({ assetIndex });
-    } else if (appIndex) {
+      continue;
+    }
+    if (appIndex) {
       references.push({ appIndex });
+      continue;
     }
     const holding = item.get('h') as Map<string, unknown> | undefined;
     if (holding) {
@@ -137,6 +145,7 @@ export function convertIndicesToResourceReferences(
           : (references[hAddressIndex - 1].address as Address);
       const asset = references[hAssetIndex - 1].assetIndex as bigint;
       references.push({ holding: { address: hAddress, assetIndex: asset } });
+      continue;
     }
     const locals = item.get('l') as Map<string, unknown> | undefined;
     if (locals) {
@@ -151,6 +160,7 @@ export function convertIndicesToResourceReferences(
           ? BigInt(0)
           : (references[lAppIndex - 1].appIndex as bigint);
       references.push({ locals: { address: lAddress, appIndex: app } });
+      continue;
     }
     const box = item.get('b') as Map<string, unknown> | undefined;
     if (box) {
@@ -232,7 +242,7 @@ export function foreignArraysToResourceReferences({
   function ensureAsset(asset: number | bigint) {
     let assetFound = false;
     for (const rr of accessList) {
-      if (rr.assetIndex && rr.assetIndex === asset) {
+      if (rr.assetIndex === asset) {
         assetFound = true;
         break;
       }

--- a/src/appAccess.ts
+++ b/src/appAccess.ts
@@ -1,0 +1,154 @@
+import { Address } from './encoding/address.js';
+import {
+  BoxReference,
+  HoldingReference,
+  LocalsReference,
+  ResourceReference,
+} from './types/transactions/base.js';
+
+/**
+ * resourceReferencesToEncodingData translates an array of ResourceReferences into an array of encoding data
+ * maps.
+ */
+export function resourceReferencesToEncodingData(
+  appIndex: bigint,
+  references: ReadonlyArray<ResourceReference>
+): Array<Map<string, unknown>> {
+  const accessList: Array<Map<string, unknown>> = [];
+
+  function ensure(target: ResourceReference): number {
+    for (let idx = 0; idx < accessList.length; idx++) {
+      const a = accessList[idx];
+      if (a.size !== 1) {
+        throw new Error('more than a single resource reference set');
+      }
+      if (
+        a.get('d') === target.address ||
+        a.get('s') === target.assetIndex ||
+        a.get('p') === target.appIndex
+      ) {
+        return idx + 1; // 1-based index
+      }
+    }
+    if (target.appIndex) {
+      accessList.push(new Map<string, unknown>([['d', target.address]]));
+    }
+    if (target.assetIndex) {
+      accessList.push(new Map<string, unknown>([['s', target.assetIndex]]));
+    }
+    if (target.appIndex) {
+      accessList.push(new Map<string, unknown>([['p', target.appIndex]]));
+    }
+    return accessList.length; // length is 1-based position of new element
+  }
+
+  const zeroAddr = Address.zeroAddress();
+
+  for (const rr of references) {
+    if (rr.address || rr.assetIndex || rr.appIndex) {
+      ensure(rr);
+    }
+
+    if (rr.holding) {
+      const h = rr.holding;
+      let addrIdx = 0;
+      if (h.address && !(h.address as Address).equals(zeroAddr)) {
+        addrIdx = ensure({ address: h.address });
+      }
+      const assetIdx = ensure({ assetIndex: h.assetIndex });
+      accessList.push(
+        new Map<string, unknown>([
+          [
+            'h',
+            new Map<string, unknown>([
+              ['d', addrIdx],
+              ['s', assetIdx],
+            ]),
+          ],
+        ])
+      );
+    }
+    if (rr.locals) {
+      const l = rr.locals;
+      let addrIdx = 0;
+      if (l.address && !(l.address as Address).equals(zeroAddr)) {
+        addrIdx = ensure({ address: l.address });
+      }
+      let appIdx = 0;
+      if (l.appIndex && BigInt(l.appIndex) !== appIndex) {
+        appIdx = ensure({ appIndex: l.appIndex });
+      }
+      accessList.push(
+        new Map<string, unknown>([
+          [
+            'l',
+            new Map<string, unknown>([
+              ['d', addrIdx],
+              ['p', appIdx],
+            ]),
+          ],
+        ])
+      );
+    }
+    if (rr.boxes) {
+      const b = rr.boxes;
+      let appIdx = 0;
+      if (b.appIndex && BigInt(b.appIndex) !== appIndex) {
+        appIdx = ensure({ appIndex: b.appIndex });
+      }
+      accessList.push(
+        new Map<string, unknown>([
+          [
+            'b',
+            new Map<string, unknown>([
+              ['i', appIdx],
+              ['n', b.name],
+            ]),
+          ],
+        ])
+      );
+    }
+  }
+  return accessList;
+}
+
+/**
+ * foreignArraysToResourceReferences makes a single array of ResourceReferences from various foreign resource arrays.
+ * Note, runtime representation of ResourceReference uses addresses, app and asset identifiers, not indexes.
+ *
+ * @param accounts - optional array of accounts
+ * @param foreignApps - optional array of foreign apps
+ * @param foreignAssets - optional array of foreign assets
+ * @param holdings - optional array of holdings
+ * @param locals - optional array of locals
+ * @param boxes - optional array of boxes
+ */
+export function foreignArraysToResourceReferences(
+  accounts?: ReadonlyArray<string | Address>,
+  foreignApps?: ReadonlyArray<number | bigint>,
+  foreignAssets?: ReadonlyArray<number | bigint>,
+  holdings?: ReadonlyArray<HoldingReference>,
+  locals?: ReadonlyArray<LocalsReference>,
+  boxes?: ReadonlyArray<BoxReference>
+): Array<ResourceReference> {
+  const accessList: Array<ResourceReference> = [];
+  for (const acct of accounts ?? []) {
+    accessList.push({ address: acct });
+  }
+  for (const app of foreignApps ?? []) {
+    accessList.push({ appIndex: app });
+  }
+  for (const asset of foreignAssets ?? []) {
+    accessList.push({ assetIndex: asset });
+  }
+  for (const holding of holdings ?? []) {
+    accessList.push({ holding });
+  }
+  for (const local of locals ?? []) {
+    accessList.push({ locals: local });
+  }
+  for (const box of boxes ?? []) {
+    accessList.push({ boxes: box });
+  }
+  return accessList;
+}

--- a/src/appAccess.ts
+++ b/src/appAccess.ts
@@ -19,18 +19,15 @@ export function resourceReferencesToEncodingData(
   function ensure(target: ResourceReference): number {
     for (let idx = 0; idx < accessList.length; idx++) {
       const a = accessList[idx];
-      if (a.size !== 1) {
-        throw new Error('more than a single resource reference set');
-      }
       if (
-        a.get('d') === target.address ||
-        a.get('s') === target.assetIndex ||
+        a.get('d') === target.address &&
+        a.get('s') === target.assetIndex &&
         a.get('p') === target.appIndex
       ) {
         return idx + 1; // 1-based index
       }
     }
-    if (target.appIndex) {
+    if (target.address) {
       accessList.push(new Map<string, unknown>([['d', target.address]]));
     }
     if (target.assetIndex) {
@@ -117,29 +114,36 @@ export function resourceReferencesToEncodingData(
  * Note, runtime representation of ResourceReference uses addresses, app and asset identifiers, not indexes.
  *
  * @param accounts - optional array of accounts
- * @param foreignApps - optional array of foreign apps
  * @param foreignAssets - optional array of foreign assets
+ * @param foreignApps - optional array of foreign apps
  * @param holdings - optional array of holdings
  * @param locals - optional array of locals
  * @param boxes - optional array of boxes
  */
-export function foreignArraysToResourceReferences(
-  accounts?: ReadonlyArray<string | Address>,
-  foreignApps?: ReadonlyArray<number | bigint>,
-  foreignAssets?: ReadonlyArray<number | bigint>,
-  holdings?: ReadonlyArray<HoldingReference>,
-  locals?: ReadonlyArray<LocalsReference>,
-  boxes?: ReadonlyArray<BoxReference>
-): Array<ResourceReference> {
+export function foreignArraysToResourceReferences({
+  accounts,
+  foreignAssets,
+  foreignApps,
+  holdings,
+  locals,
+  boxes,
+}: {
+  accounts?: ReadonlyArray<string | Address>;
+  foreignAssets?: ReadonlyArray<number | bigint>;
+  foreignApps?: ReadonlyArray<number | bigint>;
+  holdings?: ReadonlyArray<HoldingReference>;
+  locals?: ReadonlyArray<LocalsReference>;
+  boxes?: ReadonlyArray<BoxReference>;
+}): Array<ResourceReference> {
   const accessList: Array<ResourceReference> = [];
   for (const acct of accounts ?? []) {
     accessList.push({ address: acct });
   }
-  for (const app of foreignApps ?? []) {
-    accessList.push({ appIndex: app });
-  }
   for (const asset of foreignAssets ?? []) {
     accessList.push({ assetIndex: asset });
+  }
+  for (const app of foreignApps ?? []) {
+    accessList.push({ appIndex: app });
   }
   for (const holding of holdings ?? []) {
     accessList.push({ holding });

--- a/src/makeTxn.ts
+++ b/src/makeTxn.ts
@@ -9,8 +9,10 @@ import {
   AssetTransferTransactionParams,
   AssetFreezeTransactionParams,
   ApplicationCallTransactionParams,
+  ApplicationCallReferenceParams,
 } from './types/transactions/base.js';
 import { Address } from './encoding/address.js';
+import { foreignArraysToResourceReferences } from './appAccess.js';
 
 /** Contains parameters common to every transaction type */
 export interface CommonTransactionParams {
@@ -397,6 +399,10 @@ export function makeApplicationCallTxnFromObject({
   foreignApps,
   foreignAssets,
   boxes,
+  convertToAccess,
+  holdings,
+  locals,
+  access,
   approvalProgram,
   clearProgram,
   numLocalInts,
@@ -408,9 +414,28 @@ export function makeApplicationCallTxnFromObject({
   lease,
   rekeyTo,
   suggestedParams,
-}: ApplicationCallTransactionParams & CommonTransactionParams): Transaction {
+}: ApplicationCallTransactionParams &
+  CommonTransactionParams &
+  ApplicationCallReferenceParams): Transaction {
   if (onComplete == null) {
     throw Error('onComplete must be provided');
+  }
+  if (
+    access &&
+    (accounts || foreignApps || foreignAssets || boxes || holdings || locals)
+  ) {
+    throw Error('cannot specify both access and other access fields');
+  }
+  let access2 = access;
+  if (convertToAccess) {
+    access2 = foreignArraysToResourceReferences(
+      accounts,
+      foreignApps,
+      foreignAssets,
+      holdings,
+      locals,
+      boxes
+    );
   }
   return new Transaction({
     type: TransactionType.appl,
@@ -427,6 +452,7 @@ export function makeApplicationCallTxnFromObject({
       foreignAssets,
       foreignApps,
       boxes,
+      access: access2,
       approvalProgram,
       clearProgram,
       numLocalInts,
@@ -451,6 +477,10 @@ export function makeApplicationCreateTxnFromObject({
   foreignApps,
   foreignAssets,
   boxes,
+  convertToAccess,
+  holdings,
+  locals,
+  access,
   approvalProgram,
   clearProgram,
   numLocalInts,
@@ -469,7 +499,8 @@ export function makeApplicationCreateTxnFromObject({
   Required<
     Pick<ApplicationCallTransactionParams, 'approvalProgram' | 'clearProgram'>
   > &
-  CommonTransactionParams): Transaction {
+  CommonTransactionParams &
+  ApplicationCallReferenceParams): Transaction {
   if (!approvalProgram || !clearProgram) {
     throw Error('approvalProgram and clearProgram must be provided');
   }
@@ -485,6 +516,10 @@ export function makeApplicationCreateTxnFromObject({
     foreignApps,
     foreignAssets,
     boxes,
+    convertToAccess,
+    holdings,
+    locals,
+    access,
     approvalProgram,
     clearProgram,
     numLocalInts,
@@ -512,6 +547,10 @@ export function makeApplicationUpdateTxnFromObject({
   foreignApps,
   foreignAssets,
   boxes,
+  convertToAccess,
+  holdings,
+  locals,
+  access,
   approvalProgram,
   clearProgram,
   note,
@@ -532,7 +571,8 @@ export function makeApplicationUpdateTxnFromObject({
   Required<
     Pick<ApplicationCallTransactionParams, 'approvalProgram' | 'clearProgram'>
   > &
-  CommonTransactionParams): Transaction {
+  CommonTransactionParams &
+  ApplicationCallReferenceParams): Transaction {
   if (!appIndex) {
     throw Error('appIndex must be provided');
   }
@@ -548,6 +588,10 @@ export function makeApplicationUpdateTxnFromObject({
     foreignApps,
     foreignAssets,
     boxes,
+    convertToAccess,
+    holdings,
+    locals,
+    access,
     approvalProgram,
     clearProgram,
     note,
@@ -570,6 +614,10 @@ export function makeApplicationDeleteTxnFromObject({
   foreignApps,
   foreignAssets,
   boxes,
+  convertToAccess,
+  holdings,
+  locals,
+  access,
   note,
   lease,
   rekeyTo,
@@ -585,7 +633,8 @@ export function makeApplicationDeleteTxnFromObject({
   | 'approvalProgram'
   | 'clearProgram'
 > &
-  CommonTransactionParams): Transaction {
+  CommonTransactionParams &
+  ApplicationCallReferenceParams): Transaction {
   if (!appIndex) {
     throw Error('appIndex must be provided');
   }
@@ -598,6 +647,10 @@ export function makeApplicationDeleteTxnFromObject({
     foreignApps,
     foreignAssets,
     boxes,
+    convertToAccess,
+    holdings,
+    locals,
+    access,
     note,
     lease,
     rekeyTo,
@@ -618,6 +671,10 @@ export function makeApplicationOptInTxnFromObject({
   foreignApps,
   foreignAssets,
   boxes,
+  convertToAccess,
+  holdings,
+  locals,
+  access,
   note,
   lease,
   rekeyTo,
@@ -633,7 +690,8 @@ export function makeApplicationOptInTxnFromObject({
   | 'approvalProgram'
   | 'clearProgram'
 > &
-  CommonTransactionParams): Transaction {
+  CommonTransactionParams &
+  ApplicationCallReferenceParams): Transaction {
   if (!appIndex) {
     throw Error('appIndex must be provided');
   }
@@ -647,6 +705,10 @@ export function makeApplicationOptInTxnFromObject({
     foreignAssets,
     boxes,
     note,
+    convertToAccess,
+    holdings,
+    locals,
+    access,
     lease,
     rekeyTo,
     suggestedParams,
@@ -666,6 +728,10 @@ export function makeApplicationCloseOutTxnFromObject({
   foreignApps,
   foreignAssets,
   boxes,
+  convertToAccess,
+  holdings,
+  locals,
+  access,
   note,
   lease,
   rekeyTo,
@@ -681,7 +747,8 @@ export function makeApplicationCloseOutTxnFromObject({
   | 'approvalProgram'
   | 'clearProgram'
 > &
-  CommonTransactionParams): Transaction {
+  CommonTransactionParams &
+  ApplicationCallReferenceParams): Transaction {
   if (!appIndex) {
     throw Error('appIndex must be provided');
   }
@@ -694,6 +761,10 @@ export function makeApplicationCloseOutTxnFromObject({
     foreignApps,
     foreignAssets,
     boxes,
+    convertToAccess,
+    holdings,
+    locals,
+    access,
     note,
     lease,
     rekeyTo,
@@ -714,6 +785,10 @@ export function makeApplicationClearStateTxnFromObject({
   foreignApps,
   foreignAssets,
   boxes,
+  convertToAccess,
+  holdings,
+  locals,
+  access,
   note,
   lease,
   rekeyTo,
@@ -729,7 +804,8 @@ export function makeApplicationClearStateTxnFromObject({
   | 'approvalProgram'
   | 'clearProgram'
 > &
-  CommonTransactionParams): Transaction {
+  CommonTransactionParams &
+  ApplicationCallReferenceParams): Transaction {
   if (!appIndex) {
     throw Error('appIndex must be provided');
   }
@@ -742,6 +818,10 @@ export function makeApplicationClearStateTxnFromObject({
     foreignApps,
     foreignAssets,
     boxes,
+    convertToAccess,
+    holdings,
+    locals,
+    access,
     note,
     lease,
     rekeyTo,
@@ -762,6 +842,10 @@ export function makeApplicationNoOpTxnFromObject({
   foreignApps,
   foreignAssets,
   boxes,
+  convertToAccess,
+  holdings,
+  locals,
+  access,
   note,
   lease,
   rekeyTo,
@@ -777,7 +861,8 @@ export function makeApplicationNoOpTxnFromObject({
   | 'approvalProgram'
   | 'clearProgram'
 > &
-  CommonTransactionParams): Transaction {
+  CommonTransactionParams &
+  ApplicationCallReferenceParams): Transaction {
   if (!appIndex) {
     throw Error('appIndex must be provided');
   }
@@ -790,6 +875,10 @@ export function makeApplicationNoOpTxnFromObject({
     foreignApps,
     foreignAssets,
     boxes,
+    convertToAccess,
+    holdings,
+    locals,
+    access,
     note,
     lease,
     rekeyTo,

--- a/src/makeTxn.ts
+++ b/src/makeTxn.ts
@@ -426,9 +426,14 @@ export function makeApplicationCallTxnFromObject({
   ) {
     throw Error('cannot specify both access and other access fields');
   }
+  let accounts2 = accounts;
+  let foreignApps2 = foreignApps;
+  let foreignAssets2 = foreignAssets;
+  let boxes2 = boxes;
   let access2 = access;
   if (convertToAccess) {
     access2 = foreignArraysToResourceReferences({
+      appIndex,
       accounts,
       foreignApps,
       foreignAssets,
@@ -436,6 +441,10 @@ export function makeApplicationCallTxnFromObject({
       locals,
       boxes,
     });
+    accounts2 = undefined;
+    foreignApps2 = undefined;
+    foreignAssets2 = undefined;
+    boxes2 = undefined;
   }
   return new Transaction({
     type: TransactionType.appl,
@@ -448,10 +457,10 @@ export function makeApplicationCallTxnFromObject({
       appIndex,
       onComplete,
       appArgs,
-      accounts,
-      foreignAssets,
-      foreignApps,
-      boxes,
+      accounts: accounts2,
+      foreignAssets: foreignAssets2,
+      foreignApps: foreignApps2,
+      boxes: boxes2,
       access: access2,
       approvalProgram,
       clearProgram,

--- a/src/makeTxn.ts
+++ b/src/makeTxn.ts
@@ -428,14 +428,14 @@ export function makeApplicationCallTxnFromObject({
   }
   let access2 = access;
   if (convertToAccess) {
-    access2 = foreignArraysToResourceReferences(
+    access2 = foreignArraysToResourceReferences({
       accounts,
       foreignApps,
       foreignAssets,
       holdings,
       locals,
-      boxes
-    );
+      boxes,
+    });
   }
   return new Transaction({
     type: TransactionType.appl,

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -229,26 +229,24 @@ function ensureResourceReference(input: unknown): TransactionResourceReference {
   if (input != null && typeof input === 'object') {
     const { address, appIndex, assetIndex, holding, locals, box } =
       input as TransactionResourceReference;
-    let result = {};
     if (address !== undefined) {
-      result = { ...result, address: ensureAddress(address) };
+      return { address: ensureAddress(address) };
     }
     if (appIndex !== undefined) {
-      result = { ...result, appIndex: utils.ensureUint64(appIndex) };
+      return { appIndex: utils.ensureUint64(appIndex) };
     }
     if (assetIndex !== undefined) {
-      result = { ...result, assetIndex: utils.ensureUint64(assetIndex) };
+      return { assetIndex: utils.ensureUint64(assetIndex) };
     }
     if (holding !== undefined) {
-      result = { ...result, holding: ensureHoldingReference(holding) };
+      return { holding: ensureHoldingReference(holding) };
     }
     if (locals !== undefined) {
-      result = { ...result, locals: ensureLocalsReference(locals) };
+      return { locals: ensureLocalsReference(locals) };
     }
     if (box !== undefined) {
-      result = { ...result, box: ensureBoxReference(box) };
+      return { box: ensureBoxReference(box) };
     }
-    return result;
   }
   throw new Error(`Not a resource reference: ${input}`);
 }

--- a/src/types/transactions/base.ts
+++ b/src/types/transactions/base.ts
@@ -258,7 +258,7 @@ export interface ResourceReference {
   /**
    * Box definition: application ID and a name of the box
    */
-  boxes?: BoxReference;
+  box?: BoxReference;
 }
 
 /**

--- a/src/types/transactions/base.ts
+++ b/src/types/transactions/base.ts
@@ -182,6 +182,86 @@ export interface BoxReference {
 }
 
 /**
+ * A grouping of the asset index and address of the account
+ */
+export interface HoldingReference {
+  /**
+   * The asset index of the holding
+   */
+  assetIndex: number | bigint;
+
+  /**
+   * The address of the account holding the asset
+   */
+  address: string | Address;
+}
+
+/** A grouping of the application index and address of the account
+ */
+export interface LocalsReference {
+  /**
+   * The application index of the local state
+   */
+  appIndex: number | bigint;
+
+  /**
+   * The address of the account holding the local state
+   */
+  address: string | Address;
+}
+
+/**
+ * Parameters for resource references in application transactions
+ */
+export interface ApplicationCallReferenceParams {
+  /**
+   * A grouping of the asset index and address of the account
+   */
+  holdings?: HoldingReference[];
+
+  /** A grouping of the application index and address of the account
+   */
+  locals?: LocalsReference[];
+
+  /**
+   * If true, use the foreign accounts, apps, assets, boxes, holdings, and locals fields to construct the access list
+   */
+  convertToAccess?: boolean;
+}
+
+export interface ResourceReference {
+  /**
+   * Address string, any additional accounts to supply to the application
+   */
+  address?: string | Address;
+
+  /**
+   * Asset index uniquely specifying the asset
+   */
+  assetIndex?: number | bigint;
+
+  /**
+   * A unique application ID
+   */
+  appIndex?: number | bigint;
+
+  /**
+   * Holding definition: asset ID and account address
+   */
+  holding?: HoldingReference;
+
+  /**
+   * Local state definition: application ID and account address
+   */
+  locals?: LocalsReference;
+
+  /**
+   * Box definition: application ID and a name of the box
+   */
+  boxes?: BoxReference;
+}
+
+/**
  * Contains payment transaction parameters.
  *
  * The full documentation is available at:
@@ -451,6 +531,11 @@ export interface ApplicationCallTransactionParams {
    * A grouping of the app ID and name of the box in an Uint8Array
    */
   boxes?: BoxReference[];
+
+  /**
+   * Resources accessed by the application
+   */
+  access?: ResourceReference[];
 }
 
 /**

--- a/tests/5.Transaction.ts
+++ b/tests/5.Transaction.ts
@@ -2195,6 +2195,11 @@ describe('Convert', () => {
       const foreignAssets = [2222, 3333];
       const foreignApps = [222, 333];
 
+      const boxNames = [
+        new TextEncoder().encode('aaa'),
+        new TextEncoder().encode('bbb'),
+        new TextEncoder().encode('bbb2'),
+      ];
       const testCases = [
         [
           {
@@ -2235,9 +2240,9 @@ describe('Convert', () => {
             foreignAssets,
             foreignApps,
             boxes: [
-              { appIndex: 3, name: Buffer.from('aaa') },
-              { appIndex: 0, name: Buffer.from('bbb') },
-              { appIndex: 111, name: Buffer.from('bbb2') },
+              { appIndex: 3, name: boxNames[0] },
+              { appIndex: 0, name: boxNames[1] },
+              { appIndex: 111, name: boxNames[2] },
             ],
           },
           [
@@ -2254,7 +2259,7 @@ describe('Convert', () => {
                 'b',
                 new Map<string, any>([
                   ['i', 7],
-                  ['n', Buffer.from('aaa')],
+                  ['n', boxNames[0]],
                 ]),
               ],
             ]),
@@ -2263,7 +2268,7 @@ describe('Convert', () => {
                 'b',
                 new Map<string, any>([
                   ['i', 0],
-                  ['n', Buffer.from('bbb')],
+                  ['n', boxNames[1]],
                 ]),
               ],
             ]),
@@ -2272,7 +2277,7 @@ describe('Convert', () => {
                 'b',
                 new Map<string, any>([
                   ['i', 0],
-                  ['n', Buffer.from('bbb2')],
+                  ['n', boxNames[2]],
                 ]),
               ],
             ]),
@@ -2284,9 +2289,9 @@ describe('Convert', () => {
             foreignAssets,
             foreignApps,
             boxes: [
-              { appIndex: 3, name: Buffer.from('aaa') },
-              { appIndex: 0, name: Buffer.from('bbb') },
-              { appIndex: 111, name: Buffer.from('bbb2') },
+              { appIndex: 3, name: boxNames[0] },
+              { appIndex: 0, name: boxNames[1] },
+              { appIndex: 111, name: boxNames[2] },
             ],
             holdings: [
               { assetIndex: 111, address: one },
@@ -2328,7 +2333,7 @@ describe('Convert', () => {
                 'b',
                 new Map<string, any>([
                   ['i', 11],
-                  ['n', Buffer.from('aaa')],
+                  ['n', boxNames[0]],
                 ]),
               ],
             ]),
@@ -2337,7 +2342,7 @@ describe('Convert', () => {
                 'b',
                 new Map<string, any>([
                   ['i', 0],
-                  ['n', Buffer.from('bbb')],
+                  ['n', boxNames[1]],
                 ]),
               ],
             ]),
@@ -2346,7 +2351,7 @@ describe('Convert', () => {
                 'b',
                 new Map<string, any>([
                   ['i', 0],
-                  ['n', Buffer.from('bbb2')],
+                  ['n', boxNames[2]],
                 ]),
               ],
             ]),
@@ -2358,9 +2363,9 @@ describe('Convert', () => {
             foreignAssets,
             foreignApps,
             boxes: [
-              { appIndex: 3, name: Buffer.from('aaa') },
-              { appIndex: 0, name: Buffer.from('bbb') },
-              { appIndex: 111, name: Buffer.from('bbb2') },
+              { appIndex: 3, name: boxNames[0] },
+              { appIndex: 0, name: boxNames[1] },
+              { appIndex: 111, name: boxNames[2] },
             ],
             holdings: [
               { assetIndex: 111, address: one },
@@ -2437,7 +2442,7 @@ describe('Convert', () => {
                 'b',
                 new Map<string, any>([
                   ['i', 16],
-                  ['n', Buffer.from('aaa')],
+                  ['n', boxNames[0]],
                 ]),
               ],
             ]),
@@ -2446,7 +2451,7 @@ describe('Convert', () => {
                 'b',
                 new Map<string, any>([
                   ['i', 0],
-                  ['n', Buffer.from('bbb')],
+                  ['n', boxNames[1]],
                 ]),
               ],
             ]),
@@ -2455,7 +2460,7 @@ describe('Convert', () => {
                 'b',
                 new Map<string, any>([
                   ['i', 0],
-                  ['n', Buffer.from('bbb2')],
+                  ['n', boxNames[2]],
                 ]),
               ],
             ]),

--- a/tests/5.Transaction.ts
+++ b/tests/5.Transaction.ts
@@ -2173,7 +2173,7 @@ describe('Sign', () => {
   });
 });
 
-describe('Application Resources Refeneces', () => {
+describe('Application Resources References', () => {
   describe('foreign arrays to resource references', () => {
     const accounts = [
       Address.fromString(
@@ -2491,6 +2491,72 @@ describe('Application Resources Refeneces', () => {
         const res = resourceReferencesToEncodingData(appIndex, references);
         assert.deepStrictEqual(res, expected, JSON.stringify(testCase[0]));
       }
+    });
+    it('should throw if both access and foreign arrays provided', () => {
+      assert.throws(
+        () =>
+          algosdk.makeApplicationCallTxnFromObject({
+            sender:
+              'BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4',
+            appIndex: 111,
+            onComplete: algosdk.OnApplicationComplete.NoOpOC,
+            foreignApps,
+            access: [{ assetIndex: 123 }],
+            suggestedParams: {
+              minFee: 1000,
+              fee: 0,
+              firstValid: 322575,
+              lastValid: 323575,
+              genesisID: 'testnet-v1.0',
+              genesisHash: algosdk.base64ToBytes(
+                'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI='
+              ),
+            },
+          }),
+        Error('cannot specify both access and other access fields')
+      );
+    });
+    it('should not create access if convertToAccess is false', () => {
+      const txn = algosdk.makeApplicationCallTxnFromObject({
+        sender: 'BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4',
+        appIndex: 111,
+        onComplete: algosdk.OnApplicationComplete.NoOpOC,
+        foreignApps,
+        foreignAssets,
+        convertToAccess: false,
+        suggestedParams: {
+          minFee: 1000,
+          fee: 0,
+          firstValid: 322575,
+          lastValid: 323575,
+          genesisID: 'testnet-v1.0',
+          genesisHash: algosdk.base64ToBytes(
+            'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI='
+          ),
+        },
+      });
+      assert.deepStrictEqual(txn.applicationCall?.access, []);
+    });
+    it.only('should accept access list', () => {
+      const txn = algosdk.makeApplicationCallTxnFromObject({
+        sender: 'BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4',
+        appIndex: 111,
+        onComplete: algosdk.OnApplicationComplete.NoOpOC,
+        access: [{ assetIndex: 123 }],
+        suggestedParams: {
+          minFee: 1000,
+          fee: 0,
+          firstValid: 322575,
+          lastValid: 323575,
+          genesisID: 'testnet-v1.0',
+          genesisHash: algosdk.base64ToBytes(
+            'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI='
+          ),
+        },
+      });
+      assert.deepStrictEqual(txn.applicationCall?.access, [
+        { assetIndex: BigInt(123) },
+      ]);
     });
     it('should correctly serialize and deserialize an application transaction with access', () => {
       const expectedTxn = algosdk.makeApplicationCallTxnFromObject({

--- a/tests/5.Transaction.ts
+++ b/tests/5.Transaction.ts
@@ -1,7 +1,13 @@
 /* eslint-env mocha */
 import assert from 'assert';
-import algosdk from '../src/index.js';
+import algosdk, { HoldingReference, LocalsReference } from '../src/index.js';
+import { Address } from '../src/encoding/address.js';
 import { boxReferencesToEncodingData } from '../src/boxStorage.js';
+import {
+  foreignArraysToResourceReferences,
+  resourceReferencesToEncodingData,
+} from '../src/appAccess.js';
+import { BoxReference } from '../src/types/transactions/base.js';
 
 describe('Sign', () => {
   it('should not modify input arrays', () => {
@@ -2162,6 +2168,322 @@ describe('Sign', () => {
           testCase[2]
         );
         assert.deepStrictEqual(actual, expected);
+      }
+    });
+  });
+});
+
+describe('Convert', () => {
+  describe('foreign arrays to resource references', () => {
+    it('should convert', () => {
+      const appIndex = BigInt(111);
+      const accounts = [
+        Address.fromString(
+          '47YPQTIGQEO7T4Y4RWDYWEKV6RTR2UNBQXBABEEGM72ESWDQNCQ52OPASU'
+        ),
+        Address.fromString(
+          'BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4'
+        ),
+      ];
+      const zero = Address.zeroAddress();
+      const one = Address.fromString(
+        'AEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKE3PRHE'
+      );
+      const two = Address.fromString(
+        'AIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGFFWAF4'
+      );
+      const foreignAssets = [2222, 3333];
+      const foreignApps = [222, 333];
+
+      const testCases = [
+        [
+          {
+            accounts,
+          },
+          [new Map([['d', accounts[0]]]), new Map([['d', accounts[1]]])],
+        ],
+        [
+          {
+            accounts,
+            foreignAssets,
+          },
+          [
+            new Map([['d', accounts[0]]]),
+            new Map([['d', accounts[1]]]),
+            new Map([['s', 2222]]),
+            new Map([['s', 3333]]),
+          ],
+        ],
+        [
+          {
+            accounts,
+            foreignAssets,
+            foreignApps,
+          },
+          [
+            new Map([['d', accounts[0]]]),
+            new Map([['d', accounts[1]]]),
+            new Map([['s', 2222]]),
+            new Map([['s', 3333]]),
+            new Map([['p', 222]]),
+            new Map([['p', 333]]),
+          ],
+        ],
+        [
+          {
+            accounts,
+            foreignAssets,
+            foreignApps,
+            boxes: [
+              { appIndex: 3, name: Buffer.from('aaa') },
+              { appIndex: 0, name: Buffer.from('bbb') },
+              { appIndex: 111, name: Buffer.from('bbb2') },
+            ],
+          },
+          [
+            new Map([['d', accounts[0]]]),
+            new Map([['d', accounts[1]]]),
+            new Map([['s', 2222]]),
+            new Map([['s', 3333]]),
+            new Map([['p', 222]]),
+            new Map([['p', 333]]),
+
+            new Map([['p', 3]]),
+            new Map([
+              [
+                'b',
+                new Map<string, any>([
+                  ['i', 7],
+                  ['n', Buffer.from('aaa')],
+                ]),
+              ],
+            ]),
+            new Map([
+              [
+                'b',
+                new Map<string, any>([
+                  ['i', 0],
+                  ['n', Buffer.from('bbb')],
+                ]),
+              ],
+            ]),
+            new Map([
+              [
+                'b',
+                new Map<string, any>([
+                  ['i', 0],
+                  ['n', Buffer.from('bbb2')],
+                ]),
+              ],
+            ]),
+          ],
+        ],
+        [
+          {
+            accounts,
+            foreignAssets,
+            foreignApps,
+            boxes: [
+              { appIndex: 3, name: Buffer.from('aaa') },
+              { appIndex: 0, name: Buffer.from('bbb') },
+              { appIndex: 111, name: Buffer.from('bbb2') },
+            ],
+            holdings: [
+              { assetIndex: 111, address: one },
+              { assetIndex: 3333, address: zero },
+            ],
+          },
+          [
+            new Map([['d', accounts[0]]]),
+            new Map([['d', accounts[1]]]),
+            new Map([['s', 2222]]),
+            new Map([['s', 3333]]),
+            new Map([['p', 222]]),
+            new Map([['p', 333]]),
+
+            new Map([['d', one]]),
+            new Map([['s', 111]]),
+            new Map([
+              [
+                'h',
+                new Map<string, any>([
+                  ['s', 8],
+                  ['d', 7],
+                ]),
+              ],
+            ]),
+            new Map([
+              [
+                'h',
+                new Map<string, any>([
+                  ['s', 4],
+                  ['d', 0],
+                ]),
+              ],
+            ]),
+
+            new Map([['p', 3]]),
+            new Map([
+              [
+                'b',
+                new Map<string, any>([
+                  ['i', 11],
+                  ['n', Buffer.from('aaa')],
+                ]),
+              ],
+            ]),
+            new Map([
+              [
+                'b',
+                new Map<string, any>([
+                  ['i', 0],
+                  ['n', Buffer.from('bbb')],
+                ]),
+              ],
+            ]),
+            new Map([
+              [
+                'b',
+                new Map<string, any>([
+                  ['i', 0],
+                  ['n', Buffer.from('bbb2')],
+                ]),
+              ],
+            ]),
+          ],
+        ],
+        [
+          {
+            accounts,
+            foreignAssets,
+            foreignApps,
+            boxes: [
+              { appIndex: 3, name: Buffer.from('aaa') },
+              { appIndex: 0, name: Buffer.from('bbb') },
+              { appIndex: 111, name: Buffer.from('bbb2') },
+            ],
+            holdings: [
+              { assetIndex: 111, address: one },
+              { assetIndex: 3333, address: zero },
+            ],
+            locals: [
+              { appIndex: 111, address: two },
+              { appIndex: 333, address: zero },
+              { appIndex: 444, address: one },
+            ],
+          },
+          [
+            new Map([['d', accounts[0]]]),
+            new Map([['d', accounts[1]]]),
+            new Map([['s', 2222]]),
+            new Map([['s', 3333]]),
+            new Map([['p', 222]]),
+            new Map([['p', 333]]),
+
+            new Map([['d', one]]),
+            new Map([['s', 111]]),
+            new Map([
+              [
+                'h',
+                new Map<string, any>([
+                  ['s', 8],
+                  ['d', 7],
+                ]),
+              ],
+            ]),
+            new Map([
+              [
+                'h',
+                new Map<string, any>([
+                  ['s', 4],
+                  ['d', 0],
+                ]),
+              ],
+            ]),
+
+            new Map([['d', two]]),
+            new Map([
+              [
+                'l',
+                new Map<string, any>([
+                  ['p', 0],
+                  ['d', 11],
+                ]),
+              ],
+            ]),
+            new Map([
+              [
+                'l',
+                new Map<string, any>([
+                  ['p', 6],
+                  ['d', 0],
+                ]),
+              ],
+            ]),
+            new Map([['p', 444]]),
+            new Map([
+              [
+                'l',
+                new Map<string, any>([
+                  ['p', 14],
+                  ['d', 7],
+                ]),
+              ],
+            ]),
+
+            new Map([['p', 3]]),
+            new Map([
+              [
+                'b',
+                new Map<string, any>([
+                  ['i', 16],
+                  ['n', Buffer.from('aaa')],
+                ]),
+              ],
+            ]),
+            new Map([
+              [
+                'b',
+                new Map<string, any>([
+                  ['i', 0],
+                  ['n', Buffer.from('bbb')],
+                ]),
+              ],
+            ]),
+            new Map([
+              [
+                'b',
+                new Map<string, any>([
+                  ['i', 0],
+                  ['n', Buffer.from('bbb2')],
+                ]),
+              ],
+            ]),
+          ],
+        ],
+      ];
+
+      for (const testCase of testCases) {
+        // testCase is a 2-tuple: [ inputObject, expectedEncoding ]
+        const inputs = testCase[0] as {
+          accounts: Address[];
+          foreignAssets?: bigint[];
+          foreignApps?: bigint[];
+          holdings?: HoldingReference[];
+          locals?: LocalsReference[];
+          boxes?: BoxReference[];
+        };
+        const expected = testCase[1];
+        const references = foreignArraysToResourceReferences({
+          accounts: inputs.accounts,
+          foreignAssets: inputs.foreignAssets,
+          foreignApps: inputs.foreignApps,
+          holdings: inputs.holdings,
+          locals: inputs.locals,
+          boxes: inputs.boxes,
+        });
+        const res = resourceReferencesToEncodingData(appIndex, references);
+        assert.deepStrictEqual(res, expected, JSON.stringify(testCase[0]));
       }
     });
   });

--- a/tests/5.Transaction.ts
+++ b/tests/5.Transaction.ts
@@ -2537,7 +2537,7 @@ describe('Application Resources References', () => {
       });
       assert.deepStrictEqual(txn.applicationCall?.access, []);
     });
-    it.only('should accept access list', () => {
+    it('should accept access list', () => {
       const txn = algosdk.makeApplicationCallTxnFromObject({
         sender: 'BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4',
         appIndex: 111,


### PR DESCRIPTION
## Summary

Add `txn.Access` support similarly to other SDKs and tests.
The caveat is JS SDK uses the same types for deflated and inflated representation of box references (and so that holdings and locals inside resource reference) and accepts weakly typed addresses (`string`, `Address`).
This type acrobatics while maintaining proper inflated/deflated versions contributed to the PR size.