### PR TITLE
fix: treat msgpack nil as empty bytes in ByteArraySchema

### DIFF
--- a/src/encoding/schema/bytearray.ts
+++ b/src/encoding/schema/bytearray.ts
@@ -30,6 +30,10 @@ export class ByteArraySchema extends Schema {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _rawStringProvider: MsgpackRawStringProvider
   ): Uint8Array {
+    if (encoded === null || encoded === undefined) {
+      // algod/indexer omit empty binaries as msgpack nil (decoded as JS null)
+      return this.defaultValue();
+    }
     if (encoded instanceof Uint8Array) {
       return encoded;
     }

--- a/tests/2.Encoding.ts
+++ b/tests/2.Encoding.ts
@@ -1478,6 +1478,27 @@ describe('encoding', () => {
         });
       }
     });
+    describe('ByteArraySchema', () => {
+      it('decodes msgpack/JSON null as an empty byte array', () => {
+        const schema = new ByteArraySchema();
+        const rawStringProvider = new MsgpackRawStringProvider({
+          baseObjectBytes: new Uint8Array(),
+        });
+        assert.deepStrictEqual(
+          schema.fromPreparedMsgpack(null, rawStringProvider),
+          new Uint8Array()
+        );
+        assert.deepStrictEqual(
+          schema.fromPreparedMsgpack(undefined, rawStringProvider),
+          new Uint8Array()
+        );
+        assert.deepStrictEqual(schema.fromPreparedJSON(null), new Uint8Array());
+        assert.deepStrictEqual(
+          schema.fromPreparedJSON(undefined),
+          new Uint8Array()
+        );
+      });
+    });
     describe('NamedMapSchema', () => {
       it('correctly handles omitEmpty', () => {
         const testValues: Array<{


### PR DESCRIPTION
## Proposed Changes

- Decode msgpack `nil`/JS `null` as an empty `Uint8Array` in `ByteArraySchema.fromPreparedMsgpack`.
- JSON already did this in #991; the msgpack path still threw `Invalid byte array: (object) null`.

Fixes #909. Related: #968 was the JSON/indexer form, already handled by #991.

## Validation

- `npm test` — 439 passing, including `ByteArraySchema decodes msgpack/JSON null as an empty byte array`