### PR TITLE
Apps: Make sure reject version param gets serialized to message pack format

### DIFF
--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -588,6 +588,7 @@ export class Transaction implements encoding.Encodable {
         ),
       },
       { key: 'apep', valueSchema: new OptionalSchema(new Uint64Schema()) },
+      { key: 'aprv', valueSchema: new OptionalSchema(new Uint64Schema()) },
       // StateProof
       { key: 'sptype', valueSchema: new OptionalSchema(new Uint64Schema()) },
       { key: 'sp', valueSchema: new OptionalSchema(StateProof.encodingSchema) },

--- a/tests/5.Transaction.ts
+++ b/tests/5.Transaction.ts
@@ -2643,8 +2643,11 @@ describe('Application Resources References', () => {
       const encodingData = txnWithRejectVersion.toEncodingData();
       assert.strictEqual(encodingData.get('aprv'), 5);
 
-      // Note: Serialization/deserialization test temporarily removed due to msgpack decoding issue
-      // The core functionality works correctly as verified by other tests
+      // Test serialization/deserialization
+      const encodedTxn =
+        algosdk.encodeUnsignedTransaction(txnWithRejectVersion);
+      const decodedTxn = algosdk.decodeUnsignedTransaction(encodedTxn);
+      assert.strictEqual(decodedTxn.applicationCall?.rejectVersion, 5);
 
       // Test with default rejectVersion (should be 0)
       const txnDefaultRejectVersion = algosdk.makeApplicationCallTxnFromObject({


### PR DESCRIPTION
Fixes #1006 