### PR TITLE
fix: explain 24-word BIP-39 mnemonics in seedFromMnemonic

### DIFF
--- a/src/mnemonic/mnemonic.ts
+++ b/src/mnemonic/mnemonic.ts
@@ -9,6 +9,13 @@ export const FAIL_TO_DECODE_MNEMONIC_ERROR_MSG = 'failed to decode mnemonic';
 export const NOT_IN_WORDS_LIST_ERROR_MSG =
   'the mnemonic contains a word that is not in the wordlist';
 
+export function invalidMnemonicWordCountErrorMsg(wordCount: number): string {
+  return (
+    `invalid mnemonic: expected 25 Algorand words, got ${wordCount}. ` +
+    'A 24-word BIP-39 phrase (for example from a Pera Universal Wallet) is not compatible with algosdk.'
+  );
+}
+
 // https://stackoverflow.com/a/51452614
 function toUint11Array(buffer8: Uint8Array | number[]): number[] {
   const buffer11: number[] = [];
@@ -100,6 +107,9 @@ function toUint8Array(buffer11: number[]): Uint8Array {
  */
 export function seedFromMnemonic(mnemonic: string) {
   const words = mnemonic.split(' ');
+  if (words.length !== 25) {
+    throw new Error(invalidMnemonicWordCountErrorMsg(words.length));
+  }
   const key = words.slice(0, 24);
 
   // Check that all words are in list

--- a/tests/1.Mnemonics_test.ts
+++ b/tests/1.Mnemonics_test.ts
@@ -56,4 +56,21 @@ describe('#mnemonic', () => {
       passphrase.seedFromMnemonic(mn);
     }, new Error(passphrase.NOT_IN_WORDS_LIST_ERROR_MSG));
   });
+
+  it('should explain a 24-word BIP-39 mnemonic is the wrong format', () => {
+    const words = new Array(24).fill('abandon').join(' ');
+    assert.throws(() => {
+      passphrase.seedFromMnemonic(words);
+    }, new Error(passphrase.invalidMnemonicWordCountErrorMsg(24)));
+    assert.throws(() => {
+      algosdk.mnemonicToSecretKey(words);
+    }, new Error(passphrase.invalidMnemonicWordCountErrorMsg(24)));
+  });
+
+  it('should reject a mnemonic with an unexpected word count', () => {
+    const words = new Array(26).fill('abandon').join(' ');
+    assert.throws(() => {
+      passphrase.seedFromMnemonic(words);
+    }, new Error(passphrase.invalidMnemonicWordCountErrorMsg(26)));
+  });
 });


### PR DESCRIPTION
## Summary
- `seedFromMnemonic` now checks the word count before decoding.
- A 24-word BIP-39 phrase (the default Pera Universal Wallet export) gets an actionable error instead of `failed to decode mnemonic`.
- Other unexpected counts (e.g. 26) get the same explicit message.

Fixes #1064

## Why
Pera's default new-account type is a 24-word BIP-39 mnemonic. `algosdk` only accepts the 25-word Algorand checksum mnemonic, but the old error gave no hint that the format was wrong.

## Validation
```
npx tsx tests/mocha.js tests/1.Mnemonics_test.ts
```
440 passing, including new cases for 24-word and 26-word inputs.