### PR TITLE
CI: fix npm publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
       - run: |
           if git diff-index --quiet HEAD --; then
             echo 'DRY_RUN: '$DRY_RUN
-            if [ '$DRY_RUN' == 'false' ]; then
+            if [ "$DRY_RUN" == 'false' ]; then
               npm publish
             else
               npm publish --dry-run

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ on:
         type: 'string'
       node_version:
         description: 'The node_version to build with.'
-        default: '22'
+        default: '24'
         required: true
         type: 'string'
       dry_run:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ on:
         description: "The Node.js version to use for publishing"
         required: true
         type: string
-        default: "22"
+        default: "24"
 
 permissions:
   id-token: write


### PR DESCRIPTION
This PR adds two changes. The first of which fixes the use of single quotes in bash to ensure the DRY_RUN variable is properly expanded. The second changes the default node version to 24, which includes the npm version that enables OIDC