### PR TITLE
fix: ABI Type decoders ignoring byteOffset in subarray views

### DIFF
--- a/src/abi/abi_type.ts
+++ b/src/abi/abi_type.ts
@@ -32,13 +32,7 @@ const staticArrayRegexp = /^([a-z\d[\](),]+)\[(0|[1-9][\d]*)]$/;
 const ufixedRegexp = /^ufixed([1-9][\d]*)x([1-9][\d]*)$/;
 
 export type ABIValue =
-  | boolean
-  | number
-  | bigint
-  | string
-  | Uint8Array
-  | ABIValue[]
-  | Address;
+  boolean | number | bigint | string | Uint8Array | ABIValue[] | Address;
 
 export abstract class ABIType {
   // Converts a ABIType object to a string
@@ -532,7 +526,14 @@ export class ABIArrayDynamicType extends ABIType {
   }
 
   decode(byteString: Uint8Array): ABIValue[] {
-    const view = new DataView(byteString.buffer, 0, LENGTH_ENCODE_BYTE_SIZE);
+    // Account for byteString's byteOffset: it may be a subarray view into a
+    // larger buffer (e.g. simulate/confirmation logs), in which case
+    // byteString.buffer is the whole backing buffer and byteOffset is non-zero.
+    const view = new DataView(
+      byteString.buffer,
+      byteString.byteOffset,
+      LENGTH_ENCODE_BYTE_SIZE
+    );
     const byteLength = view.getUint16(0);
     const convertedTuple = this.toABITupleType(byteLength);
     return convertedTuple.decode(
@@ -675,7 +676,16 @@ export class ABITupleType extends ABIType {
     const valuePartition: Array<Uint8Array | null> = [];
     let i = 0;
     let iterIndex = 0;
-    const view = new DataView(byteString.buffer);
+    // Account for byteString's byteOffset: it may be a subarray view into a
+    // larger buffer (e.g. simulate/confirmation logs), in which case
+    // byteString.buffer is the whole backing buffer and byteOffset is non-zero.
+    // getUint16 below is called with iterIndex, an offset relative to the start
+    // of byteString, so the view must begin at byteString.byteOffset.
+    const view = new DataView(
+      byteString.buffer,
+      byteString.byteOffset,
+      byteString.byteLength
+    );
 
     while (i < tupleTypes.length) {
       const tupleType = tupleTypes[i];

--- a/tests/10.ABI.ts
+++ b/tests/10.ABI.ts
@@ -440,6 +440,45 @@ describe('ABI encoding', () => {
     });
   });
 
+  it('should decode dynamic types from a non-zero byteOffset subarray view', () => {
+    // Regression test: decode() must honor the input Uint8Array's byteOffset.
+    // Simulate/confirmation logs and other API responses arrive as subarray
+    // views into a larger buffer (non-zero byteOffset). ABITupleType.decode and
+    // ABIArrayDynamicType.decode read dynamic head offsets via DataView.getUint16;
+    // if the DataView ignores byteOffset it reads from the wrong position and
+    // throws "dynamic index segment miscalculation: left is greater than right
+    // index" (or returns garbage).
+    const cases: Array<{ type: ABIType; value: ABIValue }> = [
+      { type: ABIType.from('(string,uint16)'), value: ['hello', BigInt(7)] },
+      {
+        type: ABIType.from('uint16[]'),
+        value: [BigInt(1), BigInt(2), BigInt(3)],
+      },
+      {
+        type: ABIType.from('(string,bool,bool,bool,bool,string)'),
+        value: ['AB', true, false, true, false, 'DE'],
+      },
+      { type: ABIType.from('string'), value: 'a longer string value' },
+    ];
+
+    for (const { type, value } of cases) {
+      const encoded = type.encode(value);
+      // Place the encoding at a non-zero offset inside a larger backing buffer.
+      const offset = 5;
+      const backing = new Uint8Array(offset + encoded.length + 3);
+      backing.set(encoded, offset);
+      const view = backing.subarray(offset, offset + encoded.length);
+      assert.notStrictEqual(view.byteOffset, 0);
+
+      const decoded = type.decode(view);
+      assert.deepStrictEqual(
+        decoded,
+        value,
+        `failed to decode ${type} from offset view`
+      );
+    }
+  });
+
   it('should fail for bad values during encoding', () => {
     assert.throws(() => new ABIUintType(8).encode(BigInt(-1)));
     assert.throws(() => new ABIUintType(512).encode(BigInt(2 ** 512)));


### PR DESCRIPTION
  Two decode() methods in src/abi/abi_type.ts built a DataView over the input's entire backing buffer while ignoring the Uint8Array's byteOffset:

  - ABITupleType.decode (line ~678): new DataView(byteString.buffer) — then read dynamic-field head offsets with view.getUint16(iterIndex), where iterIndex is relative to the start of byteString. When byteString was a subarray view with a non-zero byteOffset (which is exactly how simulate/confirmation logs arrive), every getUint16 read from the wrong absolute position, producing bogus segment offsets and the "dynamic index segment miscalculation: left is greater than right index" throw.
  - ABIArrayDynamicType.decode (line ~535): new DataView(byteString.buffer, 0, LENGTH_ENCODE_BYTE_SIZE) same class of bug, hardcoding offset 0.

Subarray views are used in algokit-utils, e.g. in simulate logs, leading to bugs when passing logs into these decode functions - encountered [here](https://github.com/algorandfoundation/algoland/blob/main/projects/algoland-sdk/src/sdk-read.ts#L43)
