### PR TITLE
fix: decode online keyreg when voteFirst is 0

### DIFF
--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -1102,6 +1102,18 @@ export class Transaction implements encoding.Encodable {
         voteKeyDilution: data.get('votekd'),
         nonParticipation: data.get('nonpart'),
       };
+      // Protocol/goal omitempty drops votefst=0. Restore 0 so online keyreg decode
+      // does not treat the omitted field as missing.
+      const looksOnline =
+        keyregParams.nonParticipation !== true &&
+        (keyregParams.voteKey ||
+          keyregParams.selectionKey ||
+          keyregParams.stateProofKey ||
+          typeof keyregParams.voteLast !== 'undefined' ||
+          typeof keyregParams.voteKeyDilution !== 'undefined');
+      if (looksOnline && typeof keyregParams.voteFirst === 'undefined') {
+        keyregParams.voteFirst = 0n;
+      }
       params.keyregParams = keyregParams;
     } else if (params.type === TransactionType.acfg) {
       const assetConfigParams: AssetConfigurationTransactionParams = {

--- a/tests/5.Transaction.ts
+++ b/tests/5.Transaction.ts
@@ -698,6 +698,78 @@ describe('Sign', () => {
       assert.deepStrictEqual(reencRep, encRep);
     });
 
+    it('should decode an online keyreg with voteFirst 0 after msgpack encode omits votefst', () => {
+      const expectedTxn = new algosdk.Transaction({
+        type: algosdk.TransactionType.keyreg,
+        sender: 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU',
+        keyregParams: {
+          voteKey: algosdk.base64ToBytes(
+            '5/D4TQaBHfnzHI2HixFV9GcdUaGFwgCQhmf0SVhwaKE='
+          ),
+          selectionKey: algosdk.base64ToBytes(
+            'oImqaSLjuZj63/bNSAjd+eAh5JROOJ6j1cY4eGaJGX4='
+          ),
+          stateProofKey: algosdk.base64ToBytes(
+            'mgh7ddGf7dF1Z5/9RDzN/JZZF9yA7XYCKJXvqhwPdvI7pLKh7hizaM5rTC2kizVOpVRIU9PXSLeapvBJ/OxQYA=='
+          ),
+          voteFirst: 0,
+          voteLast: 456,
+          voteKeyDilution: 1234,
+        },
+        suggestedParams: {
+          minFee: 1000,
+          fee: 10,
+          firstValid: 51,
+          lastValid: 61,
+          genesisHash: algosdk.base64ToBytes(
+            'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI='
+          ),
+          genesisID: 'mock-network',
+        },
+        note: new Uint8Array([123, 12, 200]),
+      });
+      const encTxn = algosdk.encodeMsgpack(expectedTxn);
+      const decTxn = algosdk.decodeMsgpack(encTxn, algosdk.Transaction);
+      assert.strictEqual(decTxn.keyreg?.voteFirst, 0n);
+      assert.deepStrictEqual(decTxn, expectedTxn);
+    });
+
+    it('should decode an online keyreg whose wire encoding omitted votefst', () => {
+      const txn = new algosdk.Transaction({
+        type: algosdk.TransactionType.keyreg,
+        sender: 'XMHLMNAVJIMAW2RHJXLXKKK4G3J3U6VONNO3BTAQYVDC3MHTGDP3J5OCRU',
+        keyregParams: {
+          voteKey: algosdk.base64ToBytes(
+            '5/D4TQaBHfnzHI2HixFV9GcdUaGFwgCQhmf0SVhwaKE='
+          ),
+          selectionKey: algosdk.base64ToBytes(
+            'oImqaSLjuZj63/bNSAjd+eAh5JROOJ6j1cY4eGaJGX4='
+          ),
+          stateProofKey: algosdk.base64ToBytes(
+            'mgh7ddGf7dF1Z5/9RDzN/JZZF9yA7XYCKJXvqhwPdvI7pLKh7hizaM5rTC2kizVOpVRIU9PXSLeapvBJ/OxQYA=='
+          ),
+          voteFirst: 123,
+          voteLast: 456,
+          voteKeyDilution: 1234,
+        },
+        suggestedParams: {
+          minFee: 1000,
+          fee: 10,
+          firstValid: 51,
+          lastValid: 61,
+          genesisHash: algosdk.base64ToBytes(
+            'JgsgCaCTqIaLeVhyL6XlRu3n7Rfk2FxMeK+wRSaQ7dI='
+          ),
+          genesisID: 'mock-network',
+        },
+        note: new Uint8Array([123, 12, 200]),
+      });
+      const encodingData = txn.toEncodingData();
+      encodingData.delete('votefst');
+      const decTxn = algosdk.Transaction.fromEncodingData(encodingData);
+      assert.strictEqual(decTxn.keyreg?.voteFirst, 0n);
+    });
+
     it('should correctly serialize and deserialize an offline key registration transaction from msgpack representation', () => {
       const expectedTxn = new algosdk.Transaction({
         type: algosdk.TransactionType.keyreg,
@@ -717,6 +789,7 @@ describe('Sign', () => {
       });
       const encTxn = algosdk.encodeMsgpack(expectedTxn);
       const decTxn = algosdk.decodeMsgpack(encTxn, algosdk.Transaction);
+      assert.strictEqual(decTxn.keyreg?.voteFirst, undefined);
       assert.deepStrictEqual(decTxn, expectedTxn);
 
       const encRep = expectedTxn.toEncodingData();


### PR DESCRIPTION
Fixes https://github.com/algorand/js-algorand-sdk/issues/925

## Problem

The protocol and `goal` omit `votefst` when it is `0` (`omitempty`). The SDK maps `votefst` through `OptionalSchema(Uint64Schema)`, so encode also drops `voteFirst: 0`. On decode, `fromEncodingData` then left `voteFirst` undefined. The constructor treats an online keyreg (vote/selection keys present) with a missing `voteFirst` as invalid and throws:

`Online key registration missing at least one of the following fields: voteKey, selectionKey, voteFirst, voteLast, voteKeyDilution`

That broke Lora when it tried to decode keyreg transactions created on localnet/fnet with `--roundFirstValid 0`.

## Change

Decode-only: if a keyreg looks online (any of `voteKey`, `selectionKey`, `stateProofKey`, `voteLast`, `voteKeyDilution` present, and `nonParticipation` is not true) and `voteFirst` is missing, restore `voteFirst` to `0n`.

The constructor's send-time missing-field check is unchanged. `OptionalSchema` / `Uint64Schema` are unchanged. Offline keyreg (`keyregParams: {}`) still decodes with undefined `voteFirst`.

## Maintainer consensus

From #925:

> the protocol does not require voteFirst to not be 0, so at the very least, I agree the sdk should decode such transactions. Do we really want to stop erroring on trying to send them though?

> we want Lora (through the sdk) to be able to read such a transaction, but I'm not hearing enthusiasm for sending such transactions. (Of course, I'd argue for simplicity, so if it's easier to support both because it's a single code path, I'd be ok with that.)

> it probably shouldn't be encouraged to create a transaction with the first valid round set to 0, but in the event a transaction like that appears, the SDK should be able to handle it.

This PR follows that: decode of `voteFirst: 0` is required; send of `0` is not encouraged; a single decode path that restores omitted `votefst` is enough.

## Validation

- `npx mocha --import=tsx tests/5.Transaction.ts --timeout 20000 --grep 'keyreg|key registration'` — 9 passing
- `npm test` (`tsx tests/mocha.js`) — 440 passing
- `npx prettier --check src/transaction.ts tests/5.Transaction.ts`
- `npx eslint src/transaction.ts tests/5.Transaction.ts`