### PR TITLE
CI: permissions for publishing via OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,10 @@ on:
         type: string
         default: "22"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   release_and_publish:
     runs-on: ubuntu-24.04
@@ -97,8 +101,6 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Publish release to NPM
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.ALGORAND_NPM_TOKEN }}
         run: |
           # Ensure we're on the latest version of the branch
           git checkout ${{ steps.get_pr_info.outputs.BASE_BRANCH }}


### PR DESCRIPTION
# Summary

NPM is improving their security stance by limiting token lifetime, which is another reason to switch to OIDC authentication.

This change will remove the NPM token from the main release file, as well as add permissions so that an OIDC token can be generated. As a result token regeneration for the regular workflow should no longer be required.

On the other side of this NPM was updated to allow publishing from this workflow.

Because you can only have one authorized workflow, the `publish.yml` workflow was left unmodified. Note that this token will age out, requiring regeneration to run, but as this is infrequent and require assistance from someone who is authorized, this is acceptable.

# Testing

N/A
